### PR TITLE
fix: do not check date for admin

### DIFF
--- a/admin/src/scenes/volontaires/edit.js
+++ b/admin/src/scenes/volontaires/edit.js
@@ -488,14 +488,6 @@ const Item = ({ title, values, name, handleChange, type = "text", disabled = fal
         <>
           <Field
             hidden
-            validate={(v) => {
-              if (!v) return requiredMessage;
-              var from = new Date(2003, 6, 2); // -1 because months are from 0 to 11
-              var to = new Date(2006, 3, 20);
-              const [y, m, d] = v.substring(0, 10).split("-");
-              var check = new Date(Date.UTC(parseInt(y), parseInt(m - 1), parseInt(d)));
-              return (check < from || check > to) && "Vous n'avez pas l'âge requis pour vous inscrire au SNU";
-            }}
             name="birthdateAt"
             value={values.birthdateAt}
           />


### PR DESCRIPTION
cf https://trello.com/c/TI5EbR46/278-en-tant-quadmin-je-narrive-pas-%C3%A0-changer-la-date-de-naissance-dun-volontaire-erreur-silencieuse

En fait je me dis qu'on n'a pas besoin de valider les dates pour les admins/référents : s'ils mettent une date hors des clous ils ont surement une bonne raison. Donc j'ai réglé l'erreur silencieuse en supprimant l'erreur. 🙃 