### PR TITLE
fix: redirect when es query fails

### DIFF
--- a/admin/src/scenes/auth/signin.js
+++ b/admin/src/scenes/auth/signin.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { FormGroup, Row, Col } from "reactstrap";
 import { Formik, Field } from "formik";
 import validator from "validator";
@@ -6,6 +6,7 @@ import { Link, Redirect } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
 import styled from "styled-components";
+import queryString from "query-string";
 
 import { setUser, setStructure } from "../../redux/auth/actions";
 
@@ -16,6 +17,13 @@ export default () => {
   const dispatch = useDispatch();
   const user = useSelector((state) => state.Auth.user);
   const [userIsValid, setUserIsValid] = useState(true);
+
+  useEffect(() => {
+    const { unauthorized } = queryString.parse(location.search);
+    if (unauthorized === "1") {
+      toastr.error("Votre session a expiré", "Vous devez entrer à nouveau vos identifiants pour continuer.");
+    }
+  }, []);
 
   return (
     <Wrapper noGutters>
@@ -39,7 +47,7 @@ export default () => {
                 if (e && (e.code === "EMAIL_OR_PASSWORD_INVALID" || e.code === "USER_NOT_EXISTS")) {
                   return setUserIsValid(false);
                 }
-                toastr.error("Erreur détecté");
+                toastr.error("Erreur détectée");
               }
               actions.setSubmitting(false);
             }}

--- a/admin/src/services/api.js
+++ b/admin/src/services/api.js
@@ -2,6 +2,15 @@ import "isomorphic-fetch";
 
 import { apiURL } from "../config";
 
+function jsonOrRedirectToSignIn(response) {
+  if (response.ok === false && response.status === 401) {
+    if (window && window.location && window.location.href) {
+      window.location.href = "/auth?unauthorized=1";
+    }
+  }
+  return response.json();
+}
+
 class api {
   constructor() {
     this.token = "";
@@ -25,9 +34,9 @@ class api {
       headers: { "Content-Type": "application/x-ndjson", Authorization: `JWT ${this.token}` },
       body: query,
     })
-      .then((r) => r.json())
+      .then((r) => jsonOrRedirectToSignIn(r))
       .catch((e) => {
-        console.log(e);
+        console.error(e);
       });
   }
 


### PR DESCRIPTION
Ça ne répare pas tout ça (cf saisie d'écran) : par exemple les requetes qui partent direct avec `ReactiveSearch` ne sont pas catchées... car je n'y arrive pas. C'est donc seulement une première étape mais je ne veux pas y passer trop de temps pour l'instant : voyons déjà si ça marche !

Pour tester on peut mettre le JWT à un temps court.

<img width="1187" alt="Capture d’écran 2021-01-18 à 22 20 28" src="https://user-images.githubusercontent.com/1575946/105019792-cb4d8d80-5a46-11eb-9467-a24542ec578c.png">
