### PR TITLE
fix: suggestion error on etablissement

### DIFF
--- a/app/src/scenes/inscription/components/etablissmentInput.js
+++ b/app/src/scenes/inscription/components/etablissmentInput.js
@@ -69,8 +69,8 @@ const AutoComplete = ({ placeholder, onSelect }) => {
   const [hits, setHits] = useState([]);
   const [value, setValue] = useState("");
 
-  const onSuggestionsFetchRequested = ({ value }) => {
-    setHits(getSuggestions(value));
+  const onSuggestionsFetchRequested = async ({ value }) => {
+    setHits(await getSuggestions(value));
   };
 
   const onSuggestionsClearRequested = () => {
@@ -101,7 +101,7 @@ const AutoComplete = ({ placeholder, onSelect }) => {
     const hits = responses[0]?.hits?.hits.map((e) => e._source);
     // if (hits.length) return setHits(hits);
     hits.push({ name2: "", city: "", postcode: "", type: "AUTRE" });
-    return setHits(hits);
+    return hits;
   };
 
   return (


### PR DESCRIPTION
Pour éviter l'erreur:

> Failed prop type: Invalid prop `suggestions` of type `object` supplied to `Autosuggest`, expected `array`.

Quand on commence à taper.

(on envoyait une promesse au lieu d'un tableau)