### PR TITLE
fix file with same name

### DIFF
--- a/app/src/components/dndFileInput.js
+++ b/app/src/components/dndFileInput.js
@@ -41,6 +41,14 @@ export default ({ value, onChange, name, errorMessage = requiredMessage, placeho
   });
 
   function onAdd(files) {
+    Object.keys(files).forEach((i) => {
+      const fileName = files[i].name.match(/(.*)(\..*)/);
+      const newName = `${fileName[1]}-${filesList.length}${fileName[2]}`;
+      Object.defineProperty(files[i], "name", {
+        writable: true,
+        value: newName,
+      });
+    });
     handleChange([...filesList, ...files]);
   }
 


### PR DESCRIPTION
si un user upload deux fichiers avec le meme nom, le premier est écrasé :(
donc petit quickfix qui rajoute un index a la fin du nom de fichier a chaque fois...