### PR TITLE
feat: france connect logout

### DIFF
--- a/api/src/controllers/young.js
+++ b/api/src/controllers/young.js
@@ -131,7 +131,7 @@ router.post("/france-connect/user-info", async (req, res) => {
     headers: { Authorization: `Bearer ${token["access_token"]}` },
   });
   const userInfo = await userInfoResponse.json();
-  res.status(200).send({ ok: true, data: userInfo });
+  res.status(200).send({ ok: true, data: userInfo, tokenId: token["id_token"] });
 });
 
 // Delete one user (only admin can delete user)

--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -94,6 +94,7 @@ const Schema = new mongoose.Schema({
   parent1Department: { type: String },
   parent1Region: { type: String },
   parent1Location: { lat: Number, lon: Number },
+  parent1FromFranceConnect: { type: String, enum: ["true", "false"], default: "false" },
 
   parent2Status: { type: String },
   parent2FirstName: { type: String },
@@ -108,6 +109,7 @@ const Schema = new mongoose.Schema({
   parent2Department: { type: String },
   parent2Region: { type: String },
   parent2Location: { lat: Number, lon: Number },
+  parent2FromFranceConnect: { type: String, enum: ["true", "false"], default: "false" },
 
   // * Situations particulières
   handicap: { type: String, enum: ["true", "false"] },

--- a/app/src/config.js
+++ b/app/src/config.js
@@ -14,10 +14,12 @@ if (environment === "production") {
 const S3PREFIX = "";
 const SENTRY_URL = "https://415a2c2d9246422fa05cd5e96dd39c23@o348403.ingest.sentry.io/5557988";
 
+const franceConnectUrl = "https://fcp.integ01.dev-franceconnect.fr/api/v1";
+
 function getEnvironment() {
   if (window.location.href.indexOf("localhost") !== -1 || window.location.href.indexOf("127.0.0.1") !== -1) return "development";
   if (window.location.href.indexOf("app-66aba4d6-e5fc-4c74-b252-f55fb0e9d37f.cleverapps.io") !== -1) return "staging";
   return "production";
 }
 
-export { apiURL, S3PREFIX, SENTRY_URL, environment };
+export { apiURL, S3PREFIX, SENTRY_URL, environment, franceConnectUrl };

--- a/app/src/scenes/inscription/Create/stepRepresentants.js
+++ b/app/src/scenes/inscription/Create/stepRepresentants.js
@@ -13,33 +13,41 @@ import matomo from "../../../services/matomo";
 
 import { setYoung } from "../../../redux/auth/actions";
 import ErrorMessage, { requiredMessage } from "../components/errorMessage";
-import FranceConnectButton from "../../../components/FranceConnectButton";
+import FranceConnectButton from "../components/FranceConnectButton";
 import { environment } from "../../../config";
 
 import { saveYoung, STEPS } from "../utils";
 
-function getFranceConnectCallback(idRepresentant) {
-  return `inscription/representants?action=updateFromFranceConnect&representant=${idRepresentant}`;
-}
-
 const Parent = ({ id = 1, values, errors, touched, handleChange }) => {
+  const isParentFromFranceConnect = values[`parent${id}FromFranceConnect`] === "true";
+
+  function FranceConnectZone({ id, handleSave }) {
+    function getFranceConnectCallback(idRepresentant) {
+      return `inscription/france-connect-callback?representant=${idRepresentant}`;
+    }
+    if (environment === "production") return null;
+    if (isParentFromFranceConnect) {
+      return <i>Les information en provenance de FranceConnect du représentant légal n°{id} ont bien été enregistrées.</i>;
+    }
+    return (
+      <FormRow>
+        <Col>
+          <p>
+            Vous pouvez utiliser ce bouton vous pour identifier et récupérer les données (nom, prénom et email) du représentant légal n°{id} avec FranceConnect, ou remplir les
+            informations manuellement ci-dessous.
+          </p>
+          <FranceConnectButton callback={getFranceConnectCallback(id)} beforeRedirect={() => handleSave()} />
+        </Col>
+      </FormRow>
+    );
+  }
   async function handleSave() {
     await saveYoung(values);
   }
   return (
     <>
       <FormLegend>Représentant légal n°{id}</FormLegend>
-      {environment !== "production" ? (
-        <FormRow>
-          <Col>
-            <p>
-              Vous pouvez utiliser ce bouton vous pour identifier et récupérer les données (nom, prénom et email) du représentant légal n°{id} avec FranceConnect, ou remplir les
-              informations manuellement ci-dessous.
-            </p>
-            <FranceConnectButton callback={getFranceConnectCallback(id)} beforeRedirect={() => handleSave()} />
-          </Col>
-        </FormRow>
-      ) : null}
+      <FranceConnectZone handleSave={() => handleSave()} id={id} />
 
       <FormRow>
         <Col md={4}>
@@ -94,6 +102,7 @@ const Parent = ({ id = 1, values, errors, touched, handleChange }) => {
             value={values[`parent${id}FirstName`]}
             onChange={handleChange}
             className="form-control"
+            disabled={isParentFromFranceConnect}
           />
           <ErrorMessage errors={errors} touched={touched} name={`parent${id}FirstName`} />
         </Col>
@@ -110,6 +119,7 @@ const Parent = ({ id = 1, values, errors, touched, handleChange }) => {
             value={values[`parent${id}LastName`]}
             onChange={handleChange}
             className="form-control"
+            disabled={isParentFromFranceConnect}
           />
           <ErrorMessage errors={errors} touched={touched} name={`parent${id}LastName`} />
         </Col>
@@ -127,6 +137,7 @@ const Parent = ({ id = 1, values, errors, touched, handleChange }) => {
             value={values[`parent${id}Email`]}
             onChange={handleChange}
             className="form-control"
+            disabled={isParentFromFranceConnect}
           />
           <ErrorMessage errors={errors} touched={touched} name={`parent${id}Email`} />
         </Col>
@@ -220,10 +231,6 @@ export default () => {
   const [isParent2Visible, setIsParent2Visible] = useState(false);
   const [initialValues, setInitialValues] = useState(young);
 
-  if (!young) {
-    history.push("/inscription/profil");
-    return <div />;
-  }
   const hasParent2Infos = () => {
     return young && (young.parent2Status || young.parent2FirstName || young.parent2LastName || young.parent2Email || young.parent2Phone);
   };
@@ -231,28 +238,10 @@ export default () => {
     setIsParent2Visible(hasParent2Infos());
   }, [young]);
 
-  // Update from France Connect.
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const action = urlParams.get("action");
-    const id = urlParams.get("representant");
-    const code = urlParams.get("code");
-    if (action === "updateFromFranceConnect" && id && code) {
-      async function fetchData() {
-        const { data } = await api.post("/young/france-connect/user-info", { code, callback: getFranceConnectCallback(id) });
-        if (data && data["email"]) {
-          if (id === "2") setIsParent2Visible(true);
-          setInitialValues({
-            ...young,
-            [`parent${id}FirstName`]: data["given_name"],
-            [`parent${id}LastName`]: data["family_name"],
-            [`parent${id}Email`]: data["email"],
-          });
-        }
-      }
-      fetchData();
-    }
-  }, []);
+  if (!young) {
+    history.push("/inscription/profil");
+    return <div />;
+  }
 
   const handleSave = async (values) => {
     const young = await saveYoung(values);

--- a/app/src/scenes/inscription/Create/stepRepresentants.js
+++ b/app/src/scenes/inscription/Create/stepRepresentants.js
@@ -137,7 +137,6 @@ const Parent = ({ id = 1, values, errors, touched, handleChange }) => {
             value={values[`parent${id}Email`]}
             onChange={handleChange}
             className="form-control"
-            disabled={isParentFromFranceConnect}
           />
           <ErrorMessage errors={errors} touched={touched} name={`parent${id}Email`} />
         </Col>

--- a/app/src/scenes/inscription/components/FranceConnectButton.js
+++ b/app/src/scenes/inscription/components/FranceConnectButton.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
-import api from "../services/api";
+import api from "../../../services/api";
 
 export default ({ callback, beforeRedirect }) => {
   const [hover, setHover] = useState(false);

--- a/app/src/scenes/inscription/components/FranceConnectCallback.js
+++ b/app/src/scenes/inscription/components/FranceConnectCallback.js
@@ -1,0 +1,42 @@
+import React, { useEffect } from "react";
+import { useSelector } from "react-redux";
+import api from "../../../services/api";
+import { franceConnectUrl } from "../../../config";
+import { saveYoung } from "../utils";
+
+function getFranceConnectCallback(idRepresentant) {
+  return `inscription/france-connect-callback?representant=${idRepresentant}`;
+}
+
+export default function FranceConnectCallback() {
+  const young = useSelector((state) => state.Auth.young);
+  // Update from France Connect.
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const id = urlParams.get("representant");
+    const code = urlParams.get("code");
+    if (id && code) {
+      async function fetchData() {
+        const { data, tokenId } = await api.post("/young/france-connect/user-info", { code, callback: getFranceConnectCallback(id) });
+        if (data && data["email"]) {
+          await saveYoung({
+            ...young,
+            [`parent${id}FirstName`]: data["given_name"],
+            [`parent${id}LastName`]: data["family_name"],
+            [`parent${id}Email`]: data["email"],
+            [`parent${id}FromFranceConnect`]: "true",
+          });
+          const params = new URLSearchParams({
+            id_token_hint: tokenId,
+            state: Math.round(Math.random() * 1000000),
+            post_logout_redirect_uri: `${window.location.origin}/inscription/representants`,
+          }).toString();
+          window.location.href = `${franceConnectUrl}/logout?${params.toString()}`;
+        }
+      }
+      fetchData();
+    }
+  }, []);
+
+  return <div>Enregistrement des données de FranceConnect, veuillez patienter…</div>;
+}

--- a/app/src/scenes/inscription/index.js
+++ b/app/src/scenes/inscription/index.js
@@ -7,6 +7,7 @@ import Particulieres from "./Create/stepParticulieres";
 import Consentements from "./Create/stepConsentements";
 import Motivations from "./Create/stepMotivations";
 import Nav from "./components/Nav";
+import FranceConnectCallback from "./components/FranceConnectCallback";
 import Done from "./Create/stepDone";
 import styled from "styled-components";
 
@@ -46,6 +47,7 @@ export default () => {
       <Route path="/inscription/consentements" component={() => <Step step={STEPS.CONSENTEMENTS} />} />
       <Route path="/inscription/motivations" component={() => <Step step={STEPS.MOTIVATIONS} />} />
       <Route path="/inscription/done" component={() => <Step step={STEPS.DONE} />} />
+      <Route path="/inscription/france-connect-callback" component={() => <FranceConnectCallback />} />
       <Route path="/inscription" component={Home} />
     </Switch>
   );


### PR DESCRIPTION
L'idée suite aux échanges avec FranceConnect c'est :
- Rendre disable les champs nom / prenom ( laisser email editable ) lors que france connect est utilise
- Mettre en avant le fait que c'est plus simple d'utilise France connect
- Faire l’auto logout

Je n'ai pas fait le deuxième point pour l'instant. Si tu valides, la dernière étape est de réfléchir à comment gérer le formulaire de signature de consentement grâce à France connect et on expliquera ensuite dans le point 2 ce que ça ajoute.