### PR TITLE
fix: pdf js

### DIFF
--- a/admin/src/components/DocumentInModal.js
+++ b/admin/src/components/DocumentInModal.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Modal } from "reactstrap";
-import { Page, Document } from "react-pdf";
+import { Page, Document, pdfjs } from "react-pdf";
+pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 
 export default function DocumentInModal({ value, onChange }) {
   if (!value || !value.data || !value.data.data) return <div />;
@@ -12,7 +13,7 @@ export default function DocumentInModal({ value, onChange }) {
   function renderFile() {
     if (value.mimeType === "application/pdf") {
       return (
-        <Document file={imageUrl} onLoadSuccess={() => {}}>
+        <Document file={imageUrl} onLoadSuccess={() => {}} onLoadError={console.error}>
           <Page pageNumber={1} />
         </Document>
       );

--- a/admin/src/components/DocumentInModal.js
+++ b/admin/src/components/DocumentInModal.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { Modal } from "reactstrap";
 import { Page, Document, pdfjs } from "react-pdf";
-pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
+import { pdfjsworker } from "pdfjs-dist/es5/build/pdf.worker.entry";
+pdfjs.GlobalWorkerOptions.workerSrc = pdfjsworker;
+// pdfjs.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/es5/build/pdf.worker.min.js`;
 
 export default function DocumentInModal({ value, onChange }) {
   if (!value || !value.data || !value.data.data) return <div />;

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -5,8 +5,6 @@ import ReduxToastr from "react-redux-toastr";
 import "react-redux-toastr/lib/css/react-redux-toastr.min.css";
 import store from "./redux/store";
 import App from "./app";
-import { pdfjs } from "react-pdf";
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
Ça permet d'afficher les PDF sur les vieux navigateurs.

Mais ça augmente de 1 MO 😱 
Il faudrait le prendre d'un CDN (cf commentaire) mais ça marche pas.

Il faut trouver une solution ou partir là dessus, preneur de ton avis @tangimds 