### PR TITLE
Fix : view referent (mission et structure)

### DIFF
--- a/admin/src/scenes/missions/list.js
+++ b/admin/src/scenes/missions/list.js
@@ -20,8 +20,6 @@ export default () => {
   const user = useSelector((state) => state.Auth.user);
   const DEFAULT_QUERY = () => {
     if (user.role === "supervisor") return { query: { bool: { filter: { terms: { "structureId.keyword": structureIds } } } } };
-    if (user.role === "referent_department") return { query: { bool: { filter: { term: { "department.keyword": user.department } } } } };
-    if (user.role === "referent_region") return { query: { bool: { filter: { term: { "region.keyword": user.region } } } } };
     return { query: { match_all: {} } };
   };
 
@@ -114,6 +112,7 @@ export default () => {
                   URLParams={true}
                   showSearch={false}
                   sortBy="asc"
+                  defaultValue={user.role === "referent_region" && [user.region]}
                 />
                 <MultiDropdownList
                   defaultQuery={DEFAULT_QUERY}
@@ -126,6 +125,7 @@ export default () => {
                   URLParams={true}
                   showSearch={false}
                   sortBy="asc"
+                  defaultValue={user.role === "referent_department" && [user.department]}
                 />
                 <MultiDropdownList
                   defaultQuery={DEFAULT_QUERY}

--- a/admin/src/scenes/structure/list.js
+++ b/admin/src/scenes/structure/list.js
@@ -103,6 +103,7 @@ export default () => {
                   URLParams={true}
                   showSearch={false}
                   sortBy="asc"
+                  defaultValue={user.role === "referent_department" && [user.department]}
                 />
                 <MultiDropdownList
                   defaultQuery={DEFAULT_QUERY}
@@ -115,6 +116,7 @@ export default () => {
                   URLParams={true}
                   showSearch={false}
                   sortBy="asc"
+                  defaultValue={user.role === "referent_region" && [user.region]}
                 />
                 <MultiDropdownList
                   className="dropdown-filter"

--- a/api/src/controllers/es.js
+++ b/api/src/controllers/es.js
@@ -57,11 +57,6 @@ function filter(body, user, index) {
     if (user.role === "referent_department") filter.push({ term: { "department.keyword": user.department } });
   }
 
-  if (index === "structure") {
-    if (user.role === "referent_region") filter.push({ term: { "region.keyword": user.region } });
-    if (user.role === "referent_department") filter.push({ term: { "department.keyword": user.department } });
-  }
-
   if (index === "referent") {
     if (user.role === "responsible") filter.push({ terms: { "role.keyword": ["responsible", "supervisor"] } });
 


### PR DESCRIPTION
1/ Permettre aux référents de voir toutes les structures et missions d'une manière générale, en filtrant par défaut la vue des différents onglet par (filtre "département" sélectionné par défaut pour les ref départementaux / "région" pour les ref régionaux)


2/ Pas de changement pour le dashboard (rapport territorial)