### PR TITLE
Feat : search mission relative

### DIFF
--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -189,6 +189,7 @@ const Schema = new mongoose.Schema({
   mobilityNearHome: { type: String, enum: ["true", "false"] },
   mobilityNearRelative: { type: String, enum: ["true", "false"] },
   mobilityNearRelativeName: { type: String },
+  mobilityNearRelativeAddress: { type: String },
   mobilityNearRelativeZip: { type: String },
   mobilityTransport: { type: [String] },
   mobilityTransportOther: { type: String },

--- a/app/src/components/addressInput.js
+++ b/app/src/components/addressInput.js
@@ -38,9 +38,11 @@ export default ({ keys, values, handleChange, errors, touched, departAndRegionVi
     handleChange({ target: { name: keys.zip, value: suggestion.properties.postcode } });
     handleChange({ target: { name: keys.address, value: suggestion.properties.label } });
     handleChange({ target: { name: keys.location, value: { lon: suggestion.geometry.coordinates[0], lat: suggestion.geometry.coordinates[1] } } });
-    if (values.cohort === "2020") return;
-    handleChange({ target: { name: keys.department, value: departmentLookUp[depart] } });
-    handleChange({ target: { name: keys.region, value: department2region[departmentLookUp[depart]] } });
+    if (values.cohort !== "2020") {
+      handleChange({ target: { name: keys.department, value: departmentLookUp[depart] } });
+      handleChange({ target: { name: keys.region, value: department2region[departmentLookUp[depart]] } });
+    }
+    return;
   };
 
   const renderSuggestion = (suggestion) => <div>{suggestion !== "noresult" ? suggestion.properties.label : NORESULTMESSAGE}</div>;

--- a/app/src/scenes/account.js
+++ b/app/src/scenes/account.js
@@ -125,6 +125,14 @@ export default () => {
       <Formik
         initialValues={young}
         onSubmit={async (values) => {
+          if (young.address !== values.address || young.city !== values.city || young.department !== values.department || young.region !== values.region) {
+            if (
+              !confirm(
+                "Attention, vous êtes sur le point de changer votre adresse. La proposition des missions et d'autres fonctionnalités dépendent de cette adresse.\n\nAssurez-vous que ce changement est indispensable avant de continuer ! Si ce n'est pas le cas, merci d'annuler cette action."
+              )
+            )
+              return;
+          }
           try {
             const { ok, code, data: young } = await api.put("/young", values);
             if (!ok) toastr.error("Une erreur s'est produite :", translate(code));

--- a/app/src/scenes/missions/components/FilterGeoloc.js
+++ b/app/src/scenes/missions/components/FilterGeoloc.js
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from "react";
 import { ReactiveComponent } from "@appbaseio/reactivesearch";
 import { Col, Row } from "reactstrap";
 
-export default ({ componentId = "FILTER", young }) => {
-  return <ReactiveComponent componentId={componentId} render={(data) => <SubComponent young={young} {...data} />} />;
+export default ({ componentId = "FILTER", young, targetLocation }) => {
+  return <ReactiveComponent componentId={componentId} render={(data) => <SubComponent young={young} targetLocation={targetLocation} {...data} />} />;
 };
 
-const SubComponent = ({ setQuery, young }) => {
+const SubComponent = ({ setQuery, young, targetLocation }) => {
   const [distance, setDistance] = useState("50");
 
   useEffect(() => {
@@ -18,7 +18,9 @@ const SubComponent = ({ setQuery, young }) => {
           },
         },
       };
-      let location = young.location || (await getCoordinates(young.city));
+      let location;
+      if (targetLocation) location = await getCoordinates({ postcode: targetLocation });
+      else location = young.location || (await getCoordinates({ q: young.city }));
       if (location) {
         query.bool["filter"] = {
           geo_distance: {
@@ -29,11 +31,12 @@ const SubComponent = ({ setQuery, young }) => {
       }
       setQuery({ query });
     })();
-  }, [distance]);
+  }, [distance, targetLocation]);
 
-  const getCoordinates = async (c) => {
+  const getCoordinates = async ({ q, postcode }) => {
     try {
-      let url = `https://api-adresse.data.gouv.fr/search/?q=${c}`;
+      let url = `https://api-adresse.data.gouv.fr/search/?q=${q || postcode}`;
+      if (postcode) url += `&postcode=${postcode}`;
       const res = await fetch(url).then((response) => response.json());
       const lon = res?.features[0]?.geometry?.coordinates[0] || null;
       const lat = res?.features[0]?.geometry?.coordinates[1] || null;

--- a/app/src/scenes/missions/components/FilterGeoloc.js
+++ b/app/src/scenes/missions/components/FilterGeoloc.js
@@ -19,7 +19,7 @@ const SubComponent = ({ setQuery, young, targetLocation }) => {
         },
       };
       let location;
-      if (targetLocation) location = await getCoordinates({ postcode: targetLocation });
+      if (targetLocation === "relative") location = await getCoordinates({ q: young.mobilityNearRelativeAddress, postcode: young.mobilityNearRelativeZip });
       else location = young.location || (await getCoordinates({ q: young.city }));
       if (location) {
         query.bool["filter"] = {

--- a/app/src/scenes/missions/list.js
+++ b/app/src/scenes/missions/list.js
@@ -83,16 +83,7 @@ export default () => {
       <ReactiveBase url={`${apiURL}/es`} app="mission" headers={{ Authorization: `JWT ${api.getToken()}` }}>
         <Filters>
           <Row>
-            <DomainsFilter md={6}>
-              <select id="tl" className="form-control" value={targetLocation} onChange={handleChangeTargetLocation}>
-                <option value="">A proximité de mon domicile ({young.city})</option>
-                <option value={young.mobilityNearRelativeZip}>
-                  A proximité d'un proche ({young.mobilityNearRelativeName} - {young.mobilityNearRelativeZip})
-                </option>
-              </select>
-            </DomainsFilter>
-
-            <SearchBox md={6}>
+            <SearchBox md={12}>
               <DataSearch
                 innerClass={{ input: "form-control" }}
                 placeholder="Recherche par mots clés..."
@@ -102,6 +93,19 @@ export default () => {
                 queryFormat="and"
               />
             </SearchBox>
+            <DomainsFilter md={6}>
+              <select id="tl" className="form-control" value={targetLocation} onChange={handleChangeTargetLocation}>
+                <option value="">A proximité de mon domicile ({young.city})</option>
+                {young.mobilityNearRelativeZip && (
+                  <option value="relative">
+                    A proximité d'un proche ({young.mobilityNearRelativeName} - {young.mobilityNearRelativeZip})
+                  </option>
+                )}
+              </select>
+            </DomainsFilter>
+            <Col md={6}>
+              <FilterGeoloc young={young} targetLocation={targetLocation} componentId="GEOLOC" />
+            </Col>
             <DomainsFilter md={6}>
               <SingleDropdownList
                 defaultQuery={DEFAULT_QUERY}
@@ -132,9 +136,6 @@ export default () => {
                 showSearch={false}
               />
             </DomainsFilter>
-            <Col md={6}>
-              <FilterGeoloc young={young} targetLocation={targetLocation} componentId="GEOLOC" />
-            </Col>
           </Row>
         </Filters>
         <Missions>

--- a/app/src/scenes/missions/list.js
+++ b/app/src/scenes/missions/list.js
@@ -12,10 +12,11 @@ import api from "../../services/api";
 import Loader from "../../components/Loader";
 import FilterGeoloc from "./components/FilterGeoloc";
 
-const FILTERS = ["DOMAIN", "SEARCH", "STATUS", "GEOLOC", "DATE", "PERIOD"];
+const FILTERS = ["DOMAIN", "SEARCH", "STATUS", "GEOLOC", "DATE", "PERIOD", "RELATIVE"];
 
 export default () => {
   const young = useSelector((state) => state.Auth.young);
+  const [targetLocation, setTargetLocation] = useState("");
   const [showAlert, setShowAlert] = useState(true);
   const [applications, setApplications] = useState();
   const DEFAULT_QUERY = () => {
@@ -42,7 +43,7 @@ export default () => {
         },
       },
     };
-    if (young.location)
+    if (young.location && !targetLocation)
       query.sort = [
         {
           _geo_distance: {
@@ -68,6 +69,8 @@ export default () => {
     })();
   }, []);
 
+  const handleChangeTargetLocation = (e) => setTargetLocation(e.target.value);
+
   if (!applications) return <Loader />;
 
   return (
@@ -80,6 +83,15 @@ export default () => {
       <ReactiveBase url={`${apiURL}/es`} app="mission" headers={{ Authorization: `JWT ${api.getToken()}` }}>
         <Filters>
           <Row>
+            <DomainsFilter md={6}>
+              <select id="tl" className="form-control" value={targetLocation} onChange={handleChangeTargetLocation}>
+                <option value="">A proximité de mon domicile ({young.city})</option>
+                <option value={young.mobilityNearRelativeZip}>
+                  A proximité d'un proche ({young.mobilityNearRelativeName} - {young.mobilityNearRelativeZip})
+                </option>
+              </select>
+            </DomainsFilter>
+
             <SearchBox md={6}>
               <DataSearch
                 innerClass={{ input: "form-control" }}
@@ -121,7 +133,7 @@ export default () => {
               />
             </DomainsFilter>
             <Col md={6}>
-              <FilterGeoloc young={young} componentId="GEOLOC" />
+              <FilterGeoloc young={young} targetLocation={targetLocation} componentId="GEOLOC" />
             </Col>
           </Row>
         </Filters>

--- a/app/src/scenes/preferences/mobilityCard.js
+++ b/app/src/scenes/preferences/mobilityCard.js
@@ -29,6 +29,17 @@ export default ({ title, handleChange, values, errors, touched }) => {
           <Field
             validate={(v) => {
               if (!v) return requiredMessage;
+            }}
+            placeholder="Adresse"
+            className="form-control"
+            name="mobilityNearRelativeAddress"
+            value={values.mobilityNearRelativeAddress}
+            onChange={handleChange}
+          />
+          <ErrorMessage errors={errors} touched={touched} name="mobilityNearRelativeAddress" />
+          <Field
+            validate={(v) => {
+              if (!v) return requiredMessage;
               if (!/\d{5}/.test(v)) return "Format incorrect";
             }}
             placeholder="Code postal"

--- a/app/src/scenes/preferences/mobilityCard.js
+++ b/app/src/scenes/preferences/mobilityCard.js
@@ -29,6 +29,7 @@ export default ({ title, handleChange, values, errors, touched }) => {
           <Field
             validate={(v) => {
               if (!v) return requiredMessage;
+              if (!/\d{5}/.test(v)) return "Format incorrect";
             }}
             placeholder="Code postal"
             className="form-control"


### PR DESCRIPTION
**Constat : **
La zone de recherche de mission ne tient compte que de l'adresse postale du volontaire.
Mais, dans ses préférences, le volontaire peut déclarer l'adresse d'un proche et doit donc pouvoir accéder aux missions de la zone de recherche liée à cette 2e adresse.

~Il ne DOIT PAS pouvoir changer son adresse postale QUE en cas de déménagement~

**Conséquence : **
- Ajouter filtre avec menu déroulant https://prnt.sc/10a4j7y
 ~- ajouter pop up avant de changer d'adresse postale dans le profil pour demander si la personne déménage (si non, elle ne doit toucher à rien)~
- ajouter dans la section "préférence de mission" l'adresse postale du proche (en plus de son code postal)

(ce qui est barré n'a pas été fait mais il faudrait, à itérer)