### PR TITLE
refactor(optimization): only 1 query for missions search in structure

### DIFF
--- a/admin/src/scenes/structure/list.js
+++ b/admin/src/scenes/structure/list.js
@@ -172,7 +172,7 @@ export default () => {
                 innerClass={{ pagination: "pagination" }}
                 renderNoResults={() => <div style={{ padding: "10px 25px" }}>Aucun résultat.</div>}
                 onData={({ rawData }) => {
-                  if (rawData && rawData.hits.hits) setStructureIds(rawData.hits.hits.map((e) => e._id));
+                  if (rawData?.hits?.hits) setStructureIds(rawData.hits.hits.map((e) => e._id));
                 }}
                 renderResultStats={(e) => {
                   return (


### PR DESCRIPTION
Pour éviter ce genre de problème https://github.com/betagouv/service-national-universel/issues/274 on essaye de faire une requête au lieu de 30. En plus ça évite que l'écran clignote.