### PR TITLE
fix(style): header height

### DIFF
--- a/admin/src/components/drawer/index.js
+++ b/admin/src/components/drawer/index.js
@@ -125,7 +125,7 @@ const Logo = styled.h1`
   background: #372f78;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
   margin-bottom: 0;
-  padding: 15px 20px 5px;
+  padding: 15px 20px 15px;
   a {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Before

<img width="320" alt="Capture d’écran 2021-06-18 à 14 33 51" src="https://user-images.githubusercontent.com/1575946/122561558-4c36a280-d042-11eb-8b6d-8d506cba75af.png">

After

<img width="370" alt="Capture d’écran 2021-06-18 à 14 34 14" src="https://user-images.githubusercontent.com/1575946/122561568-4e98fc80-d042-11eb-9d46-4ea6a3cd6e4f.png">


Et c'est globalement mieux centré.
