### PR TITLE
Fix footer admin as young's footer

### DIFF
--- a/admin/src/app.js
+++ b/admin/src/app.js
@@ -141,11 +141,13 @@ const RestrictedRoute = ({ component: Component, isLoggedIn, ...rest }) => {
 };
 
 const ContentContainer = styled.div`
-  margin-left: 250px;
-  width: 100%;
+  margin-left: auto;
+  width: 85%;
+  max-width: calc(100% - 250px);
   @media (max-width: 768px) {
     width: 100%;
     padding: 0;
     margin-left: auto;
+    max-width: 100%;
   }
 `;

--- a/admin/src/components/drawer/index.js
+++ b/admin/src/components/drawer/index.js
@@ -155,15 +155,17 @@ const Sidebar = styled.div`
     height: 100vh;
     width: 100vw;
     z-index: 11;
+    position: fixed;
   }
   background-color: #362f78;
-  width: 250px;
-  position: fixed;
+  width: 15%;
+  position: sticky;
   top: 0;
   bottom: 0;
   left: 0;
-  z-index: 90;
-  min-height: 100vh;
+  z-index: 1;
+  height: 100vh;
+  min-width: 250px;
   overflow-y: auto;
   transition: 0.2s;
   ul {


### PR DESCRIPTION
J'ai reglé le drawer en admin comme pour le drawer des youngs permettant au footer de bien s'afficher en bas de l'écran. Cela a aussi permis que lors d'un chargement de liste le footer ne se déplace pas en haut de la page ( ref https://github.com/betagouv/service-national-universel/issues/296 ) puisqu'il est sous le drawer. L'affichage sous portable est toujours le même en admin (pas beau) mais je fais une PR car ce sont deux issues différentes.