### PR TITLE
refactor: remove findOne when findById is available

### DIFF
--- a/api/src/__tests__/helpers/application.js
+++ b/api/src/__tests__/helpers/application.js
@@ -13,7 +13,7 @@ async function deleteApplicationHelper() {
 }
 
 async function getApplicationByIdHelper(applicationId) {
-  return await ApplicationObject.findOne({ _id: applicationId });
+  return await ApplicationObject.findById(applicationId);
 }
 
 const notExistingApplicationId = "104a49ba503040e4d8853973";

--- a/api/src/__tests__/helpers/bus.js
+++ b/api/src/__tests__/helpers/bus.js
@@ -5,7 +5,7 @@ async function getBusesHelper() {
 }
 
 async function getBusByIdHelper(id) {
-  return await BusObject.findOne({ _id: id });
+  return await BusObject.findById(id);
 }
 
 async function createBusHelper(Bus) {

--- a/api/src/__tests__/helpers/contract.js
+++ b/api/src/__tests__/helpers/contract.js
@@ -5,7 +5,7 @@ async function getContractsHelper(params = {}) {
 }
 
 async function getContractByIdHelper(contractId) {
-  return await ContractObject.findOne({ _id: contractId });
+  return await ContractObject.findById(contractId);
 }
 
 async function deleteContractByIdHelper(contractId) {

--- a/api/src/__tests__/helpers/departmentService.js
+++ b/api/src/__tests__/helpers/departmentService.js
@@ -5,7 +5,7 @@ async function getDepartmentServicesHelper() {
 }
 
 async function getDepartmentServiceByIdHelper(id) {
-  return await DepartmentServiceObject.findOne({ _id: id });
+  return await DepartmentServiceObject.findById(id);
 }
 
 async function deleteDepartmentServiceByIdHelper(id) {

--- a/api/src/__tests__/helpers/meetingPoint.js
+++ b/api/src/__tests__/helpers/meetingPoint.js
@@ -5,7 +5,7 @@ async function createMeetingPointHelper(MeetingPoint) {
 }
 
 async function getMeetingPointByIdHelper(id) {
-  return await MeetingPointObject.findOne({ _id: id });
+  return await MeetingPointObject.findById(id);
 }
 
 const notExistingMeetingPointId = "104a49ba223040e4d2153223";

--- a/api/src/__tests__/helpers/mission.js
+++ b/api/src/__tests__/helpers/mission.js
@@ -5,7 +5,7 @@ async function getMissionsHelper(params = {}) {
 }
 
 async function getMissionByIdHelper(missionId) {
-  return await MissionObject.findOne({ _id: missionId });
+  return await MissionObject.findById(missionId);
 }
 
 async function deleteMissionByIdHelper(missionId) {

--- a/api/src/__tests__/helpers/program.js
+++ b/api/src/__tests__/helpers/program.js
@@ -5,7 +5,7 @@ async function getProgramsHelper() {
 }
 
 async function getProgramByIdHelper(programId) {
-  return await ProgramObject.findOne({ _id: programId });
+  return await ProgramObject.findById(programId);
 }
 
 async function deleteProgramByIdHelper(programId) {

--- a/api/src/__tests__/helpers/referent.js
+++ b/api/src/__tests__/helpers/referent.js
@@ -5,7 +5,7 @@ async function getReferentsHelper() {
 }
 
 async function getReferentByIdHelper(referentId) {
-  return await ReferentObject.findOne({ _id: referentId });
+  return await ReferentObject.findById(referentId);
 }
 
 async function deleteReferentByIdHelper(referentId) {

--- a/api/src/__tests__/helpers/structure.js
+++ b/api/src/__tests__/helpers/structure.js
@@ -5,7 +5,7 @@ async function getStructuresHelper() {
 }
 
 async function getStructureByIdHelper(structureId) {
-  return await StructureObject.findOne({ _id: structureId });
+  return await StructureObject.findById(structureId);
 }
 
 async function deleteStructureByIdHelper(structureId) {

--- a/api/src/__tests__/helpers/young.js
+++ b/api/src/__tests__/helpers/young.js
@@ -5,7 +5,7 @@ async function getYoungsHelper() {
 }
 
 async function getYoungByIdHelper(youngId) {
-  return await YoungObject.findOne({ _id: youngId });
+  return await YoungObject.findById(youngId);
 }
 
 async function deleteYoungByIdHelper(youngId) {

--- a/api/src/controllers/program.js
+++ b/api/src/controllers/program.js
@@ -43,7 +43,7 @@ router.get("/:id", passport.authenticate(["referent", "young"], { session: false
   try {
     const { error, value: checkedId } = validateId(req.params.id);
     if (error) return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS, error });
-    const data = await ProgramObject.findOne({ _id: checkedId });
+    const data = await ProgramObject.findById(checkedId);
     if (!data) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
     return res.status(200).send({ ok: true, data });
   } catch (error) {
@@ -74,7 +74,7 @@ router.delete("/:id", passport.authenticate("referent", { session: false }), asy
   try {
     const { error, value: checkedId } = validateId(req.params.id);
     if (error) return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS, error });
-    const program = await ProgramObject.findOne({ _id: checkedId });
+    const program = await ProgramObject.findById(checkedId);
     await program.remove();
     console.log(`Program ${req.params.id} has been deleted`);
     res.status(200).send({ ok: true });

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -673,7 +673,7 @@ router.put("/:id/structure/:structureId", passport.authenticate("referent", { se
 
 router.delete("/:id", passport.authenticate("referent", { session: false }), async (req, res) => {
   try {
-    const referent = await ReferentModel.findOne({ _id: req.params.id });
+    const referent = await ReferentModel.findById(req.params.id);
     if (!referent) return res.status(404).send({ ok: false });
     if (!canDeleteReferent(req.user, referent)) return res.status(401).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     await referent.remove();

--- a/api/src/controllers/structure.js
+++ b/api/src/controllers/structure.js
@@ -22,7 +22,7 @@ const setAndSave = async (data, keys) => {
 async function updateNetworkName(structure) {
   if (structure.networkId) {
     // When the structure is a child (part of a network), get the network
-    const network = await StructureObject.findOne({ _id: structure.networkId });
+    const network = await StructureObject.findById(structure.networkId);
     // then update networkName thanks to its name.
     if (network) await setAndSave(structure, { networkName: network.name });
   } else if (structure.isNetwork === "true") {

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -26,7 +26,7 @@ module.exports = function (app) {
         const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
         if (error) return done(null, false);
 
-        const young = await Young.findOne({ _id: value._id });
+        const young = await Young.findById(value._id);
         if (young) return done(null, young);
       } catch (error) {
         capture(error);
@@ -42,7 +42,7 @@ module.exports = function (app) {
         const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
         if (error) return done(null, false);
 
-        const referent = await Referent.findOne({ _id: value._id });
+        const referent = await Referent.findById(value._id);
         if (referent) return done(null, referent);
       } catch (error) {
         capture(error);


### PR DESCRIPTION
Parce que findById est fait pour ça et que du coup on est sûr qu'il n'y a pas de crafting de requête possible.