### PR TITLE
fix: various fix on 554

### DIFF
--- a/admin/src/scenes/association/list.js
+++ b/admin/src/scenes/association/list.js
@@ -22,6 +22,7 @@ export default () => {
 
   useEffect(() => {
     (async () => {
+      if (associations.length === 0) return;
       const rnas = associations.map((a) => a._source.id_rna);
       const raw = JSON.stringify({
         query: {

--- a/admin/src/scenes/association/list.js
+++ b/admin/src/scenes/association/list.js
@@ -78,7 +78,6 @@ export default () => {
           };
         }
       }
-      console.log(result);
       setMissionsInfo(result);
     })();
   }, [associations]);


### PR DESCRIPTION
Alors; ça aurait été un peu compliqué de faire des suggestions dans ta PR alors je fais une PR dans ta PR que je te laisse review. Les fix : 
 - Suppression de `structure, setStructure` qui ne sert à rien ici
 - Au lieu de faire 10 requêtes (1 pour chaque asso) j'ai fait une seule requête ça évite les clignotements et la charge réseau (les référents ont des réseaux de merde
 - Utilisation de useState et useEffect pour avoir un truc plus prévisible : on envoie les assos quand elles sont chargées dans un state et quand ce state bouge, on déclenche l'effet qui charge les missions. On a eu des ennuis avec tangi, quand on ne respectait pas ce pattern de données qui ne se nettoyaient pas forcément.
 - Utilisation de terms et keyword pour être sûr d'avoir un match exact
 - Suppression de la limite à 10 éléments (on n'avait pas vu ça 😱) dans elastic search, ce qui fait qu'on envoyait des résultats faux : toujours seulement 10 missions max.
 - Suppression de onClick et selected qui ne servaient à rien (copier coller)