### PR TITLE
change ticket call

### DIFF
--- a/admin/src/scenes/inbox/components/ticketMessage.js
+++ b/admin/src/scenes/inbox/components/ticketMessage.js
@@ -28,7 +28,7 @@ export default ({ ticket: propTicket }) => {
   const updateTicket = async (id) => {
     try {
       if (!id) {
-        setTicket(undefined);
+        return setTicket(undefined);
       }
       const { data, ok } = await api.get(`/support-center/ticket/${id}`);
       if (data.error || !ok) return setTicket(propTicket);

--- a/admin/src/scenes/inbox/components/ticketMessage.js
+++ b/admin/src/scenes/inbox/components/ticketMessage.js
@@ -222,7 +222,7 @@ const MessageContainer = styled.div`
   padding: 0.2rem;
 `;
 const MessageBubble = styled.div`
-  max-width: 80%;
+  max-width: 60%;
   min-width: 20%;
   padding: 0.5rem 1.5rem;
   border-radius: ${({ internal }) => (internal ? "0.2rem" : "1rem")};

--- a/admin/src/scenes/inbox/components/ticketMessage.js
+++ b/admin/src/scenes/inbox/components/ticketMessage.js
@@ -19,8 +19,8 @@ const updateHeightElement = (e) => {
   e.target.style.height = `${e.target.scrollHeight}px`;
 };
 
-export default ({ ticket }) => {
-  const [currentTicket, setCurrentTicket] = useState(ticket);
+export default ({ ticket: propTicket }) => {
+  const [ticket, setTicket] = useState(propTicket);
   const [message, setMessage] = useState();
   const user = useSelector((state) => state.Auth.user);
   const [sending, setSending] = useState(false);
@@ -28,27 +28,23 @@ export default ({ ticket }) => {
   const updateTicket = async (id) => {
     try {
       if (!id) {
-        setCurrentTicket(undefined);
-        return console.log("no id");
+        setTicket(undefined);
       }
       const { data, ok } = await api.get(`/support-center/ticket/${id}`);
-      console.log("DATA ?", data);
-      if (data.error || !ok) return setCurrentTicket(ticket);
-      return setCurrentTicket(data);
+      if (data.error || !ok) return setTicket(propTicket);
+      return setTicket(data);
     } catch (e) {
-      setCurrentTicket(undefined);
+      setTicket(undefined);
     }
   };
 
   useEffect(() => {
-    console.log("TICKET MESSAGE", ticket);
-    console.log("TICKET MESSAGE CURRENT", currentTicket);
-    updateTicket(ticket?.id);
-    const ping = setInterval(() => updateTicket(ticket?.id), 5000);
+    updateTicket(propTicket?.id);
+    const ping = setInterval(() => updateTicket(propTicket?.id), 5000);
     return () => {
       clearInterval(ping);
     };
-  }, [ticket]);
+  }, [propTicket]);
 
   const send = async () => {
     setSending(true);
@@ -57,17 +53,17 @@ export default ({ ticket }) => {
     // then send the message
     // todo : we may be able to reset the status in only one call
     // but im not sure the POST for a message can take state in its body
-    const responseMessage = await api.put(`/support-center/ticket/${currentTicket?.id}`, { message });
+    const responseMessage = await api.put(`/support-center/ticket/${ticket?.id}`, { message });
 
-    const responseState = await api.put(`/support-center/ticket/${currentTicket?.id}`, { state: "open" });
+    const responseState = await api.put(`/support-center/ticket/${ticket?.id}`, { state: "open" });
 
     // reset ticket and input message
     setMessage("");
-    updateTicket(currentTicket?.id);
+    updateTicket(ticket?.id);
     setSending(false);
   };
 
-  if (currentTicket === null) return <Loader />;
+  if (ticket === null) return <Loader />;
 
   const displayState = (state) => {
     if (state === "ouvert")
@@ -95,21 +91,21 @@ export default ({ ticket }) => {
 
   return (
     <Container style={{ padding: 0, backgroundColor: "#F1F5F9", border: "1px solid #E4E4E7", display: "flex", flexDirection: "column" }}>
-      {currentTicket === undefined ? (
+      {ticket === undefined ? (
         <div>Selectionnez un ticket</div>
       ) : (
         <>
           <Heading>
             <div>
               <h1>
-                Demande #{currentTicket?.number} - {currentTicket?.title}
+                Demande #{ticket?.number} - {ticket?.title}
               </h1>
-              <Details title="Crée le" content={currentTicket?.created_at && formatStringLongDate(currentTicket?.created_at)} />
+              <Details title="Crée le" content={ticket?.created_at && formatStringLongDate(ticket?.created_at)} />
             </div>
-            {displayState(ticketStateNameById(currentTicket?.state_id))}
+            {displayState(ticketStateNameById(ticket?.state_id))}
           </Heading>
           <Messages>
-            {currentTicket?.articles
+            {ticket?.articles
               ?.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
               ?.map((article, i) => (
                 <Message

--- a/admin/src/scenes/inbox/components/ticketTabs.js
+++ b/admin/src/scenes/inbox/components/ticketTabs.js
@@ -41,7 +41,7 @@ export default ({ setTicket, selectedTicket, setOverview }) => {
 
   const getFrom = (ticket) => {
     if (!ticket.articles?.length) return "";
-    return ticket.articles[0]?.from;
+    return ticket.articles[0].from.split("<")[0];
   };
 
   const getDate = (ticket) => {

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -411,7 +411,7 @@ router.get("/youngFile/:youngId/:key/:fileName", passport.authenticate("referent
     try {
       const { mime } = await FileType.fromBuffer(decryptedBuffer);
       mimeFromFile = mime;
-    } catch (e) { }
+    } catch (e) {}
 
     return res.status(200).send({
       data: Buffer.from(decryptedBuffer, "base64"),
@@ -582,6 +582,7 @@ router.get("/", passport.authenticate(["referent"], { session: false }), async (
     const { error, value } = Joi.string().required().email().validate(req.query.email);
     if (error) return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS, error: error.message });
     let data = await ReferentModel.findOne({ email: value });
+    if (!data) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
     return res.status(200).send({ ok: true, data: serializeReferent(data, req.user) });
   } catch (error) {
     capture(error);


### PR DESCRIPTION
Dans le composant TicketMessage, le ticket ne se mettait pas systématiquement à jour selon les messages sélectionnés. 
C'était un problème au niveau de la fonction updateTicket : lorsque que le call vers /support-center/ticket échoue, on return direct, sauf que du coup le ticket n'est pas du tout actualisé.
Je propose que dans le cas où le call échoue, on set avec le ticket récupéré dans les props. 