### PR TITLE
fix: block access screen phase2

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -19,11 +19,9 @@ import Phase2 from "./scenes/phase2";
 import Phase3 from "./scenes/phase3";
 import Diagoriente from "./scenes/diagoriente";
 import SupportCenter from "./scenes/support-center";
-import Documents from "./scenes/documents";
 import Preferences from "./scenes/preferences";
 import Missions from "./scenes/missions";
 import Applications from "./scenes/applications";
-import Cohesion from "./scenes/cohesion-2020/";
 import Contract from "./scenes/contract";
 import ContractDone from "./scenes/contract/done";
 import Loader from "./components/Loader";
@@ -126,8 +124,6 @@ const Espace = () => {
             <Route path="/phase2" component={Phase2} />
             <Route path="/phase3" component={Phase3} />
             <Route path="/les-programmes" component={Engagement} />
-            {/* useless ? */}
-            {/* <Route path="/documents" component={Documents} /> */}
             <Route path="/preferences" component={Preferences} />
             <Route path="/mission" component={Missions} />
             <Route path="/candidature" component={Applications} />

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -126,11 +126,11 @@ const Espace = () => {
             <Route path="/phase2" component={Phase2} />
             <Route path="/phase3" component={Phase3} />
             <Route path="/les-programmes" component={Engagement} />
-            <Route path="/documents" component={Documents} />
+            {/* useless ? */}
+            {/* <Route path="/documents" component={Documents} /> */}
             <Route path="/preferences" component={Preferences} />
             <Route path="/mission" component={Missions} />
             <Route path="/candidature" component={Applications} />
-            <Route path="/cohesion" component={Cohesion} />
             <Route path="/diagoriente" component={Diagoriente} />
             {ENABLE_PM && <Route path="/ma-preparation-militaire" component={MilitaryPreparation} />}
             <Route path="/" component={Home} />

--- a/app/src/scenes/applications/index.js
+++ b/app/src/scenes/applications/index.js
@@ -10,11 +10,13 @@ import Loader from "../../components/Loader";
 import Application from "./components/application";
 import api from "../../services/api";
 import AlertBox from "../../components/AlertBox";
+import { permissionPhase2 } from "../../utils";
 
 export default function Index() {
   const [applications, setApplications] = useState(null);
   const [showInfo, setShowInfo] = useState(true);
   const young = useSelector((state) => state.Auth.young);
+  if (!young || !permissionPhase2(young)) history.push("/");
 
   const toggleShowInfo = () => {
     setShowInfo(!showInfo);

--- a/app/src/scenes/applications/index.js
+++ b/app/src/scenes/applications/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { Container } from "reactstrap";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
@@ -16,6 +16,7 @@ export default function Index() {
   const [applications, setApplications] = useState(null);
   const [showInfo, setShowInfo] = useState(true);
   const young = useSelector((state) => state.Auth.young);
+  const history = useHistory();
   if (!young || !permissionPhase2(young)) history.push("/");
 
   const toggleShowInfo = () => {

--- a/app/src/scenes/militaryPreparation/index.js
+++ b/app/src/scenes/militaryPreparation/index.js
@@ -7,7 +7,7 @@ import { useHistory, Link } from "react-router-dom";
 import api from "../../services/api";
 import { toastr } from "react-redux-toastr";
 import { setYoung } from "../../redux/auth/actions";
-import { translate, SENDINBLUE_TEMPLATES } from "../../utils";
+import { translate, SENDINBLUE_TEMPLATES, permissionPhase2 } from "../../utils";
 import { HeroContainer, Hero, Content, SeparatorXS } from "../../components/Content";
 import UploadCard from "./components/UploadCard";
 import LoadingButton from "../../components/buttons/LoadingButton";
@@ -20,9 +20,10 @@ export default function Index() {
   const dispatch = useDispatch();
   const history = useHistory();
   const [modal, setModal] = useState({ isOpen: false, onConfirm: null });
-
   const [applicationsToMilitaryPreparation, setApplicationsToMilitaryPreparation] = useState(null);
   const [referentManagerPhase2, setReferentManagerPhase2] = useState();
+
+  if (!young || !permissionPhase2(young)) history.push("/");
 
   useEffect(() => {
     getApplications();

--- a/app/src/scenes/missions/index.js
+++ b/app/src/scenes/missions/index.js
@@ -1,10 +1,14 @@
 import React from "react";
 import { Switch, Route } from "react-router-dom";
+import { useSelector } from "react-redux";
 
 import List from "./list";
 import View from "./view";
+import { permissionPhase2 } from "../../utils";
 
 export default function Index() {
+  const young = useSelector((state) => state.Auth.young);
+  if (!young || !permissionPhase2(young)) history.push("/");
   return (
     <Switch>
       <Route path="/mission/:id" component={View} />

--- a/app/src/scenes/missions/index.js
+++ b/app/src/scenes/missions/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Switch, Route } from "react-router-dom";
+import { Switch, Route, useHistory } from "react-router-dom";
 import { useSelector } from "react-redux";
 
 import List from "./list";
@@ -8,6 +8,7 @@ import { permissionPhase2 } from "../../utils";
 
 export default function Index() {
   const young = useSelector((state) => state.Auth.young);
+  const history = useHistory();
   if (!young || !permissionPhase2(young)) history.push("/");
   return (
     <Switch>


### PR DESCRIPTION
https://trello.com/c/0z5wpFNy

on ne leur affichait pas les boutons, mais les url étaient accessibles.

on bloque l'accès a `/phase2/...`
mais les url ne sont pas bien rangées, (pour les missions, c'est direct `/mission` et non '/phase2/mission/` par exemple) il faudrait les mettre dans la bonne arborescence mais il doit surement y avoir des mails et des liens qui trainent dans des mailing ou autre. que faire ?

le quick win est de mettre le bloquage direct sur ces écrans. on peut deja mettre ca, et refacto a posteriori ?