### PR TITLE
fix: alert goal reached 2022

### DIFF
--- a/admin/src/components/modals/ModalConfirm.js
+++ b/admin/src/components/modals/ModalConfirm.js
@@ -4,8 +4,21 @@ import { Modal } from "reactstrap";
 import { ModalContainer, Content, Footer, Header } from "./Modal";
 import ModalButton from "../buttons/ModalButton";
 import CloseSvg from "../../assets/Close";
+import RoundWarning from "../../assets/RoundWarning";
 
-export default function ModalConfirm({ isOpen, topTitle = "alerte", title, message, onChange, onCancel, onConfirm, confirmText = "Confirmer", cancelText = "Annuler" }) {
+export default function ModalConfirm({
+  isOpen,
+  showHeaderText = true,
+  headerText = "alerte",
+  showHeaderIcon = false,
+  title,
+  message,
+  onChange,
+  onCancel,
+  onConfirm,
+  confirmText = "Confirmer",
+  cancelText = "Annuler",
+}) {
   const [sending, setSending] = useState(false);
 
   const submit = async () => {
@@ -18,7 +31,8 @@ export default function ModalConfirm({ isOpen, topTitle = "alerte", title, messa
     <Modal centered isOpen={isOpen} toggle={onCancel || onChange}>
       <ModalContainer>
         <CloseSvg className="close-icon" height={10} onClick={onCancel || onChange} />
-        <Header>{topTitle}</Header>
+        {showHeaderText ? <Header>{headerText}</Header> : null}
+        {showHeaderIcon ? <RoundWarning style={{ marginBottom: "1.5rem" }} /> : null}
         <Content>
           <h1>{title}</h1>
           <p>{message}</p>

--- a/admin/src/components/modals/ModalConfirmMultiAction.js
+++ b/admin/src/components/modals/ModalConfirmMultiAction.js
@@ -4,10 +4,13 @@ import { Modal } from "reactstrap";
 import { ModalContainer, Content, Footer, Header } from "./Modal";
 import ModalButton from "../buttons/ModalButton";
 import CloseSvg from "../../assets/Close";
+import RoundWarning from "../../assets/RoundWarning";
 
 export default function ModalConfirm({
   isOpen,
-  topTitle = "alerte",
+  showHeaderText = "true",
+  headerText = "alerte",
+  showHeaderIcon = false,
   title,
   message,
   onChange,
@@ -24,7 +27,8 @@ export default function ModalConfirm({
     <Modal centered isOpen={isOpen} toggle={onCancel || onChange}>
       <ModalContainer>
         <CloseSvg className="close-icon" height={10} onClick={onCancel || onChange} />
-        <Header>{topTitle}</Header>
+        {showHeaderText ? <Header>{headerText}</Header> : null}
+        {showHeaderIcon ? <RoundWarning style={{ marginBottom: "1.5rem" }} /> : null}
         <Content>
           <h1>{title}</h1>
           <p>{message}</p>

--- a/admin/src/components/modals/ModalConfirmMultiAction.js
+++ b/admin/src/components/modals/ModalConfirmMultiAction.js
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { Modal } from "reactstrap";
+
+import { ModalContainer, Content, Footer, Header } from "./Modal";
+import ModalButton from "../buttons/ModalButton";
+import CloseSvg from "../../assets/Close";
+
+export default function ModalConfirm({
+  isOpen,
+  topTitle = "alerte",
+  title,
+  message,
+  onChange,
+  onCancel,
+  onConfirm,
+  confirmText = "Confirmer",
+  onConfirm2,
+  confirmText2 = "Confirmer",
+  cancelText = "Annuler",
+}) {
+  const [{ sending1, sending2 }, setSending] = useState({ sending1: false, sending2: false });
+
+  return (
+    <Modal centered isOpen={isOpen} toggle={onCancel || onChange}>
+      <ModalContainer>
+        <CloseSvg className="close-icon" height={10} onClick={onCancel || onChange} />
+        <Header>{topTitle}</Header>
+        <Content>
+          <h1>{title}</h1>
+          <p>{message}</p>
+        </Content>
+        <Footer>
+          <ModalButton
+            loading={sending1}
+            disabled={sending1 || sending2}
+            onClick={() => {
+              setSending((e) => ({ ...e, sending1: true }));
+              onConfirm();
+              setSending((e) => ({ ...e, sending1: false }));
+            }}
+            primary>
+            {confirmText}
+          </ModalButton>
+          {onConfirm2 ? (
+            <ModalButton
+              loading={sending2}
+              disabled={sending1 || sending2}
+              onClick={() => {
+                setSending((e) => ({ ...e, sending2: true }));
+                onConfirm2();
+                setSending((e) => ({ ...e, sending2: false }));
+              }}>
+              {confirmText2}
+            </ModalButton>
+          ) : null}
+          <ModalButton disabled={sending1 || sending2} onClick={onCancel || onChange}>
+            {cancelText}
+          </ModalButton>
+        </Footer>
+      </ModalContainer>
+    </Modal>
+  );
+}

--- a/admin/src/components/selectStatus.js
+++ b/admin/src/components/selectStatus.js
@@ -139,6 +139,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         isOpen={modalConfirm?.isOpen}
         title={modalConfirm?.title}
         message={modalConfirm?.message}
+        headerText="Confirmation"
         onCancel={() => setModalConfirm({ isOpen: false, onConfirm: null })}
         onConfirm={() => {
           modalConfirm?.onConfirm?.();
@@ -175,6 +176,8 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         }}
       />
       <ModalConfirmMultiAction
+        showHeaderIcon={true}
+        showHeaderText={false}
         isOpen={modalGoal?.isOpen}
         title={modalGoal?.title}
         message={modalGoal?.message}

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -57,6 +57,7 @@ const YOUNG_STATUS_COLORS = {
   DONE: colors.green,
   NOT_DONE: colors.red,
   DELETED: colors.black,
+  WAITING_LIST: colors.lightOrange,
 };
 
 const MISSION_STATUS_COLORS = {


### PR DESCRIPTION
il ya deja un departement qui a dépassé ses objectifs... --'

il faut qu'on reactive la modale d'alerte quand les objectifs sont atteints.
j'ai un peu modifier l'ux, et le calcul ce fait plus simplement qu'avant.

je n'ai pas trop testé... il faudrait voir dans les cas spéciaux (pas d'objectifs renseignés, une des cohortes est pleine mais pas celle du jeune, changement dans les autres statuts, etc)

que se passe-t-il si un changement de statut pour les 2021 ?
peut etre faire ce systeme de `goalReached` que pour les cohortes de 2022 ?