### PR TITLE
feat(support): restrict access to public db

### DIFF
--- a/api/src/controllers/knowledgeBase.js
+++ b/api/src/controllers/knowledgeBase.js
@@ -9,7 +9,6 @@ const { anyAuth } = require("../passport");
 const KnowledgeBaseObject = require("../models/knowledgeBase");
 const { uploadPublicPicture, ERRORS } = require("../utils/index.js");
 const { validateId } = require("../utils/validator");
-const { mapRoleToKBAccess } = require("snu-lib/roles");
 
 const findChildrenRecursive = async (section, allChildren, { findAll = false }) => {
   if (section.type !== "section") return;
@@ -332,6 +331,25 @@ router.get("/all-slugs", async (req, res) => {
     res.status(500).send({ ok: false, code: ERRORS.SERVER_ERROR, error });
   }
 });
+
+const mapRoleToKBAccess = (user) => {
+  if (!user.constructor.modelName) return "public";
+  if (user.constructor.modelName === "young") return "young";
+  switch (user.role) {
+    case ROLES.ADMIN:
+      return "admin";
+    case ROLES.REFERENT_DEPARTMENT:
+    case ROLES.REFERENT_REGION:
+      return "referent";
+    case ROLES.RESPONSIBLE:
+    case ROLES.SUPERVISOR:
+      return "structure";
+    case ROLES.HEAD_CENTER:
+      return "head_center";
+    default:
+      return "public";
+  }
+};
 
 // this is for the public-access part of the knowledge base (not the admin part)
 router.get("/:slug", anyAuth, async (req, res) => {

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -50,4 +50,33 @@ module.exports = function () {
       return done(null, false);
     }),
   );
+
+  passport.use(
+    "any",
+    new JwtStrategy(opts, async function (jwtPayload, done) {
+      try {
+        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
+        if (error) return done(null, false);
+        console.log("any");
+        const referent = await Referent.findById(value._id);
+        if (referent) return done(null, referent);
+        const young = await Young.findById(value._id);
+        if (young) return done(null, young);
+      } catch (error) {
+        capture(error);
+      }
+      return done(null, false);
+    }),
+  );
+};
+
+module.exports.anyAuth = (req, res, next) => {
+  const token = getToken(req);
+  console.log({ token });
+  if (!token) {
+    req.user = {};
+    next();
+  } else {
+    passport.authenticate("any", { session: false })(req, res, next);
+  }
 };

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -140,7 +140,7 @@ function canUpdateReferent({ actor, originalTarget, modifiedTarget = null, struc
       ));
 
   const isActorAndTargetInTheSameRegion =
-    actor.region === (originalTarget.region || (structure && structure.region))
+    actor.region === (originalTarget.region || (structure && structure.region));
   const isActorAndTargetInTheSameDepartment =
     actor.department === (originalTarget.department || (structure && structure.department));
 
@@ -247,6 +247,28 @@ const canSendFileByMail = (actor, target) => {
   return isAdmin || isReferentRegionFromSameRegion || isReferentDepartmentFromSameDepartment;
 };
 
+const mapRoleToKBAccess = (actor) => {
+  if (!actor) return "public";
+  if (!actor.constructor) return "public";
+  if (!actor.constructor.modelName) return "public";
+  if (actor.constructor.modelName === "young") return "young";
+  if (actor.constructor.modelName !== "referent") return "public";
+  switch (actor.role) {
+    case ROLES.ADMIN:
+      return "admin";
+    case ROLES.REFERENT_DEPARTMENT:
+    case ROLES.REFERENT_REGION:
+      return "referent";
+    case ROLES.RESPONSIBLE:
+    case ROLES.SUPERVISOR:
+      return "structure";
+    case ROLES.HEAD_CENTER:
+      return "head_center";
+    default:
+      return "public";
+  }
+};
+
 module.exports = {
   ROLES,
   SUB_ROLES,
@@ -275,4 +297,5 @@ module.exports = {
   canDeleteStructure,
   canSigninAs,
   canSendFileByMail,
+  mapRoleToKBAccess,
 };

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -247,28 +247,6 @@ const canSendFileByMail = (actor, target) => {
   return isAdmin || isReferentRegionFromSameRegion || isReferentDepartmentFromSameDepartment;
 };
 
-const mapRoleToKBAccess = (actor) => {
-  if (!actor) return "public";
-  if (!actor.constructor) return "public";
-  if (!actor.constructor.modelName) return "public";
-  if (actor.constructor.modelName === "young") return "young";
-  if (actor.constructor.modelName !== "referent") return "public";
-  switch (actor.role) {
-    case ROLES.ADMIN:
-      return "admin";
-    case ROLES.REFERENT_DEPARTMENT:
-    case ROLES.REFERENT_REGION:
-      return "referent";
-    case ROLES.RESPONSIBLE:
-    case ROLES.SUPERVISOR:
-      return "structure";
-    case ROLES.HEAD_CENTER:
-      return "head_center";
-    default:
-      return "public";
-  }
-};
-
 module.exports = {
   ROLES,
   SUB_ROLES,
@@ -297,5 +275,4 @@ module.exports = {
   canDeleteStructure,
   canSigninAs,
   canSendFileByMail,
-  mapRoleToKBAccess,
 };


### PR DESCRIPTION
Est-ce que ça vous choque / est-ce que vous voyez un inconvénient à faire comme ça pour l'authentification ?

Cette PR n'est pas finie, il faut encore que je filtre les articles/sections par rôle, mais je voudrais juste avoir votre avis sur l'auth. 

Afin de résoudre la problématique: il faut que je puisse accéder à ces deux routes que je sois connecté ou non, et en fonction de si je suis connecté et avec quel rôle, j'ai le droit de voir tel ou tel article/session.
