### PR TITLE
fix: create/delete session phase1

### DIFF
--- a/admin/src/scenes/centers/edit.js
+++ b/admin/src/scenes/centers/edit.js
@@ -45,7 +45,7 @@ export default function Edit(props) {
           if (isNew) values.placesLeft = values.placesTotal;
           else values.placesLeft += values.placesTotal - defaultValue.placesTotal;
 
-          const { ok, code, data } = values._id ? await api.put("/cohesion-center", values) : await api.post("/cohesion-center", values);
+          const { ok, code, data } = values._id ? await api.put(`/cohesion-center/${values._id}`, values) : await api.post("/cohesion-center", values);
 
           setLoading(false);
           if (!ok) return toastr.error("Une erreur s'est produite lors de l'enregistrement de ce centre !!", translate(code));

--- a/admin/src/scenes/centers/edit.js
+++ b/admin/src/scenes/centers/edit.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Col, Row } from "reactstrap";
 import styled from "styled-components";
 import { toastr } from "react-redux-toastr";
-import { Formik } from "formik";
+import { Formik, Field } from "formik";
 import { useHistory } from "react-router-dom";
 
 import { translate } from "../../utils";
@@ -14,6 +14,7 @@ import Select from "./components/Select";
 import LoadingButton from "../../components/buttons/LoadingButton";
 import AddressInput from "../../components/addressInputV2";
 import MultiSelect from "../../components/Multiselect";
+import Error, { requiredMessage } from "../../components/errorMessage";
 
 export default function Edit(props) {
   const [defaultValue, setDefaultValue] = useState(null);
@@ -88,6 +89,9 @@ export default function Edit(props) {
                       touched={touched}
                     />
                     <MultiSelectWithTitle
+                      required
+                      errors={errors}
+                      touched={touched}
                       title="Séjour(s) de cohésion concerné(s)"
                       value={values.cohorts}
                       onChange={handleChange}
@@ -137,14 +141,16 @@ export default function Edit(props) {
     </Formik>
   );
 }
-const MultiSelectWithTitle = ({ title, value, onChange, name, options, placeholder }) => {
+const MultiSelectWithTitle = ({ title, value, onChange, name, options, placeholder, required, errors, touched }) => {
   return (
     <Row className="detail">
       <Col md={4}>
         <label>{title}</label>
       </Col>
       <Col md={8}>
+        <Field hidden value={value} name={name} onChange={onChange} validate={(v) => required && !v?.length && requiredMessage} />
         <MultiSelect value={value} onChange={onChange} name={name} options={options} placeholder={placeholder} />
+        {errors && touched && <Error errors={errors} touched={touched} name={name} />}
       </Col>
     </Row>
   );

--- a/admin/src/scenes/centers/edit.js
+++ b/admin/src/scenes/centers/edit.js
@@ -74,7 +74,7 @@ export default function Edit(props) {
                   <BoxContent direction="column">
                     <Item title="Nom du centre" values={values} name={"name"} handleChange={handleChange} required errors={errors} touched={touched} />
                     {values._id ? <Item disabled title="Code" values={values} name="_id" /> : null}
-                    <Item title="Capacité d'accueil" values={values} name={"placesTotal"} handleChange={handleChange} required errors={errors} touched={touched} />
+                    <Item type="number" title="Capacité d'accueil" values={values} name={"placesTotal"} handleChange={handleChange} required errors={errors} touched={touched} />
                     <Select
                       name="pmr"
                       values={values}

--- a/admin/src/scenes/centers/list.js
+++ b/admin/src/scenes/centers/list.js
@@ -169,7 +169,7 @@ export default function List() {
                           hit={hit}
                           sessionsPhase1={sessionsPhase1
                             .filter((e) => e?._source?.cohesionCenterId === hit._id && (!filterCohorts.length || filterCohorts.includes(e?._source?.cohort)))
-                            .map((e) => e._source)}
+                            .map((e) => e)}
                           onClick={() => setCenter(hit)}
                           selected={center?._id === hit._id}
                         />
@@ -203,7 +203,7 @@ const Hit = ({ hit, onClick, selected, sessionsPhase1 }) => {
       <td>
         {sessionsPhase1.map((sessionPhase1) => (
           <SubTd key={sessionPhase1._id}>
-            <Badge text={sessionPhase1.cohort} />
+            <Badge text={sessionPhase1._source.cohort} />
           </SubTd>
         ))}
       </td>
@@ -211,15 +211,15 @@ const Hit = ({ hit, onClick, selected, sessionsPhase1 }) => {
         {sessionsPhase1.map((sessionPhase1) => (
           <SubTd key={sessionPhase1._id}>
             <MultiLine>
-              <h2>{sessionPhase1.placesLeft} places disponibles</h2>
-              <p>sur {sessionPhase1.placesTotal} places proposées</p>
+              <h2>{sessionPhase1._source.placesLeft} places disponibles</h2>
+              <p>sur {sessionPhase1._source.placesTotal} places proposées</p>
             </MultiLine>
           </SubTd>
         ))}
       </td>
       <td>
         {sessionsPhase1.map((sessionPhase1) => (
-          <SubTd key={sessionPhase1._id}>{sessionPhase1.placesLeft > 0 ? <Badge text="Places disponibles" color="#6CC763" /> : <Badge text="Complet" />}</SubTd>
+          <SubTd key={sessionPhase1._id}>{sessionPhase1._source.placesLeft > 0 ? <Badge text="Places disponibles" color="#6CC763" /> : <Badge text="Complet" />}</SubTd>
         ))}
       </td>
     </tr>

--- a/api/src/__tests__/cohesion-center.test.js
+++ b/api/src/__tests__/cohesion-center.test.js
@@ -276,16 +276,15 @@ describe("Cohesion Center", () => {
 
   describe("PUT /cohesion-center/:id", () => {
     it("should return 404 when cohesion center is not found", async () => {
-      const res = await request(getAppHelper()).put("/cohesion-center/").send({
-        _id: notExistingCohesionCenterId,
+      const res = await request(getAppHelper()).put("/cohesion-center/" + notExistingCohesionCenterId).send({
+        name: 'newname',
       });
       expect(res.status).toBe(404);
     });
     it("should return 200 when cohesion center is found", async () => {
       const cohesionCenter = await createCohesionCenter(getNewCohesionCenterFixture());
-      const res = await request(getAppHelper()).put("/cohesion-center/").send({
+      const res = await request(getAppHelper()).put("/cohesion-center/" + cohesionCenter._id).send({
         name: "new name",
-        _id: cohesionCenter._id,
       });
       expect(res.status).toBe(200);
       expect(res.body.data.name).toBe("new name");
@@ -296,10 +295,9 @@ describe("Cohesion Center", () => {
       const young = await createYoungHelper({ ...getNewYoungFixture(), cohesionCenterId: cohesionCenter._id });
       const meetingPoint = await createMeetingPointHelper({ ...getNewMeetingPointFixture(), centerId: cohesionCenter._id });
 
-      const res = await request(getAppHelper()).put("/cohesion-center/").send({
+      const res = await request(getAppHelper()).put("/cohesion-center/" + cohesionCenter._id).send({
         name: "new name",
         code: "new code",
-        _id: cohesionCenter._id,
       });
 
       const updatedReferent = await getReferentByIdHelper(referent._id);
@@ -313,8 +311,8 @@ describe("Cohesion Center", () => {
       const passport = require("passport");
       passport.user.role = ROLES.RESPONSIBLE;
       const cohesionCenter = await createCohesionCenter(getNewCohesionCenterFixture());
-      const res = await request(getAppHelper()).put("/cohesion-center/").send({
-        _id: cohesionCenter._id,
+      const res = await request(getAppHelper()).put("/cohesion-center/" + cohesionCenter._id).send({
+        name: 'nonono',
       });
       expect(res.status).toBe(403);
       passport.user.role = ROLES.ADMIN;

--- a/api/src/__tests__/fixtures/cohesionCenter.js
+++ b/api/src/__tests__/fixtures/cohesionCenter.js
@@ -20,6 +20,7 @@ function getNewCohesionCenterFixture() {
     observations: faker.lorem.word(),
     waitingList: [faker.lorem.word(), faker.lorem.word()],
     COR: faker.lorem.word(),
+    cohorts: ["2020"],
   };
 }
 

--- a/api/src/controllers/cohesion-center.js
+++ b/api/src/controllers/cohesion-center.js
@@ -265,9 +265,13 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
           const cohesionCenterId = center._id;
           const placesTotal = center.placesTotal;
           const placesLeft = center.placesTotal;
-          // :warning: peut etre creation de doublons ?
-          // il faudrait peut etre check si une session existe deja pour ce centre et cette cohorte avant de creer une nouvelle
-          await SessionPhase1.create({ cohesionCenterId, cohort, placesTotal, placesLeft });
+          const session = await SessionPhase1.findOne({ cohesionCenterId, cohort });
+          if (session) {
+            session.set({ placesTotal, placesLeft })
+            await session.save();
+          } else {
+            await SessionPhase1.create({ cohesionCenterId, cohort, placesTotal, placesLeft });
+          }
         }
       }
 

--- a/api/src/controllers/cohesion-center.js
+++ b/api/src/controllers/cohesion-center.js
@@ -254,30 +254,30 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
     center.set(newCenter);
     await center.save();
 
-    const addedCohorts = (newCenter.cohorts || []).filter((cohort) => !previousCohorts.includes(cohort));
-    let deletedCohorts = [];
+    // if we change the cohorts, we need to update the sessionPhase1
     if (newCenter?.cohorts?.length) {
-      deletedCohorts = previousCohorts.filter((cohort) => !newCenter.cohorts.includes(cohort));
-    }
+      const addedCohorts = newCenter.cohorts.filter((cohort) => !previousCohorts.includes(cohort));
+      const deletedCohorts = previousCohorts.filter((cohort) => !newCenter.cohorts.includes(cohort));
 
-    // add sessionPhase1 documents linked to this cohesion center
-    if (addedCohorts?.length > 0) {
-      for (let cohort of addedCohorts) {
-        const cohesionCenterId = center._id;
-        const placesTotal = center.placesTotal;
-        const placesLeft = center.placesTotal;
-        // :warning: peut etre creation de doublons ?
-        // il faudrait peut etre check si une session existe deja pour ce centre et cette cohorte avant de creer une nouvelle
-        await SessionPhase1.create({ cohesionCenterId, cohort, placesTotal, placesLeft });
+      // add sessionPhase1 documents linked to this cohesion center
+      if (addedCohorts?.length > 0) {
+        for (let cohort of addedCohorts) {
+          const cohesionCenterId = center._id;
+          const placesTotal = center.placesTotal;
+          const placesLeft = center.placesTotal;
+          // :warning: peut etre creation de doublons ?
+          // il faudrait peut etre check si une session existe deja pour ce centre et cette cohorte avant de creer une nouvelle
+          await SessionPhase1.create({ cohesionCenterId, cohort, placesTotal, placesLeft });
+        }
       }
-    }
 
-    // ! MAYBE DANGEROUS ?
-    // delete sessionPhase1 documents linked to this cohesion center
-    if (deletedCohorts?.length > 0) {
-      for (let cohort of deletedCohorts) {
-        const sessionPhase1 = await SessionPhase1.findOne({ cohesionCenterId: center._id, cohort });
-        await sessionPhase1.remove();
+      // ! MAYBE DANGEROUS ?
+      // delete sessionPhase1 documents linked to this cohesion center
+      if (deletedCohorts?.length > 0) {
+        for (let cohort of deletedCohorts) {
+          const sessionPhase1 = await SessionPhase1.findOne({ cohesionCenterId: center._id, cohort });
+          await sessionPhase1.remove();
+        }
       }
     }
 

--- a/api/src/controllers/cohesion-center.js
+++ b/api/src/controllers/cohesion-center.js
@@ -258,17 +258,19 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
     const deletedCohorts = previousCohorts.filter((cohort) => !newCenter.cohorts.includes(cohort));
 
     // add sessionPhase1 documents linked to this cohesion center
-    if (addedCohorts.length > 0) {
+    if (addedCohorts?.length > 0) {
       for (let cohort of addedCohorts) {
         const cohesionCenterId = center._id;
         const placesTotal = center.placesTotal;
         const placesLeft = center.placesTotal;
+        // :warning: peut etre creation de doublons ?
+        // il faudrait peut etre check si une session existe deja pour ce centre et cette cohorte avant de creer une nouvelle
         await SessionPhase1.create({ cohesionCenterId, cohort, placesTotal, placesLeft });
       }
     }
 
     // delete sessionPhase1 documents linked to this cohesion center
-    if (deletedCohorts.length > 0) {
+    if (deletedCohorts?.length > 0) {
       for (let cohort of deletedCohorts) {
         const sessionPhase1 = await SessionPhase1.findOne({ cohesionCenterId: center._id, cohort });
         await sessionPhase1.remove();

--- a/api/src/controllers/cohesion-center.js
+++ b/api/src/controllers/cohesion-center.js
@@ -255,14 +255,11 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
     await center.save();
 
     const addedCohorts = newCenter.cohorts.filter((cohort) => !previousCohorts.includes(cohort));
-    console.log("✍️ ~ addedCohorts", addedCohorts);
     const deletedCohorts = previousCohorts.filter((cohort) => !newCenter.cohorts.includes(cohort));
-    console.log("✍️ ~ deletedCohorts", deletedCohorts);
 
     // add sessionPhase1 documents linked to this cohesion center
     if (addedCohorts.length > 0) {
       for (let cohort of addedCohorts) {
-        console.log("✍️ ~ add cohort", cohort);
         const cohesionCenterId = center._id;
         const placesTotal = center.placesTotal;
         const placesLeft = center.placesTotal;
@@ -273,7 +270,6 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
     // delete sessionPhase1 documents linked to this cohesion center
     if (deletedCohorts.length > 0) {
       for (let cohort of deletedCohorts) {
-        console.log("✍️ ~ delete cohort", cohort);
         const sessionPhase1 = await SessionPhase1.findOne({ cohesionCenterId: center._id, cohort });
         await sessionPhase1.remove();
       }

--- a/api/src/controllers/cohesion-center.js
+++ b/api/src/controllers/cohesion-center.js
@@ -267,7 +267,7 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
           const placesLeft = center.placesTotal;
           const session = await SessionPhase1.findOne({ cohesionCenterId, cohort });
           if (session) {
-            session.set({ placesTotal, placesLeft })
+            session.set({ placesTotal, placesLeft });
             await session.save();
           } else {
             await SessionPhase1.create({ cohesionCenterId, cohort, placesTotal, placesLeft });
@@ -280,7 +280,7 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
       if (deletedCohorts?.length > 0) {
         for (let cohort of deletedCohorts) {
           const sessionPhase1 = await SessionPhase1.findOne({ cohesionCenterId: center._id, cohort });
-          await sessionPhase1.remove();
+          await sessionPhase1?.remove();
         }
       }
     }

--- a/api/src/controllers/cohesion-center.js
+++ b/api/src/controllers/cohesion-center.js
@@ -250,12 +250,15 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
     const center = await CohesionCenterModel.findById(checkedId);
     if (!center) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
 
-    const previousCohorts = center.cohorts;
+    const previousCohorts = center.cohorts || [];
     center.set(newCenter);
     await center.save();
 
-    const addedCohorts = newCenter.cohorts.filter((cohort) => !previousCohorts.includes(cohort));
-    const deletedCohorts = previousCohorts.filter((cohort) => !newCenter.cohorts.includes(cohort));
+    const addedCohorts = (newCenter.cohorts || []).filter((cohort) => !previousCohorts.includes(cohort));
+    let deletedCohorts = [];
+    if (newCenter?.cohorts?.length) {
+      deletedCohorts = previousCohorts.filter((cohort) => !newCenter.cohorts.includes(cohort));
+    }
 
     // add sessionPhase1 documents linked to this cohesion center
     if (addedCohorts?.length > 0) {
@@ -269,6 +272,7 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
       }
     }
 
+    // ! MAYBE DANGEROUS ?
     // delete sessionPhase1 documents linked to this cohesion center
     if (deletedCohorts?.length > 0) {
       for (let cohort of deletedCohorts) {

--- a/api/src/models/cohesionCenter.js
+++ b/api/src/models/cohesionCenter.js
@@ -65,6 +65,12 @@ const Schema = new mongoose.Schema({
       description: "Région du centre",
     },
   },
+  addressVerified: {
+    type: String,
+    documentation: {
+      description: "Adresse validée",
+    },
+  },
   placesTotal: {
     type: Number,
     documentation: {

--- a/api/src/utils/validator.js
+++ b/api/src/utils/validator.js
@@ -255,9 +255,7 @@ function validateNewCohesionCenter(application) {
 }
 
 function validateUpdateCohesionCenter(application) {
-  return Joi.object()
-    .keys({ ...cohesionCenterKeys, _id: Joi.string().required() })
-    .validate(application, { stripUnknown: true });
+  return Joi.object().keys(cohesionCenterKeys).validate(application, { stripUnknown: true });
 }
 
 const sessionPhase1Keys = {

--- a/api/src/utils/validator.js
+++ b/api/src/utils/validator.js
@@ -240,6 +240,7 @@ const cohesionCenterKeys = {
   zip: Joi.string().allow(null, ""),
   department: Joi.string().allow(null, ""),
   region: Joi.string().allow(null, ""),
+  addressVerified: Joi.string().allow(null, ""),
   placesTotal: Joi.alternatives().try(Joi.string().allow(null, ""), Joi.number().allow(null)),
   placesLeft: Joi.alternatives().try(Joi.string().allow(null, ""), Joi.number().allow(null)),
   outfitDelivered: Joi.string().allow(null, ""),


### PR DESCRIPTION
permettre la création et la suppression de `sessionPhase1` a la modification des `cohesionCenter`.

La suppression est peut etre un peu dangeureuse.
a la base, j'avais une grosse faille qui aurait pu nous couter cher :
imaginons on ne mets a jour que le `name`.
il y aurait eu des trucs bizarre dans les ajouts et suppression de `sessionPhase1`... je pense qu'on peut améliorer ca