### PR TITLE
feat: Ajouter bouton suppression de compte sur la fiche d'autres référents

### DIFF
--- a/admin/src/scenes/utilisateur/edit.js
+++ b/admin/src/scenes/utilisateur/edit.js
@@ -12,7 +12,18 @@ import ReactSelect from "react-select";
 import { Box, BoxContent, BoxHeadTitle } from "../../components/box";
 import LoadingButton from "../../components/buttons/LoadingButton";
 import DateInput from "../../components/dateInput";
-import { departmentList, regionList, department2region, translate, ROLES, VISITOR_SUBROLES, REFERENT_DEPARTMENT_SUBROLE, REFERENT_REGION_SUBROLE, colors } from "../../utils";
+import {
+  departmentList,
+  regionList,
+  department2region,
+  translate,
+  ROLES,
+  VISITOR_SUBROLES,
+  REFERENT_DEPARTMENT_SUBROLE,
+  REFERENT_REGION_SUBROLE,
+  colors,
+  canDeleteReferent,
+} from "../../utils";
 import api from "../../services/api";
 import { toastr } from "react-redux-toastr";
 import Loader from "../../components/Loader";
@@ -314,10 +325,7 @@ export default function Edit(props) {
           <HistoricComponent model="referent" value={user} />
         </Box>
       ) : null}
-      {currentUser.role === ROLES.ADMIN ||
-      ([ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(currentUser.role) && [ROLES.RESPONSIBLE, ROLES.SUPERVISOR].includes(user.role)) ? (
-        <DeleteBtn onClick={onClickDelete}>{`Supprimer le compte de ${user.firstName} ${user.lastName}`}</DeleteBtn>
-      ) : null}
+      {canDeleteReferent(currentUser, user) ? <DeleteBtn onClick={onClickDelete}>{`Supprimer le compte de ${user.firstName} ${user.lastName}`}</DeleteBtn> : null}
       {canModify(currentUser, user) && user.role === ROLES.REFERENT_DEPARTMENT && (
         <Formik
           initialValues={service || { department: user.department }}

--- a/admin/src/scenes/utilisateur/list.js
+++ b/admin/src/scenes/utilisateur/list.js
@@ -165,7 +165,7 @@ export default function List() {
                         <th>Rôle</th>
                         <th>Crée le</th>
                         <th>Dernière connexion le</th>
-                        {[ROLES.ADMIN, ROLES.SUPERVISOR].includes(user.role) && <th>Actions</th>}
+                        <th>Actions</th>
                       </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
Les référents régionaux peuvent supprimer les comptes
- des référents régionaux de leur région
- des référents départementaux de leur région

Les référents départementaux peuvent supprimer les compte des référents départementaux de leur département