### PR TITLE
fix(api): update only contract that linked to active application

### DIFF
--- a/api/src/__tests__/contract.test.js
+++ b/api/src/__tests__/contract.test.js
@@ -44,7 +44,7 @@ describe("Structure", () => {
     describe("when it works", () => {
       async function createContract(options, initialYoung) {
         const young = initialYoung || (await createYoungHelper(getNewYoungFixture()));
-        const application = await createApplication({ ...getNewApplicationFixture(), youngId: young._id });
+        const application = await createApplication({ ...getNewApplicationFixture(), status:"VALIDATED", youngId: young._id });
         const contractFixture = getNewContractFixture();
         contractFixture.youngId = young._id;
         contractFixture.applicationId = application._id;

--- a/api/src/controllers/application.js
+++ b/api/src/controllers/application.js
@@ -14,7 +14,7 @@ const { validateUpdateApplication, validateNewApplication } = require("../utils/
 const { ADMIN_URL, APP_URL } = require("../config");
 const { SUB_ROLES, ROLES, SENDINBLUE_TEMPLATES, department2region } = require("snu-lib");
 const { serializeApplication } = require("../utils/serializer");
-const { updateYoungPhase2Hours, updateStatusPhase2 } = require("../utils");
+const { updateYoungPhase2Hours, updateStatusPhase2, updateYoungStatusPhase2Contract } = require("../utils");
 
 const updatePlacesMission = async (app, fromUser) => {
   try {
@@ -85,6 +85,7 @@ router.post("/", passport.authenticate(["young", "referent"], { session: false, 
     await updateYoungPhase2Hours(young);
     await updateStatusPhase2(young);
     await updatePlacesMission(data, req.user);
+    await updateYoungStatusPhase2Contract(young, req.user);
     return res.status(200).send({ ok: true, data: serializeApplication(data) });
   } catch (error) {
     capture(error);
@@ -113,6 +114,7 @@ router.put("/", passport.authenticate(["referent", "young"], { session: false, f
 
     await updateYoungPhase2Hours(young);
     await updateStatusPhase2(young);
+    await updateYoungStatusPhase2Contract(young, req.user);
     await updatePlacesMission(application, req.user);
 
     res.status(200).send({ ok: true, data: serializeApplication(application) });

--- a/api/src/controllers/contract.js
+++ b/api/src/controllers/contract.js
@@ -16,31 +16,8 @@ const contractTemplate = require("../templates/contractPhase2");
 const { SENDINBLUE_TEMPLATES } = require("snu-lib/constants");
 const { validateId, validateContract, validateOptionalId } = require("../utils/validator");
 const { serializeContract } = require("../utils/serializer");
-const { updateYoungPhase2Hours, updateStatusPhase2 } = require("../utils");
+const { updateYoungPhase2Hours, updateStatusPhase2, updateYoungStatusPhase2Contract, checkStatusContract } = require("../utils");
 const Joi = require("joi");
-
-function checkStatusContract(contract) {
-  if (!contract.invitationSent || contract.invitationSent === "false") return "DRAFT";
-  // To find if everybody has validated we count actual tokens and number of validated. It should be improved later.
-  const tokenKeys = ["parent1Token", "parent2Token", "projectManagerToken", "structureManagerToken", "youngContractToken"];
-  const tokenCount = tokenKeys.reduce((acc, current) => (contract[current] ? acc + 1 : acc), 0);
-  const validateKeys = ["parent1Status", "parent2Status", "projectManagerStatus", "structureManagerStatus", "youngContractStatus"];
-  const validatedCount = validateKeys.reduce((acc, current) => (contract[current] === "VALIDATED" ? acc + 1 : acc), 0);
-  if (validatedCount >= tokenCount) {
-    return "VALIDATED";
-  } else {
-    return "SENT";
-  }
-}
-
-async function updateYoungStatusPhase2Contract(young, fromUser) {
-  const contracts = await ContractObject.find({ youngId: young._id });
-  young.set({
-    statusPhase2Contract: contracts.map((contract) => checkStatusContract(contract)),
-  });
-
-  await young.save({ fromUser });
-}
 
 async function createContract(data, fromUser) {
   const { sendMessage } = data;


### PR DESCRIPTION
avant, on mettait à jour le `statusPhase2Contract` uniquement à la modif du contrat.
et pas à la mise a jour de l'application.

de plus, on comptait tous les contrats. il faut comptabiliser uniquement les contrats liés à des candidatures active (ou le contrat a un interet)
par exemple : une mission annulée -> on s'en fou du contrat (on pourrait presque le supprimer, mais mieux vaut garder les docs en db)

---
une fois merge, il faudra faire tourner cette nouvelle fonction sur toute la collection `young`