### PR TITLE
fix: reinit-fields-change-cohort

### DIFF
--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -425,7 +425,7 @@ router.put("/young/:id/change-cohort", passport.authenticate("referent", { sessi
       young.set({ meetingPointId: undefined });
     }
 
-    young.set({ statusPhase1: YOUNG_STATUS_PHASE1.WAITING_AFFECTATION, cohort, cohortChangeReason });
+    young.set({ statusPhase1: YOUNG_STATUS_PHASE1.WAITING_AFFECTATION, cohort, cohortChangeReason, cohesionStayPresence: undefined, cohesionStayMedicalFileReceived: undefined });
     await young.save({ fromUser: req.user });
 
     // if they had a session, we check if we need to update the places taken / left

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -531,9 +531,18 @@ router.put("/:id/change-cohort", passport.authenticate("young", { session: false
         cohortDetailedChangeReason,
         status: YOUNG_STATUS.WAITING_LIST,
         statusPhase1: YOUNG_STATUS_PHASE1.WAITING_AFFECTATION,
+        cohesionStayPresence: undefined,
+        cohesionStayMedicalFileReceived: undefined,
       });
     } else {
-      young.set({ cohort, cohortChangeReason, cohortDetailedChangeReason, statusPhase1: YOUNG_STATUS_PHASE1.WAITING_AFFECTATION });
+      young.set({
+        cohort,
+        cohortChangeReason,
+        cohortDetailedChangeReason,
+        statusPhase1: YOUNG_STATUS_PHASE1.WAITING_AFFECTATION,
+        cohesionStayPresence: undefined,
+        cohesionStayMedicalFileReceived: undefined,
+      });
     }
 
     await young.save({ fromUser: req.user });


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Rattrapage-changement-de-cohorte-et-pr-sence-360e2153d65a42e2ae4fddd06e77c0bb

une fois que c'est merge, on pourra faire tourner un script pour rattraper les jeunes avec des données corrompues.
`2022-04-06_reinit-champs-phase1-chmt-cohorte`
et les scirpts de maj de places (sessions et bus)