### PR TITLE
fix(api): verify file magic numbers + mime type for uploads

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -25,7 +25,7 @@
         "express": "^4.17.1",
         "express-fileupload": "^1.2.0",
         "express-rate-limit": "^6.3.0",
-        "file-type": "^16.2.0",
+        "file-type": "^16.5.3",
         "gm": "^1.23.1",
         "helmet": "^4.5.0",
         "http-aws-es": "^6.0.0",
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -2036,11 +2036,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/debug": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -4445,17 +4440,16 @@
       }
     },
     "node_modules/file-type": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.2.0.tgz",
-      "integrity": "sha512-1Wwww3mmZCMmLjBfslCluwt2mxH80GsAXYrvPnfQ42G1EGWag336kB1iyCgyn7UXiKY3cJrNykXPrCwA7xb5Ag==",
+      "version": "16.5.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.0.3",
-        "token-types": "^2.0.0",
-        "typedarray-to-buffer": "^3.1.5"
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -5279,7 +5273,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "node_modules/is-weakref": {
       "version": "1.0.1",
@@ -7071,9 +7066,9 @@
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "node_modules/peek-readable": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.3.tgz",
-      "integrity": "sha512-mpAcysyRJxmICBcBa5IXH7SZPvWkcghm6Fk8RekoS3v+BpbSzlZzuWbMx+GXrlUwESi9qHar4nVEZNMKylIHvg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
       "engines": {
         "node": ">=8"
       },
@@ -8124,16 +8119,15 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.8.tgz",
-      "integrity": "sha512-QLgv+oiXwXgCgp2PdPPa+Jpp4D9imK9e/0BsyfeFMr6QL6wMVqoVn9+OXQ9I7MZbmUzN6lmitTJ09uwS2OmGcw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "dependencies": {
-        "@tokenizer/token": "^0.1.1",
-        "@types/debug": "^4.1.5",
-        "peek-readable": "^3.1.3"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -8421,15 +8415,15 @@
       }
     },
     "node_modules/token-types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz",
-      "integrity": "sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.0.tgz",
+      "integrity": "sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==",
       "dependencies": {
-        "@tokenizer/token": "^0.1.1",
+        "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "engines": {
-        "node": ">=0.1.98"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -8597,6 +8591,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -10571,9 +10566,9 @@
       }
     },
     "@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -10629,11 +10624,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/debug": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -12518,14 +12508,13 @@
       }
     },
     "file-type": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.2.0.tgz",
-      "integrity": "sha512-1Wwww3mmZCMmLjBfslCluwt2mxH80GsAXYrvPnfQ42G1EGWag336kB1iyCgyn7UXiKY3cJrNykXPrCwA7xb5Ag==",
+      "version": "16.5.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
       "requires": {
         "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.0.3",
-        "token-types": "^2.0.0",
-        "typedarray-to-buffer": "^3.1.5"
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       }
     },
     "fill-range": {
@@ -13119,7 +13108,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-weakref": {
       "version": "1.0.1",
@@ -14498,9 +14488,9 @@
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "peek-readable": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.3.tgz",
-      "integrity": "sha512-mpAcysyRJxmICBcBa5IXH7SZPvWkcghm6Fk8RekoS3v+BpbSzlZzuWbMx+GXrlUwESi9qHar4nVEZNMKylIHvg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
     },
     "pend": {
       "version": "1.2.0",
@@ -15314,13 +15304,12 @@
       "dev": true
     },
     "strtok3": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.8.tgz",
-      "integrity": "sha512-QLgv+oiXwXgCgp2PdPPa+Jpp4D9imK9e/0BsyfeFMr6QL6wMVqoVn9+OXQ9I7MZbmUzN6lmitTJ09uwS2OmGcw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "requires": {
-        "@tokenizer/token": "^0.1.1",
-        "@types/debug": "^4.1.5",
-        "peek-readable": "^3.1.3"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
       }
     },
     "superagent": {
@@ -15537,11 +15526,11 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "token-types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.1.1.tgz",
-      "integrity": "sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.0.tgz",
+      "integrity": "sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==",
       "requires": {
-        "@tokenizer/token": "^0.1.1",
+        "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "dependencies": {
@@ -15667,6 +15656,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -37,7 +37,7 @@
     "express": "^4.17.1",
     "express-fileupload": "^1.2.0",
     "express-rate-limit": "^6.3.0",
-    "file-type": "^16.2.0",
+    "file-type": "^16.5.3",
     "gm": "^1.23.1",
     "helmet": "^4.5.0",
     "http-aws-es": "^6.0.0",


### PR DESCRIPTION
On vérifiait déjà le mime-type, maintenant on doit aussi vérifier le contenu (entête) du fichier lui même.

Correction bonus dans la foulée : on supprime tout le temps le fichier en cas d'erreur.