### PR TITLE
Fix (api): add statusPhase2ValidatedAt when setting "VALIDATED" through equivalence

### DIFF
--- a/api/src/controllers/young/phase2.js
+++ b/api/src/controllers/young/phase2.js
@@ -130,7 +130,7 @@ router.put("/equivalence/:idEquivalence", passport.authenticate(["referent", "yo
 
     if (["WAITING_CORRECTION", "VALIDATED", "REFUSED"].includes(value.status) && req.user?.role) {
       if (young.statusPhase2 !== "VALIDATED" && value.status === "VALIDATED") {
-        young.set({ statusPhase2: "VALIDATED" });
+        young.set({ statusPhase2: "VALIDATED", statusPhase2ValidatedAt: Date.now() });
       }
       if (young.statusPhase2 === "VALIDATED" && ["WAITING_CORRECTION", "REFUSED"].includes(value.status)) {
         const applications = await ApplicationModel.find({ youngId: young._id });


### PR DESCRIPTION
Pas de ticket mais problème remonté par le support : impossible de sortir certaines attestations. Le pb étant qu'il n'y a pas de date de validation pour la phase 2 pour certains volontaires, je pense que c'est à cause de la procédure d'équivalence.