### PR TITLE
chore(api): autoriser referents à voir tous les resp, superviseurs et chefs de centre

### DIFF
--- a/api/src/__tests__/es.test.js
+++ b/api/src/__tests__/es.test.js
@@ -409,12 +409,9 @@ describe("Es", () => {
       const res = await msearch("referent", buildMsearchQuery("referent", matchAll));
       expect(res.statusCode).toEqual(200);
       const filters = getFilter()[0].bool.should;
-      expect(filters[0].terms["role.keyword"]).toStrictEqual([ROLES.REFERENT_DEPARTMENT, ROLES.SUPERVISOR, ROLES.RESPONSIBLE]);
+      expect(filters[0].terms["role.keyword"]).toStrictEqual([ROLES.REFERENT_DEPARTMENT, ROLES.SUPERVISOR, ROLES.RESPONSIBLE, ROLES.HEAD_CENTER]);
       expect(filters[1]).toStrictEqual({
         bool: { must: [{ term: { "role.keyword": ROLES.REFERENT_REGION } }, { term: { "region.keyword": passport.user.region } }] },
-      });
-      expect(filters[2]).toStrictEqual({
-        bool: { must: [{ term: { "role.keyword": ROLES.HEAD_CENTER } }, { term: { "department.keyword": passport.user.department } }] },
       });
 
       passport.user.role = ROLES.ADMIN;
@@ -429,12 +426,9 @@ describe("Es", () => {
       const res = await msearch("referent", buildMsearchQuery("referent", matchAll));
       expect(res.statusCode).toEqual(200);
       const filters = getFilter()[0].bool.should;
-      expect(filters[0].terms["role.keyword"]).toStrictEqual([ROLES.REFERENT_REGION, ROLES.SUPERVISOR, ROLES.RESPONSIBLE]);
+      expect(filters[0].terms["role.keyword"]).toStrictEqual([ROLES.REFERENT_REGION, ROLES.SUPERVISOR, ROLES.RESPONSIBLE, ROLES.HEAD_CENTER]);
       expect(filters[1]).toStrictEqual({
         bool: { must: [{ term: { "role.keyword": ROLES.REFERENT_DEPARTMENT } }, { term: { "region.keyword": passport.user.region } }] },
-      });
-      expect(filters[2]).toStrictEqual({
-        bool: { must: [{ term: { "role.keyword": ROLES.HEAD_CENTER } }, { term: { "region.keyword": passport.user.region } }] },
       });
 
       passport.user.role = ROLES.ADMIN;

--- a/api/src/controllers/es.js
+++ b/api/src/controllers/es.js
@@ -373,9 +373,8 @@ router.post("/referent/:action(_msearch|export)", passport.authenticate(["refere
       filter.push({
         bool: {
           should: [
-            { terms: { "role.keyword": [ROLES.REFERENT_DEPARTMENT, ROLES.SUPERVISOR, ROLES.RESPONSIBLE] } },
+            { terms: { "role.keyword": [ROLES.REFERENT_DEPARTMENT, ROLES.SUPERVISOR, ROLES.RESPONSIBLE, ROLES.HEAD_CENTER] } },
             { bool: { must: [{ term: { "role.keyword": ROLES.REFERENT_REGION } }, { term: { "region.keyword": user.region } }] } },
-            { bool: { must: [{ term: { "role.keyword": ROLES.HEAD_CENTER } }, { term: { "department.keyword": user.department } }] } },
           ],
         },
       });
@@ -384,9 +383,8 @@ router.post("/referent/:action(_msearch|export)", passport.authenticate(["refere
       filter.push({
         bool: {
           should: [
-            { terms: { "role.keyword": [ROLES.REFERENT_REGION, ROLES.SUPERVISOR, ROLES.RESPONSIBLE] } },
+            { terms: { "role.keyword": [ROLES.REFERENT_REGION, ROLES.SUPERVISOR, ROLES.RESPONSIBLE, ROLES.HEAD_CENTER] } },
             { bool: { must: [{ term: { "role.keyword": ROLES.REFERENT_DEPARTMENT } }, { term: { "region.keyword": user.region } }] } },
-            { bool: { must: [{ term: { "role.keyword": ROLES.HEAD_CENTER } }, { term: { "region.keyword": user.region } }] } },
             { bool: { must: [{ term: { "role.keyword": ROLES.VISITOR } }, { term: { "region.keyword": user.region } }] } },
           ],
         },


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Acc-s-utilisateurs-chef-de-centre-responsables-et-superviseurs-574f95a6a0a146d88059ed75d618af72