### PR TITLE
fix(admin): improve address search in DOM-TOM

### DIFF
--- a/admin/src/components/addressInputV2.js
+++ b/admin/src/components/addressInputV2.js
@@ -71,9 +71,9 @@ export default function AddressInputV2({
   }, [values[keys.zip]]);
 
   const onSuggestionSelected = () => {
-    let depart = suggestion.properties.postcode.substr(0, 2);
+    let depart = suggestion.properties.postcode?.substr(0, 2) || suggestion.properties.citycode.substr(0, 2);
     if (["97", "98"].includes(depart)) {
-      depart = suggestion.properties.postcode.substr(0, 3);
+      depart = suggestion.properties.postcode?.substr(0, 3) || suggestion.properties.citycode.substr(0, 3);
     }
     if (depart === "20") {
       depart = suggestion.properties.context.substr(0, 2);
@@ -106,12 +106,15 @@ export default function AddressInputV2({
     const text = item;
 
     setLoading(true);
-    const response = await fetch(`https://api-adresse.data.gouv.fr/search/?autocomplete=1&q=${text}&limit=1&postcode=${values.zip}`, {
+    let url = `https://api-adresse.data.gouv.fr/search/?q=${text}`;
+    // For Nouvelle-Calédonie, we don't add the postcode to the query
+    if (parseInt(values.zip.substr(0, 3)) !== 988) url = url.concat(`&postcode=${values.zip}`);
+    const response = await fetch(url, {
       mode: "cors",
       method: "GET",
     });
     const res = await response.json();
-    const arr = res.features.filter((e) => e.properties.type !== "municipality");
+    const arr = res.features;
 
     setLoading(false);
     if (arr.length > 0) setSuggestion({ ok: true, status: "FOUND", ...arr[0] });


### PR DESCRIPTION
Tickets :
- https://admin-support.snu.gouv.fr/ticket/635b9c6b226ecaf110f16d95
- https://servicenation-hed2328.slack.com/archives/C030TFJTACV/p1666000639064449

Solutions:
- pour Tahiti: suppression du filtre "municipalité" de manière globale,
- pour la Nouvelle-Calédonie: suppression du postalcode dans la requête seulement si le code commence par "988" et on bascule sur le citycode pour la suggestion.

Testé avec :
- une adresse à Nouméa (Nouvelle-Calédonie),
- une adresse à Papeete (Tahiti),
- une adresse en métropole.