### PR TITLE
feat: passage mongoose en 6.0

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8879,9 +8879,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "5.13.15",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.15.tgz",
-      "integrity": "sha512-cxp1Gbb8yUWkaEbajdhspSaKzAvsIvOtRlYD87GN/P2QEUhpd6bIvebi36T6M0tIVAMauNaK9SPA055N3PwF8Q==",
+      "version": "5.13.16",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.16.tgz",
+      "integrity": "sha512-kBNB+BfaQjn3Jjh1SfdZZub70pde9dI0sA8VN6AnnCOeK4TzbLDyB0lBmPBOajppm6U9orde5YfTRyyVa1U45w==",
       "dependencies": {
         "@types/bson": "1.x || 4.0.x",
         "@types/mongodb": "^3.5.27",
@@ -18730,9 +18730,9 @@
       }
     },
     "mongoose": {
-      "version": "5.13.15",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.15.tgz",
-      "integrity": "sha512-cxp1Gbb8yUWkaEbajdhspSaKzAvsIvOtRlYD87GN/P2QEUhpd6bIvebi36T6M0tIVAMauNaK9SPA055N3PwF8Q==",
+      "version": "5.13.16",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.16.tgz",
+      "integrity": "sha512-kBNB+BfaQjn3Jjh1SfdZZub70pde9dI0sA8VN6AnnCOeK4TzbLDyB0lBmPBOajppm6U9orde5YfTRyyVa1U45w==",
       "requires": {
         "@types/bson": "1.x || 4.0.x",
         "@types/mongodb": "^3.5.27",


### PR DESCRIPTION
Il faudrait passer mongoose en 6.X.X pour l'installation de PM2 pour pas se manger 500 notifs DeprecationWarning 

Look for breaking change here :
https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md