### PR TITLE
feat(api/admin): Bloc "Affectation et pointage" champ “Disponibilité des listes de transport par centre

### DIFF
--- a/admin/src/scenes/settings/index.js
+++ b/admin/src/scenes/settings/index.js
@@ -570,7 +570,7 @@ export default function Settings() {
                 </div>
                 <div className="flex flex-col w-[45%] gap-4">
                   {/* TODO implementer parametres sur la plateforme */}
-                  {/* <div className="flex flex-col gap-3">
+                  <div className="flex flex-col gap-3">
                     <div className="flex items-center gap-2">
                       <p className="text-gray-900  text-xs font-medium">Disponibilité des listes de transport par centre (envoi par email)</p>
                       <MdInfoOutline data-tip data-for="disponibilité_liste" className="text-gray-400 h-5 w-5 cursor-pointer" />
@@ -587,15 +587,25 @@ export default function Settings() {
                     <ToggleDate
                       label="Tout utilisateur"
                       disabled={isLoading}
-                       readOnly={readOnly}
-                      value={""}
-                      onChange={() => setData({ ...data })}
-                      range={{ from: undefined, to: undefined }}
+                      readOnly={readOnly}
+                      value={data.busListAvailability}
+                      onChange={() => setData({ ...data, busListAvailability: !data.busListAvailability })}
+                      range={{
+                        from: data?.uselessInformation?.busListAvailabilityFrom || undefined,
+                        to: data?.uselessInformation?.busListAvailabilityTo || undefined,
+                      }}
                       onChangeRange={(range) => {
-                        setData({ ...data });
+                        setData({
+                          ...data,
+                          uselessInformation: {
+                            ...data.uselessInformation,
+                            busListAvailabilityFrom: range?.from,
+                            busListAvailabilityTo: range?.to,
+                          },
+                        });
                       }}
                     />
-                  </div> */}
+                  </div>
                   <div className="flex flex-col gap-3">
                     <div className="flex items-center gap-2">
                       <p className="text-gray-900  text-xs font-medium">Pointage</p>

--- a/admin/src/scenes/settings/utils.js
+++ b/admin/src/scenes/settings/utils.js
@@ -18,6 +18,8 @@ export const uselessSettings = {
   youngCheckinForRegionReferentTo: "",
   youngCheckinForDepartmentReferentFrom: "",
   youngCheckinForDepartmentReferentTo: "",
+  busListAvailabilityFrom: "",
+  busListAvailabilityTo: "",
 };
 
 export const settings = {
@@ -36,4 +38,5 @@ export const settings = {
   youngCheckinForHeadOfCenter: false,
   youngCheckinForRegionReferent: false,
   youngCheckinForDepartmentReferent: false,
+  busListAvailability: false,
 };

--- a/api/src/controllers/cohort.js
+++ b/api/src/controllers/cohort.js
@@ -225,6 +225,7 @@ router.put("/:cohort", passport.authenticate([ROLES.ADMIN], { session: false }),
       youngCheckinForHeadOfCenter: Joi.boolean().required(),
       youngCheckinForRegionReferent: Joi.boolean().required(),
       youngCheckinForDepartmentReferent: Joi.boolean().required(),
+      busListAvailability: Joi.boolean().required(),
       uselessInformation: Joi.object().allow(null),
     }).validate(req.body, { stripUnknown: true });
     if (bodyError) {
@@ -258,6 +259,7 @@ router.put("/:cohort", passport.authenticate([ROLES.ADMIN], { session: false }),
       youngCheckinForHeadOfCenter: body.youngCheckinForHeadOfCenter,
       youngCheckinForRegionReferent: body.youngCheckinForRegionReferent,
       youngCheckinForDepartmentReferent: body.youngCheckinForDepartmentReferent,
+      busListAvailability: body.busListAvailability,
       uselessInformation: body.uselessInformation,
     });
 

--- a/api/src/models/cohort.js
+++ b/api/src/models/cohort.js
@@ -107,6 +107,14 @@ const Schema = new mongoose.Schema({
     },
   },
 
+  busListAvailability: {
+    type: Boolean,
+    documentation: {
+      description:
+        " Ouverture ou fermeture de l’accès à la liste des volontaires d’un même centre par ligne de transport et par point de rassemblement envoyé par email (activation/désactivation du token)",
+    },
+  },
+
   //information n'impactant le fonctionnement de l'application
   uselessInformation: {
     type: mongoose.Schema.Types.Mixed,


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Bloc-Affectation-et-pointage-champ-Disponibilit-des-listes-de-transport-par-centre-e27a44204a1b4c01849efc872463f59d?pvs=4

Ajout sur la page de paramêtrage dynamique de : 
<img width="649" alt="image" src="https://user-images.githubusercontent.com/50077368/226355648-d13d9d7b-e0f8-434c-bc23-520920ef38b0.png">

Pour tester : http://localhost:8082/centre/6387327da4ec702331abf2c7/6387327ea4ec702331abf2cc/general?STATUS=%5B%22VALIDATED%22%5D
--> Exporter les volontaire -> Informations de transports