### PR TITLE
fix(knowledge): design link contactform

### DIFF
--- a/knowledge-base-public/src/components/knowledge-base/KnowledgeBasePublicArticle.js
+++ b/knowledge-base-public/src/components/knowledge-base/KnowledgeBasePublicArticle.js
@@ -76,7 +76,10 @@ const KnowledgeBasePublicArticle = ({ item, isLoading }) => {
               <h1 className="text-2xl font-light not-italic leading-8 text-gray-600">Aidez-nous à nous améliorer</h1>
               <p className="mt-8 justify-center leading-5 text-gray-600 ">
                 ⚠️ <span className="text-lg font-semibold text-gray-600">Rappel :</span> vous n'obtiendrez pas de réponse à votre question, merci de ne pas inscrire d'informations
-                personnelles. Pour obtenir une aide personnalisée, <span className="cursor-pointer text-lg font-semibold text-[#4F46E5] ">cliquez ici.</span>
+                personnelles. Pour obtenir une aide personnalisée,
+                <a href="https://www.snu.gouv.fr/nous-contacter/" className="text-snu-purple-200 " target="_blank" rel="noopener noreferrer">
+                  <span className="cursor-pointer text-lg font-semibold text-[#4F46E5] ">cliquez ici.</span>
+                </a>
               </p>
               <div className="mt-8 mb-2 flex w-full flex-row">
                 <p className="inline-block w-full self-end text-base font-medium leading-5 text-gray-700">Quel était votre question ?</p>
@@ -86,7 +89,7 @@ const KnowledgeBasePublicArticle = ({ item, isLoading }) => {
                 className={`h-24 w-full rounded-md border-2 ${
                   !feedback.comment || feedback.comment?.length <= 125 ? "border-gray-200" : "border-[#EF4444]"
                 } p-4 text-sm font-normal text-[#4B5563] focus:outline-none`}
-                placeholder="Describe yourself here..."
+                placeholder="Ecrivez votre question ici..."
                 onChange={(e) => setFeedback({ ...feedback, comment: e.target.value })}
               ></textarea>
               <p

--- a/knowledge-base-public/src/components/knowledge-base/KnowledgeBasePublicArticle.js
+++ b/knowledge-base-public/src/components/knowledge-base/KnowledgeBasePublicArticle.js
@@ -76,9 +76,9 @@ const KnowledgeBasePublicArticle = ({ item, isLoading }) => {
               <h1 className="text-2xl font-light not-italic leading-8 text-gray-600">Aidez-nous à nous améliorer</h1>
               <p className="mt-8 justify-center leading-5 text-gray-600 ">
                 ⚠️ <span className="text-lg font-semibold text-gray-600">Rappel :</span> vous n'obtiendrez pas de réponse à votre question, merci de ne pas inscrire d'informations
-                personnelles. Pour obtenir une aide personnalisée,
+                personnelles. Pour obtenir une aide personnalisée,{" "}
                 <a href="https://www.snu.gouv.fr/nous-contacter/" className="text-snu-purple-200 " target="_blank" rel="noopener noreferrer">
-                  <span className="cursor-pointer text-lg font-semibold text-[#4F46E5] ">cliquez ici.</span>
+                  <span className="font-semibold text-[#4F46E5] ">cliquez ici.</span>
                 </a>
               </p>
               <div className="mt-8 mb-2 flex w-full flex-row">

--- a/knowledge-base-public/src/components/knowledge-base/KnowledgeBasePublicNoAnswer.js
+++ b/knowledge-base-public/src/components/knowledge-base/KnowledgeBasePublicNoAnswer.js
@@ -15,7 +15,7 @@ const KnowledgeBasePublicNoAnswer = ({ className = "" }) => {
             <br /> La base de connaissance du SNU se construit au fil des évolutions de la plateforme et également des besoins des utilisateurs. <br />
             Si vous n'avez pas trouvé de réponse à votre question, vous pouvez nous suggérer un sujet d'article{" "}
             <a href="https://forms.gle/tUPfh6iZwYqV3Hws9" className="text-snu-purple-200 underline" target="_blank" rel="noreferrer">
-              {"en\u00A0cliquant\u00A0ici"}
+              {"en\u00A0cliquant\u00A0ici."}
             </a>
             <br />
             <br />
@@ -23,7 +23,7 @@ const KnowledgeBasePublicNoAnswer = ({ className = "" }) => {
           </p>
           <div>
             Vous pouvez nous contacter{" "}
-            <a href="https://moncompte.snu.gouv.fr/public-besoin-d-aide" target="_blank" rel="noopener noreferrer">
+            <a href="https://moncompte.snu.gouv.fr/public-besoin-d-aide" className="text-snu-purple-200 underline" target="_blank" rel="noopener noreferrer">
               en cliquant ici.
             </a>
           </div>


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/BDC-Commentaire-d-article-modifier-l-affichage-du-lien-vers-le-formulaire-de-contact-4c41ad9909324179845167645d95a28e

Et mini modif design dans la modale de commentaire après un negative feedback et ajout d'un href