### PR TITLE
Protect JWT from password change and logout

### DIFF
--- a/api/src/__tests__/referent-auth.test.js
+++ b/api/src/__tests__/referent-auth.test.js
@@ -117,8 +117,13 @@ describe("Referent", () => {
   });
   describe("POST /referent/logout", () => {
     it("should return 200", async () => {
+      const referent = await createReferentHelper(getNewReferentFixture());
+      const passport = require("passport");
+      const previous = passport.user;
+      passport.user = referent;
       const res = await request(getAppHelper()).post("/referent/logout");
       expect(res.status).toBe(200);
+      passport.user = previous;
     });
   });
 

--- a/api/src/__tests__/young-auth.test.js
+++ b/api/src/__tests__/young-auth.test.js
@@ -166,8 +166,13 @@ describe("Young", () => {
   });
   describe("POST /young/logout", () => {
     it("should return 200", async () => {
+      const young = await createYoungHelper({ ...getNewYoungFixture(), password: VALID_PASSWORD });
+      const passport = require("passport");
+      const previous = passport.user;
+      passport.user = young;
       const res = await request(getAppHelper()).post("/young/logout");
       expect(res.status).toBe(200);
+      passport.user = previous;
     });
   });
 

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -191,7 +191,7 @@ class Auth {
     const { password, email } = value;
     try {
       const now = new Date();
-      const user = await this.model.findOne({ email }).select("+passwordChangedAt +lastLogoutAt");
+      const user = await this.model.findOne({ email });
       if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_PASSWORD_INVALID });
       if (user.loginAttempts > 12) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS" });
       if (user.nextLoginAttemptIn > now) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS", data: { nextLoginAttemptIn: user.nextLoginAttemptIn } });
@@ -284,7 +284,7 @@ class Auth {
       if (newPassword !== verifyPassword) return res.status(422).send({ ok: false, code: ERRORS.PASSWORDS_NOT_MATCH });
       if (newPassword === password) return res.status(401).send({ ok: false, code: ERRORS.NEW_PASSWORD_IDENTICAL_PASSWORD });
 
-      const user = await this.model.findById(req.user._id).select("+lastLogoutAt");
+      const user = await this.model.findById(req.user._id);
       const passwordChangedAt = Date.now();
       user.set({ password: newPassword, passwordChangedAt });
       await user.save();

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -59,7 +59,7 @@ class Auth {
         acceptCGU,
         rulesYoung,
       });
-      const token = jwt.sign({ _id: user._id }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       return res.status(200).send({
@@ -159,7 +159,7 @@ class Auth {
         grade,
         inscriptionStep2023: STEPS2023.COORDONNEES,
       });
-      const token = jwt.sign({ _id: user._id }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       await sendTemplate(SENDINBLUE_TEMPLATES.young.INSCRIPTION_STARTED, {
@@ -215,7 +215,7 @@ class Auth {
       user.set({ lastLoginAt: Date.now() });
       await user.save();
 
-      const token = jwt.sign({ _id: user.id }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       const data = isYoung(user) ? serializeYoung(user, user) : serializeReferent(user, user);
@@ -233,6 +233,10 @@ class Auth {
 
   async logout(_req, res) {
     try {
+      // Find user by token
+      const { user } = req;
+      user.set({ lastLogoutAt: Date.now() });
+      await user.save();
       res.clearCookie("jwt", logoutCookieOptions());
       return res.status(200).send({ ok: true });
     } catch (error) {

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -191,7 +191,7 @@ class Auth {
     const { password, email } = value;
     try {
       const now = new Date();
-      const user = await this.model.findOne({ email }).select("password");
+      const user = await this.model.findOne({ email }).select("+password+lastLogoutAt");
       if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_PASSWORD_INVALID });
       if (user.loginAttempts > 12) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS" });
       if (user.nextLoginAttemptIn > now) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS", data: { nextLoginAttemptIn: user.nextLoginAttemptIn } });

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -231,7 +231,7 @@ class Auth {
     }
   }
 
-  async logout(_req, res) {
+  async logout(req, res) {
     try {
       // Find user by token
       const { user } = req;

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -59,7 +59,7 @@ class Auth {
         acceptCGU,
         rulesYoung,
       });
-      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       return res.status(200).send({
@@ -159,7 +159,7 @@ class Auth {
         grade,
         inscriptionStep2023: STEPS2023.COORDONNEES,
       });
-      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       await sendTemplate(SENDINBLUE_TEMPLATES.young.INSCRIPTION_STARTED, {
@@ -191,7 +191,7 @@ class Auth {
     const { password, email } = value;
     try {
       const now = new Date();
-      const user = await this.model.findOne({ email });
+      const user = await this.model.findOne({ email }).select("password");
       if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_PASSWORD_INVALID });
       if (user.loginAttempts > 12) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS" });
       if (user.nextLoginAttemptIn > now) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS", data: { nextLoginAttemptIn: user.nextLoginAttemptIn } });

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -59,7 +59,7 @@ class Auth {
         acceptCGU,
         rulesYoung,
       });
-      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: password }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: null, password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       return res.status(200).send({
@@ -159,7 +159,7 @@ class Auth {
         grade,
         inscriptionStep2023: STEPS2023.COORDONNEES,
       });
-      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: password }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: null, password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       await sendTemplate(SENDINBLUE_TEMPLATES.young.INSCRIPTION_STARTED, {
@@ -191,7 +191,7 @@ class Auth {
     const { password, email } = value;
     try {
       const now = new Date();
-      const user = await this.model.findOne({ email }).select("+password+lastLogoutAt");
+      const user = await this.model.findOne({ email }).select("+password +lastLogoutAt");
       if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_PASSWORD_INVALID });
       if (user.loginAttempts > 12) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS" });
       if (user.nextLoginAttemptIn > now) return res.status(401).send({ ok: false, code: "TOO_MANY_REQUESTS", data: { nextLoginAttemptIn: user.nextLoginAttemptIn } });
@@ -214,6 +214,7 @@ class Auth {
       user.set({ loginAttempts: 0 });
       user.set({ lastLoginAt: Date.now() });
       await user.save();
+      console.log("🚀 ~ file: auth.js:217 ~ Auth ~ signin ~ user:", user);
 
       const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -175,8 +175,8 @@ router.post("/signin_as/:type/:id", passport.authenticate("referent", { session:
     const { id, type } = params;
 
     let user = null;
-    if (type === "referent") user = await ReferentModel.findById(id).select("+passwordChangedAt +lastLogoutAt");
-    else if (type === "young") user = await YoungModel.findById(id).select("+passwordChangedAt +lastLogoutAt");
+    if (type === "referent") user = await ReferentModel.findById(id);
+    else if (type === "young") user = await YoungModel.findById(id);
     if (!user) return res.status(404).send({ code: ERRORS.USER_NOT_FOUND, ok: false });
 
     if (!canSigninAs(req.user, user)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -150,7 +150,7 @@ router.post("/signup", async (req, res) => {
     const role = ROLES.RESPONSIBLE; // responsible by default
 
     const user = await ReferentModel.create({ password, email, firstName, lastName, role, acceptCGU, phone, mobile: phone });
-    const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
+    const token = jwt.sign({ _id: user.id, lastLogoutAt: null, password }, config.secret, { expiresIn: JWT_MAX_AGE });
     res.cookie("jwt", token, cookieOptions());
 
     return res.status(200).send({ user, token, ok: true });
@@ -175,8 +175,8 @@ router.post("/signin_as/:type/:id", passport.authenticate("referent", { session:
     const { id, type } = params;
 
     let user = null;
-    if (type === "referent") user = await ReferentModel.findById(id);
-    else if (type === "young") user = await YoungModel.findById(id);
+    if (type === "referent") user = await ReferentModel.findById(id).select("+password +lastLogoutAt");
+    else if (type === "young") user = await YoungModel.findById(id).select("+password +lastLogoutAt");
     if (!user) return res.status(404).send({ code: ERRORS.USER_NOT_FOUND, ok: false });
 
     if (!canSigninAs(req.user, user)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
@@ -311,10 +311,10 @@ router.post("/signup_verify", async (req, res) => {
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
 
-    const referent = await ReferentModel.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } });
+    const referent = await ReferentModel.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } }).select("password");
     if (!referent) return res.status(404).send({ ok: false, code: ERRORS.INVITATION_TOKEN_EXPIRED_OR_INVALID });
 
-    const token = jwt.sign({ _id: referent.id, lastLogoutAt: referent.lastLogoutAt, password: referent.password }, config.secret, { expiresIn: "30d" });
+    const token = jwt.sign({ _id: referent.id, lastLogoutAt: null, password: referent.password }, config.secret, { expiresIn: "30d" });
     return res.status(200).send({ ok: true, token, data: serializeReferent(referent, referent) });
   } catch (error) {
     capture(error);
@@ -356,7 +356,7 @@ router.post("/signup_invite", async (req, res) => {
       acceptCGU,
     });
 
-    const token = jwt.sign({ _id: referent.id, lastLogoutAt: referent.lastLogoutAt, password: referent.password }, config.secret, { expiresIn: "30d" });
+    const token = jwt.sign({ _id: referent.id, lastLogoutAt: null, password }, config.secret, { expiresIn: "30d" });
     res.cookie("jwt", token, cookieOptions());
 
     await referent.save({ fromUser: req.user });
@@ -1006,7 +1006,6 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
     }
 
     const referent = await ReferentModel.findById(req.params.id);
-    console.log("🚀 ~ file: referent.js:1009 ~ router.put ~ referent:", referent);
     if (!referent) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
 
     const structure = await StructureModel.findById(value.structureId);

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -125,7 +125,7 @@ function cleanReferentData(referent) {
 }
 
 router.post("/signin", (req, res) => ReferentAuth.signin(req, res));
-router.post("/logout", (req, res) => ReferentAuth.logout(req, res));
+router.post("/logout", passport.authenticate("referent", { session: false, failWithError: true }), (req, res) => ReferentAuth.logout(req, res));
 router.post("/signup", async (req, res) => {
   try {
     const { error, value } = Joi.object({

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -1006,6 +1006,7 @@ router.put("/:id", passport.authenticate("referent", { session: false, failWithE
     }
 
     const referent = await ReferentModel.findById(req.params.id);
+    console.log("🚀 ~ file: referent.js:1009 ~ router.put ~ referent:", referent);
     if (!referent) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
 
     const structure = await StructureModel.findById(value.structureId);

--- a/api/src/controllers/signin.js
+++ b/api/src/controllers/signin.js
@@ -43,16 +43,14 @@ router.get("/token", async (req, res) => {
     const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
     if (error) return res.status(200).send({ ok: true, user: { restriction: "public" } });
 
-    // Add check of lastLoginAt and password if you find the young or referent
-
     const young = await Young.findById(value._id);
-    if (young) {
+    if (young && jwtPayload.lastLogoutAt === young.lastLogoutAt && jwtPayload.password === young.password) {
       young.set({ lastLoginAt: Date.now() });
       await young.save();
       return res.status(200).send({ ok: true, user: { ...serializeYoung(young, young), allowedRole: "young" } });
     }
     const referent = await Referent.findById(value._id);
-    if (referent) {
+    if (referent && jwtPayload.lastLogoutAt === referent.lastLogoutAt && jwtPayload.password === referent.password) {
       referent.set({ lastLoginAt: Date.now() });
       await referent.save();
       return res.status(200).send({ ok: true, user: { ...serializeReferent(referent, referent), allowedRole: allowedRole(referent) } });

--- a/api/src/controllers/signin.js
+++ b/api/src/controllers/signin.js
@@ -43,6 +43,8 @@ router.get("/token", async (req, res) => {
     const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
     if (error) return res.status(200).send({ ok: true, user: { restriction: "public" } });
 
+    // Add check of lastLoginAt and password if you find the young or referent
+
     const young = await Young.findById(value._id);
     if (young) {
       young.set({ lastLoginAt: Date.now() });

--- a/api/src/controllers/signin.js
+++ b/api/src/controllers/signin.js
@@ -40,9 +40,9 @@ router.get("/token", async (req, res) => {
       });
     });
     if (!jwtPayload) return res.status(401).send({ ok: false, user: { restriction: "public" } });
-    const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
+    const { error, value } = Joi.object({ _id: Joi.string().required(), passwordChangedAt: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
       _id: jwtPayload._id,
-      password: jwtPayload.password,
+      passwordChangedAt: jwtPayload.passwordChangedAt,
       lastLogoutAt: jwtPayload.lastLogoutAt,
     });
     if (error) return res.status(200).send({ ok: true, user: { restriction: "public" } });

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -98,7 +98,7 @@ router.post("/signup_verify", async (req, res) => {
 
     const young = await YoungObject.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } });
     if (!young) return res.status(404).send({ ok: false, code: ERRORS.INVITATION_TOKEN_EXPIRED_OR_INVALID });
-    const token = jwt.sign({ _id: young._id }, config.secret, { expiresIn: "30d" });
+    const token = jwt.sign({ _id: young._id, passport: young.passport, lastLogoutAt: young.lastLogoutAt }, config.secret, { expiresIn: "30d" });
     return res.status(200).send({ ok: true, token, data: serializeYoung(young, young) });
   } catch (error) {
     capture(error);
@@ -135,7 +135,7 @@ router.post("/signup_invite", async (req, res) => {
     young.set({ invitationToken: "" });
     young.set({ invitationExpires: null });
 
-    const token = jwt.sign({ _id: young.id }, config.secret, { expiresIn: "30d" });
+    const token = jwt.sign({ _id: young._id, passport: young.passport, lastLogoutAt: young.lastLogoutAt }, config.secret, { expiresIn: "30d" });
     res.cookie("jwt", token, cookieOptions());
 
     await young.save({ fromUser: req.user });

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -96,9 +96,9 @@ router.post("/signup_verify", async (req, res) => {
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
 
-    const young = await YoungObject.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } });
+    const young = await YoungObject.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } }).select("password");
     if (!young) return res.status(404).send({ ok: false, code: ERRORS.INVITATION_TOKEN_EXPIRED_OR_INVALID });
-    const token = jwt.sign({ _id: young._id, passport: young.passport, lastLogoutAt: young.lastLogoutAt }, config.secret, { expiresIn: "30d" });
+    const token = jwt.sign({ _id: young._id, passport: young.passport, lastLogoutAt: null }, config.secret, { expiresIn: "30d" });
     return res.status(200).send({ ok: true, token, data: serializeYoung(young, young) });
   } catch (error) {
     capture(error);
@@ -135,7 +135,7 @@ router.post("/signup_invite", async (req, res) => {
     young.set({ invitationToken: "" });
     young.set({ invitationExpires: null });
 
-    const token = jwt.sign({ _id: young._id, passport: young.passport, lastLogoutAt: young.lastLogoutAt }, config.secret, { expiresIn: "30d" });
+    const token = jwt.sign({ _id: young._id, passport, lastLogoutAt: null }, config.secret, { expiresIn: "30d" });
     res.cookie("jwt", token, cookieOptions());
 
     await young.save({ fromUser: req.user });

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -82,7 +82,7 @@ redisClient.on("error", function (error) {
 router.post("/signup", (req, res) => YoungAuth.signUp(req, res));
 router.post("/signup2023", (req, res) => YoungAuth.signUp2023(req, res));
 router.post("/signin", (req, res) => YoungAuth.signin(req, res));
-router.post("/logout", (req, res) => YoungAuth.logout(req, res));
+router.post("/logout", passport.authenticate("young", { session: false, failWithError: true }), (req, res) => YoungAuth.logout(req, res));
 router.get("/signin_token", passport.authenticate("young", { session: false, failWithError: true }), (req, res) => YoungAuth.signinToken(req, res));
 router.post("/forgot_password", async (req, res) => YoungAuth.forgotPassword(req, res, `${config.APP_URL}/auth/reset`));
 router.post("/forgot_password_reset", async (req, res) => YoungAuth.forgotPasswordReset(req, res));

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -96,7 +96,7 @@ router.post("/signup_verify", async (req, res) => {
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
 
-    const young = await YoungObject.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } }).select("password");
+    const young = await YoungObject.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } });
     if (!young) return res.status(404).send({ ok: false, code: ERRORS.INVITATION_TOKEN_EXPIRED_OR_INVALID });
     const token = jwt.sign({ _id: young._id, passport: young.passport, lastLogoutAt: null }, config.secret, { expiresIn: "30d" });
     return res.status(200).send({ ok: true, token, data: serializeYoung(young, young) });
@@ -135,7 +135,7 @@ router.post("/signup_invite", async (req, res) => {
     young.set({ invitationToken: "" });
     young.set({ invitationExpires: null });
 
-    const token = jwt.sign({ _id: young._id, passport, lastLogoutAt: null }, config.secret, { expiresIn: "30d" });
+    const token = jwt.sign({ _id: young._id, passwordChangedAt: null, lastLogoutAt: null }, config.secret, { expiresIn: "30d" });
     res.cookie("jwt", token, cookieOptions());
 
     await young.save({ fromUser: req.user });

--- a/api/src/middlewares/optionalAuth.js
+++ b/api/src/middlewares/optionalAuth.js
@@ -18,11 +18,11 @@ const optionalAuth = async (req, _, next) => {
       if (!jwtPayload._id) {
         return;
       }
-      user = await ReferentObject.findById(jwtPayload._id);
+      user = await ReferentObject.findOne(jwtPayload);
       if (!user) {
-        user = await YoungObject.findById(jwtPayload._id);
+        user = await YoungObject.findOne(jwtPayload);
       }
-      if (user && jwtPayload.lastLogoutAt === user.lastLogoutAt && jwtPayload.password === user.password) {
+      if (user) {
         req.user = user;
       }
     }

--- a/api/src/middlewares/optionalAuth.js
+++ b/api/src/middlewares/optionalAuth.js
@@ -18,14 +18,11 @@ const optionalAuth = async (req, _, next) => {
       if (!jwtPayload._id) {
         return;
       }
-
-      // Do better checks here
-
       user = await ReferentObject.findById(jwtPayload._id);
       if (!user) {
         user = await YoungObject.findById(jwtPayload._id);
       }
-      if (user) {
+      if (user && jwtPayload.lastLogoutAt === user.lastLogoutAt && jwtPayload.password === user.password) {
         req.user = user;
       }
     }

--- a/api/src/middlewares/optionalAuth.js
+++ b/api/src/middlewares/optionalAuth.js
@@ -18,6 +18,9 @@ const optionalAuth = async (req, _, next) => {
       if (!jwtPayload._id) {
         return;
       }
+
+      // Do better checks here
+
       user = await ReferentObject.findById(jwtPayload._id);
       if (!user) {
         user = await YoungObject.findById(jwtPayload._id);

--- a/api/src/models/referent.js
+++ b/api/src/models/referent.js
@@ -65,6 +65,12 @@ const Schema = new mongoose.Schema({
       description: "Date de dernière connexion",
     },
   },
+  lastLogoutAt: {
+    type: Date,
+    documentation: {
+      description: "Date de dernière déconnexion",
+    },
+  },
   registredAt: {
     type: Date,
     documentation: {
@@ -243,6 +249,7 @@ Schema.plugin(patchHistory, {
   excludes: [
     "/password",
     "/lastLoginAt",
+    "/lastLogoutAt",
     "/nextLoginAttemptIn",
     "/forgotPasswordResetToken",
     "/forgotPasswordResetExpires",
@@ -255,7 +262,7 @@ Schema.plugin(patchHistory, {
 
 Schema.plugin(
   mongooseElastic(esClient, {
-    ignore: ["password", "nextLoginAttemptIn", "forgotPasswordResetToken", "forgotPasswordResetExpires", "invitationToken", "invitationExpires", "loginAttempts"],
+    ignore: ["password", "lastLogoutAt", "nextLoginAttemptIn", "forgotPasswordResetToken", "forgotPasswordResetExpires", "invitationToken", "invitationExpires", "loginAttempts"],
   }),
   MODELNAME,
 );

--- a/api/src/models/referent.js
+++ b/api/src/models/referent.js
@@ -67,12 +67,14 @@ const Schema = new mongoose.Schema({
   },
   lastLogoutAt: {
     type: Date,
+    select: true,
     documentation: {
       description: "Date de dernière déconnexion",
     },
   },
   passwordChangedAt: {
     type: Date,
+    select: true,
     documentation: {
       description: "Date de dernier changement de password",
     },

--- a/api/src/models/referent.js
+++ b/api/src/models/referent.js
@@ -71,6 +71,12 @@ const Schema = new mongoose.Schema({
       description: "Date de dernière déconnexion",
     },
   },
+  passwordChangedAt: {
+    type: Date,
+    documentation: {
+      description: "Date de dernier changement de password",
+    },
+  },
   registredAt: {
     type: Date,
     documentation: {
@@ -250,6 +256,7 @@ Schema.plugin(patchHistory, {
     "/password",
     "/lastLoginAt",
     "/lastLogoutAt",
+    "/passwordChangedAt",
     "/nextLoginAttemptIn",
     "/forgotPasswordResetToken",
     "/forgotPasswordResetExpires",
@@ -262,7 +269,17 @@ Schema.plugin(patchHistory, {
 
 Schema.plugin(
   mongooseElastic(esClient, {
-    ignore: ["password", "lastLogoutAt", "nextLoginAttemptIn", "forgotPasswordResetToken", "forgotPasswordResetExpires", "invitationToken", "invitationExpires", "loginAttempts"],
+    ignore: [
+      "password",
+      "lastLogoutAt",
+      "passwordChangedAt",
+      "nextLoginAttemptIn",
+      "forgotPasswordResetToken",
+      "forgotPasswordResetExpires",
+      "invitationToken",
+      "invitationExpires",
+      "loginAttempts",
+    ],
   }),
   MODELNAME,
 );

--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -476,12 +476,14 @@ const Schema = new mongoose.Schema({
   },
   lastLogoutAt: {
     type: Date,
+    select: true,
     documentation: {
       description: "Date de dernière déconnexion",
     },
   },
   passwordChangedAt: {
     type: Date,
+    select: true,
     documentation: {
       description: "Date de dernier changement de password",
     },

--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -480,6 +480,12 @@ const Schema = new mongoose.Schema({
       description: "Date de dernière déconnexion",
     },
   },
+  passwordChangedAt: {
+    type: Date,
+    documentation: {
+      description: "Date de dernier changement de password",
+    },
+  },
   nextLoginAttemptIn: {
     type: Date,
     documentation: {
@@ -1955,6 +1961,7 @@ Schema.plugin(patchHistory, {
     "/password",
     "/lastLoginAt",
     "/lastLogoutAt",
+    "/passwordChangedAt",
     "/nextLoginAttemptIn",
     "/forgotPasswordResetToken",
     "/forgotPasswordResetExpires",
@@ -1977,6 +1984,7 @@ Schema.plugin(
       "missionsInMail",
       "password",
       "lastLogoutAt",
+      "passwordChangedAt",
       "nextLoginAttemptIn",
       "forgotPasswordResetToken",
       "forgotPasswordResetExpires",

--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -474,6 +474,12 @@ const Schema = new mongoose.Schema({
       description: "Date de dernière connexion",
     },
   },
+  lastLogoutAt: {
+    type: Date,
+    documentation: {
+      description: "Date de dernière déconnexion",
+    },
+  },
   nextLoginAttemptIn: {
     type: Date,
     documentation: {
@@ -1948,6 +1954,7 @@ Schema.plugin(patchHistory, {
   excludes: [
     "/password",
     "/lastLoginAt",
+    "/lastLogoutAt",
     "/nextLoginAttemptIn",
     "/forgotPasswordResetToken",
     "/forgotPasswordResetExpires",
@@ -1969,6 +1976,7 @@ Schema.plugin(
       "historic",
       "missionsInMail",
       "password",
+      "lastLogoutAt",
       "nextLoginAttemptIn",
       "forgotPasswordResetToken",
       "forgotPasswordResetExpires",

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -43,7 +43,6 @@ module.exports = function () {
   passport.use(
     "referent",
     new JwtStrategy(opts, async function (jwtPayload, done) {
-      console.log("🚀 ~ file: passport.js:46 ~ jwtPayload:", jwtPayload);
       try {
         const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().allow(null) }).validate({
           _id: jwtPayload._id,
@@ -52,9 +51,7 @@ module.exports = function () {
         });
         if (error) return done(null, false);
 
-        console.log("🚀 ~ file: passport.js:55 ~ value:", value);
         const referent = await Referent.findOne(value);
-        console.log("🚀 ~ file: passport.js:56 ~ referent:", referent);
         if (referent) return done(null, referent);
       } catch (error) {
         capture(error);

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -27,8 +27,8 @@ module.exports = function () {
         const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
         if (error) return done(null, false);
 
-        const young = await Young.findById(value._id);
-        if (young) return done(null, young);
+        const young = await Young.findById(value._id).select("password");
+        if (young && jwtPayload.lastLogoutAt === young.lastLogoutAt && jwtPayload.password === young.password) return done(null, young);
       } catch (error) {
         capture(error);
       }
@@ -43,8 +43,9 @@ module.exports = function () {
         const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
         if (error) return done(null, false);
 
-        const referent = await Referent.findById(value._id);
-        if (referent) return done(null, referent);
+        const referent = await Referent.findById(value._id).select("password");
+        console.log("🚀 ~ file: passport.js:47 ~ referent:", referent.password);
+        if (referent && jwtPayload.lastLogoutAt === referent.lastLogoutAt && jwtPayload.password === referent.password) return done(null, referent);
       } catch (error) {
         capture(error);
       }
@@ -59,8 +60,9 @@ module.exports = function () {
         const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
         if (error) return done(null, false);
 
-        const referent = await Referent.findById(value._id);
-        if (referent && referent.role === ROLES.ADMIN) return done(null, referent);
+        const referent = await Referent.findById(value._id).select("password");
+        if (referent && referent.role === ROLES.ADMIN && jwtPayload.lastLogoutAt === referent.lastLogoutAt && jwtPayload.password === referent.password)
+          return done(null, referent);
       } catch (error) {
         capture(error);
       }
@@ -75,8 +77,8 @@ module.exports = function () {
         const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
         if (error) return done(null, false);
 
-        const referent = await Referent.findById(value._id);
-        if (referent && referent.role === ROLES.DSNJ) return done(null, referent);
+        const referent = await Referent.findById(value._id).select("password");
+        if (referent && referent.role === ROLES.DSNJ && jwtPayload.lastLogoutAt === referent.lastLogoutAt && jwtPayload.password === referent.password) return done(null, referent);
       } catch (error) {
         capture(error);
       }

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -24,7 +24,7 @@ module.exports = function () {
     "young",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
           _id: jwtPayload._id,
           password: jwtPayload.password,
           lastLogoutAt: jwtPayload.lastLogoutAt,
@@ -44,19 +44,21 @@ module.exports = function () {
     "referent",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().allow(null) }).validate({
           _id: jwtPayload._id,
           password: jwtPayload.password,
           lastLogoutAt: jwtPayload.lastLogoutAt,
         });
+        console.log("🚀 ~ file: passport.js:52 ~ const{error,value}=Joi.object ~ error:", error);
         if (error) return done(null, false);
 
-        const referent = await Referent.findById(value._id).select("password");
-        console.log("🚀 ~ file: passport.js:47 ~ referent:", jwtPayload.lastLogoutAt);
+        console.log("🚀 ~ file: passport.js:56 ~ value:", value);
+        const referent = await Referent.findOne(value);
+        console.log("🚀 ~ file: passport.js:47 ~ referent:", value.lastLogoutAt);
         console.log("🚀 ~ file: passport.js:48 ~ referent.lastLogoutAt:", referent.lastLogoutAt);
-        console.log("🚀 ~ file: passport.js:47 ~ referent:", jwtPayload.password);
+        console.log("🚀 ~ file: passport.js:47 ~ referent:", value.password);
         console.log("🚀 ~ file: passport.js:50 ~ referent.password:", referent.password);
-        if (referent && value.lastLogoutAt === referent.lastLogoutAt && value.password === referent.password) return done(null, referent);
+        if (referent) return done(null, referent);
       } catch (error) {
         capture(error);
       }
@@ -68,7 +70,7 @@ module.exports = function () {
     "admin",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
           _id: jwtPayload._id,
           password: jwtPayload.password,
           lastLogoutAt: jwtPayload.lastLogoutAt,
@@ -88,7 +90,7 @@ module.exports = function () {
     "dsnj",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
           _id: jwtPayload._id,
           password: jwtPayload.password,
           lastLogoutAt: jwtPayload.lastLogoutAt,

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -24,11 +24,15 @@ module.exports = function () {
     "young",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
+        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+          _id: jwtPayload._id,
+          password: jwtPayload.password,
+          lastLogoutAt: jwtPayload.lastLogoutAt,
+        });
         if (error) return done(null, false);
 
         const young = await Young.findById(value._id).select("password");
-        if (young && jwtPayload.lastLogoutAt === young.lastLogoutAt && jwtPayload.password === young.password) return done(null, young);
+        if (young && value.lastLogoutAt === young.lastLogoutAt && value.password === young.password) return done(null, young);
       } catch (error) {
         capture(error);
       }
@@ -40,12 +44,19 @@ module.exports = function () {
     "referent",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
+        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+          _id: jwtPayload._id,
+          password: jwtPayload.password,
+          lastLogoutAt: jwtPayload.lastLogoutAt,
+        });
         if (error) return done(null, false);
 
         const referent = await Referent.findById(value._id).select("password");
-        console.log("🚀 ~ file: passport.js:47 ~ referent:", referent.password);
-        if (referent && jwtPayload.lastLogoutAt === referent.lastLogoutAt && jwtPayload.password === referent.password) return done(null, referent);
+        console.log("🚀 ~ file: passport.js:47 ~ referent:", jwtPayload.lastLogoutAt);
+        console.log("🚀 ~ file: passport.js:48 ~ referent.lastLogoutAt:", referent.lastLogoutAt);
+        console.log("🚀 ~ file: passport.js:47 ~ referent:", jwtPayload.password);
+        console.log("🚀 ~ file: passport.js:50 ~ referent.password:", referent.password);
+        if (referent && value.lastLogoutAt === referent.lastLogoutAt && value.password === referent.password) return done(null, referent);
       } catch (error) {
         capture(error);
       }
@@ -57,12 +68,15 @@ module.exports = function () {
     "admin",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
+        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+          _id: jwtPayload._id,
+          password: jwtPayload.password,
+          lastLogoutAt: jwtPayload.lastLogoutAt,
+        });
         if (error) return done(null, false);
 
         const referent = await Referent.findById(value._id).select("password");
-        if (referent && referent.role === ROLES.ADMIN && jwtPayload.lastLogoutAt === referent.lastLogoutAt && jwtPayload.password === referent.password)
-          return done(null, referent);
+        if (referent && referent.role === ROLES.ADMIN && value.lastLogoutAt === referent.lastLogoutAt && value.password === referent.password) return done(null, referent);
       } catch (error) {
         capture(error);
       }
@@ -74,11 +88,15 @@ module.exports = function () {
     "dsnj",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({ _id: jwtPayload._id });
+        const { error, value } = Joi.object({ _id: Joi.string().required() }).validate({
+          _id: jwtPayload._id,
+          password: jwtPayload.password,
+          lastLogoutAt: jwtPayload.lastLogoutAt,
+        });
         if (error) return done(null, false);
 
         const referent = await Referent.findById(value._id).select("password");
-        if (referent && referent.role === ROLES.DSNJ && jwtPayload.lastLogoutAt === referent.lastLogoutAt && jwtPayload.password === referent.password) return done(null, referent);
+        if (referent && referent.role === ROLES.DSNJ && value.lastLogoutAt === referent.lastLogoutAt && value.password === referent.password) return done(null, referent);
       } catch (error) {
         capture(error);
       }

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -24,9 +24,9 @@ module.exports = function () {
     "young",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), passwordChangedAt: Joi.date().allow(null), lastLogoutAt: Joi.date().allow(null) }).validate({
           _id: jwtPayload._id,
-          password: jwtPayload.password,
+          passwordChangedAt: jwtPayload.passwordChangedAt,
           lastLogoutAt: jwtPayload.lastLogoutAt,
         });
         if (error) return done(null, false);
@@ -44,9 +44,9 @@ module.exports = function () {
     "referent",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().allow(null) }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), passwordChangedAt: Joi.date().allow(null), lastLogoutAt: Joi.date().allow(null) }).validate({
           _id: jwtPayload._id,
-          password: jwtPayload.password,
+          passwordChangedAt: jwtPayload.passwordChangedAt,
           lastLogoutAt: jwtPayload.lastLogoutAt,
         });
         if (error) return done(null, false);
@@ -64,9 +64,9 @@ module.exports = function () {
     "admin",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), passwordChangedAt: Joi.date().allow(null), lastLogoutAt: Joi.date().allow(null) }).validate({
           _id: jwtPayload._id,
-          password: jwtPayload.password,
+          passwordChangedAt: jwtPayload.passwordChangedAt,
           lastLogoutAt: jwtPayload.lastLogoutAt,
         });
         if (error) return done(null, false);
@@ -84,9 +84,9 @@ module.exports = function () {
     "dsnj",
     new JwtStrategy(opts, async function (jwtPayload, done) {
       try {
-        const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().required() }).validate({
+        const { error, value } = Joi.object({ _id: Joi.string().required(), passwordChangedAt: Joi.date().allow(null), lastLogoutAt: Joi.date().allow(null) }).validate({
           _id: jwtPayload._id,
-          password: jwtPayload.password,
+          passwordChangedAt: jwtPayload.passwordChangedAt,
           lastLogoutAt: jwtPayload.lastLogoutAt,
         });
         if (error) return done(null, false);

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -31,8 +31,8 @@ module.exports = function () {
         });
         if (error) return done(null, false);
 
-        const young = await Young.findById(value._id).select("password");
-        if (young && value.lastLogoutAt === young.lastLogoutAt && value.password === young.password) return done(null, young);
+        const young = await Young.findOne(value);
+        if (young) return done(null, young);
       } catch (error) {
         capture(error);
       }
@@ -43,21 +43,18 @@ module.exports = function () {
   passport.use(
     "referent",
     new JwtStrategy(opts, async function (jwtPayload, done) {
+      console.log("🚀 ~ file: passport.js:46 ~ jwtPayload:", jwtPayload);
       try {
         const { error, value } = Joi.object({ _id: Joi.string().required(), password: Joi.string().required(), lastLogoutAt: Joi.date().allow(null) }).validate({
           _id: jwtPayload._id,
           password: jwtPayload.password,
           lastLogoutAt: jwtPayload.lastLogoutAt,
         });
-        console.log("🚀 ~ file: passport.js:52 ~ const{error,value}=Joi.object ~ error:", error);
         if (error) return done(null, false);
 
-        console.log("🚀 ~ file: passport.js:56 ~ value:", value);
+        console.log("🚀 ~ file: passport.js:55 ~ value:", value);
         const referent = await Referent.findOne(value);
-        console.log("🚀 ~ file: passport.js:47 ~ referent:", value.lastLogoutAt);
-        console.log("🚀 ~ file: passport.js:48 ~ referent.lastLogoutAt:", referent.lastLogoutAt);
-        console.log("🚀 ~ file: passport.js:47 ~ referent:", value.password);
-        console.log("🚀 ~ file: passport.js:50 ~ referent.password:", referent.password);
+        console.log("🚀 ~ file: passport.js:56 ~ referent:", referent);
         if (referent) return done(null, referent);
       } catch (error) {
         capture(error);
@@ -77,8 +74,8 @@ module.exports = function () {
         });
         if (error) return done(null, false);
 
-        const referent = await Referent.findById(value._id).select("password");
-        if (referent && referent.role === ROLES.ADMIN && value.lastLogoutAt === referent.lastLogoutAt && value.password === referent.password) return done(null, referent);
+        const referent = await Referent.findOne(value);
+        if (referent && referent.role === ROLES.ADMIN) return done(null, referent);
       } catch (error) {
         capture(error);
       }
@@ -97,8 +94,8 @@ module.exports = function () {
         });
         if (error) return done(null, false);
 
-        const referent = await Referent.findById(value._id).select("password");
-        if (referent && referent.role === ROLES.DSNJ && value.lastLogoutAt === referent.lastLogoutAt && value.password === referent.password) return done(null, referent);
+        const referent = await Referent.findOne(value);
+        if (referent && referent.role === ROLES.DSNJ) return done(null, referent);
       } catch (error) {
         capture(error);
       }

--- a/api/src/services/jeveuxaider.js
+++ b/api/src/services/jeveuxaider.js
@@ -28,7 +28,7 @@ router.get("/signin", async (req, res) => {
     const { _id, lastLogoutAt, passwordChangedAt } = jwt.verify(token_jva, config.secret);
     if (!_id) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
 
-    const user = await ReferentModel.find({ _id, lastLogoutAt, passwordChangedAt }).select("+passwordChangedAt +lastLogoutAt");
+    const user = await ReferentModel.find({ _id, lastLogoutAt, passwordChangedAt });
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_TOKEN_INVALID });
@@ -70,7 +70,7 @@ router.get("/getToken", async (req, res) => {
       return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });
     }
 
-    const user = await ReferentModel.findOne({ email, role: { $in: [ROLES.RESPONSIBLE, ROLES.SUPERVISOR] } }).select("+passwordChangedAt +lastLogoutAt");
+    const user = await ReferentModel.findOne({ email, role: { $in: [ROLES.RESPONSIBLE, ROLES.SUPERVISOR] } });
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });

--- a/api/src/services/jeveuxaider.js
+++ b/api/src/services/jeveuxaider.js
@@ -28,7 +28,7 @@ router.get("/signin", async (req, res) => {
     const { _id, lastLogoutAt, password } = jwt.verify(token_jva, config.secret);
     if (!_id) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
 
-    const user = await ReferentModel.findById(_id);
+    const user = await ReferentModel.find({ _id, lastLogoutAt, password }).select("+password +lastLogoutAt");
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_TOKEN_INVALID });
@@ -70,7 +70,7 @@ router.get("/getToken", async (req, res) => {
       return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });
     }
 
-    const user = await ReferentModel.findOne({ email, role: { $in: [ROLES.RESPONSIBLE, ROLES.SUPERVISOR] } });
+    const user = await ReferentModel.findOne({ email, role: { $in: [ROLES.RESPONSIBLE, ROLES.SUPERVISOR] } }).select("+password +lastLogoutAt");
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });

--- a/api/src/services/jeveuxaider.js
+++ b/api/src/services/jeveuxaider.js
@@ -32,9 +32,7 @@ router.get("/signin", async (req, res) => {
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_TOKEN_INVALID });
-    // Check if lastLogoutAt is equal to user lastLogoutAt
     if (lastLogoutAt && lastLogoutAt !== user.lastLogoutAt) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
-    // Check if password is equal to user password
     if (password && password !== user.password) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
 
     const structure = await StructureModel.findById(user.structureId);

--- a/api/src/services/jeveuxaider.js
+++ b/api/src/services/jeveuxaider.js
@@ -25,13 +25,17 @@ router.get("/signin", async (req, res) => {
 
     const { token_jva } = value;
 
-    const { _id } = jwt.verify(token_jva, config.secret);
+    const { _id, lastLogoutAt, password } = jwt.verify(token_jva, config.secret);
     if (!_id) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
 
     const user = await ReferentModel.findById(_id);
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_TOKEN_INVALID });
+    // Check if lastLogoutAt is equal to user lastLogoutAt
+    if (lastLogoutAt && lastLogoutAt !== user.lastLogoutAt) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
+    // Check if password is equal to user password
+    if (password && password !== user.password) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
 
     const structure = await StructureModel.findById(user.structureId);
 
@@ -43,7 +47,7 @@ router.get("/signin", async (req, res) => {
       user.set({ lastLoginAt: Date.now() });
       await user.save();
 
-      const token = jwt.sign({ _id: user.id }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       return res.redirect(config.ADMIN_URL);
@@ -73,7 +77,7 @@ router.get("/getToken", async (req, res) => {
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });
 
-    const token_jva = jwt.sign({ _id: user._id }, config.secret, { expiresIn: JWT_MAX_AGE });
+    const token_jva = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
 
     return res.status(200).send({ ok: true, data: { token_jva } });
   } catch (error) {

--- a/api/src/services/jeveuxaider.js
+++ b/api/src/services/jeveuxaider.js
@@ -25,15 +25,15 @@ router.get("/signin", async (req, res) => {
 
     const { token_jva } = value;
 
-    const { _id, lastLogoutAt, password } = jwt.verify(token_jva, config.secret);
+    const { _id, lastLogoutAt, passwordChangedAt } = jwt.verify(token_jva, config.secret);
     if (!_id) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
 
-    const user = await ReferentModel.find({ _id, lastLogoutAt, password }).select("+password +lastLogoutAt");
+    const user = await ReferentModel.find({ _id, lastLogoutAt, passwordChangedAt }).select("+passwordChangedAt +lastLogoutAt");
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_TOKEN_INVALID });
-    if (lastLogoutAt && lastLogoutAt !== user.lastLogoutAt) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
-    if (password && password !== user.password) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
+    if (lastLogoutAt !== user.lastLogoutAt) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
+    if (passwordChangedAt !== user.passwordChangedAt) return res.status(401).send({ ok: false, code: ERRORS.TOKEN_INVALID });
 
     const structure = await StructureModel.findById(user.structureId);
 
@@ -45,7 +45,7 @@ router.get("/signin", async (req, res) => {
       user.set({ lastLoginAt: Date.now() });
       await user.save();
 
-      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
+      const token = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, { expiresIn: JWT_MAX_AGE });
       res.cookie("jwt", token, cookieOptions());
 
       return res.redirect(config.ADMIN_URL);
@@ -70,12 +70,12 @@ router.get("/getToken", async (req, res) => {
       return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });
     }
 
-    const user = await ReferentModel.findOne({ email, role: { $in: [ROLES.RESPONSIBLE, ROLES.SUPERVISOR] } }).select("+password +lastLogoutAt");
+    const user = await ReferentModel.findOne({ email, role: { $in: [ROLES.RESPONSIBLE, ROLES.SUPERVISOR] } }).select("+passwordChangedAt +lastLogoutAt");
 
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });
 
-    const token_jva = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, password: user.password }, config.secret, { expiresIn: JWT_MAX_AGE });
+    const token_jva = jwt.sign({ _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, { expiresIn: JWT_MAX_AGE });
 
     return res.status(200).send({ ok: true, data: { token_jva } });
   } catch (error) {

--- a/api/src/utils/serializer.js
+++ b/api/src/utils/serializer.js
@@ -52,6 +52,8 @@ function serializeYoung(young, user) {
     transform: (_doc, ret) => {
       delete ret.sqlId;
       delete ret.password;
+      delete ret.passwordChangedAt;
+      delete ret.lastLogoutAt;
       delete ret.nextLoginAttemptIn;
       delete ret.forgotPasswordResetToken;
       delete ret.forgotPasswordResetExpires;
@@ -73,6 +75,8 @@ function serializeReferent(referent) {
     transform: (_doc, ret) => {
       delete ret.sqlId;
       delete ret.password;
+      delete ret.passwordChangedAt;
+      delete ret.lastLogoutAt;
       delete ret.nextLoginAttemptIn;
       delete ret.forgotPasswordResetToken;
       delete ret.forgotPasswordResetExpires;

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -202,6 +202,7 @@ function canViewReferent(actor, target) {
 }
 
 function canUpdateReferent({ actor, originalTarget, modifiedTarget = null, structure }) {
+  console.log("🚀 ~ file: roles.js:205 ~ canUpdateReferent ~ actor:", actor);
   const isMe = actor.id === originalTarget.id;
   const isAdmin = actor.role === ROLES.ADMIN;
   const withoutChangingRole = modifiedTarget === null || !("role" in modifiedTarget) || modifiedTarget.role === originalTarget.role;

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -202,7 +202,6 @@ function canViewReferent(actor, target) {
 }
 
 function canUpdateReferent({ actor, originalTarget, modifiedTarget = null, structure }) {
-  console.log("🚀 ~ file: roles.js:205 ~ canUpdateReferent ~ actor:", actor);
   const isMe = actor.id === originalTarget.id;
   const isAdmin = actor.role === ROLES.ADMIN;
   const withoutChangingRole = modifiedTarget === null || !("role" in modifiedTarget) || modifiedTarget.role === originalTarget.role;


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Invalider-c-t-serveur-le-cookie-de-session-lors-de-la-d-connexion-c9ffc45996d444d29c6d057e98aa0ab1?pvs=4

Nous stockons une date de logout chez nos users afin de permettent d'invalider tous les tokens en cas de logout.
La meme chose est faite en cas de changement de password.

La PR actuelle corrige l'invalidation des JWT en cas de déconnexion et de changement de mot de passe.

Une manière alternative aurait été de stocker dans un redis tous les JWT (un peu gourmant) ou les JWT blacklistés seulement dans un REDIS et de verifier que les token ne sont pas dans la blacklist avant de valider le token