### PR TITLE
fix: update node to 18

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -97,8 +97,8 @@
         "webpack-dev-server": "3.11.3"
       },
       "engines": {
-        "node": "^16.10",
-        "npm": "^8.0",
+        "node": "^18.16.0",
+        "npm": "^9.5.1",
         "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
       }
     },

--- a/admin/package.json
+++ b/admin/package.json
@@ -100,8 +100,8 @@
     "xlsx": "0.17.4"
   },
   "engines": {
-    "node": "^16.10",
-    "npm": "^8.0",
+    "node": "^18.16.0",
+    "npm": "^9.5.1",
     "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
   }
 }

--- a/analytics/package-lock.json
+++ b/analytics/package-lock.json
@@ -22,6 +22,11 @@
         "nodemon": "^2.0.15",
         "pg": "^8.7.3",
         "sequelize": "^6.29.0"
+      },
+      "engines": {
+        "node": "^18.16.0",
+        "npm": "^9.5.1",
+        "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
       }
     },
     "node_modules/@hapi/hoek": {

--- a/analytics/package.json
+++ b/analytics/package.json
@@ -7,6 +7,11 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js"
   },
+  "engines": {
+    "node": "^18.16.0",
+    "npm": "^9.5.1",
+    "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
+  },
   "prettier": {
     "printWidth": 2200
   },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -77,8 +77,8 @@
         "xlsx": "^0.18.5"
       },
       "engines": {
-        "node": "^16.10",
-        "npm": "^8.0",
+        "node": "^18.16.0",
+        "npm": "^9.5.1",
         "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
       }
     },

--- a/api/package.json
+++ b/api/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "^16.10",
-    "npm": "^8.0",
+    "node": "^18.16.0",
+    "npm": "^9.5.1",
     "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
   },
   "scripts": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -99,8 +99,8 @@
         "webpack-dev-server": "3.11.3"
       },
       "engines": {
-        "node": "^16.10",
-        "npm": "^8.0",
+        "node": "^18.16.0",
+        "npm": "^9.5.1",
         "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -101,8 +101,8 @@
     "validator": "13.7.0"
   },
   "engines": {
-    "node": "^16.10",
-    "npm": "^8.0",
+    "node": "^18.16.0",
+    "npm": "^9.5.1",
     "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
   }
 }

--- a/knowledge-base-public/package-lock.json
+++ b/knowledge-base-public/package-lock.json
@@ -11,7 +11,7 @@
         "is-email": "1.0.2",
         "is-hotkey": "0.2.0",
         "is-url": "1.2.4",
-        "next": "*",
+        "next": "latest",
         "next-plausible": "^3.6.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -44,8 +44,8 @@
         "tailwindcss": "3.2.2"
       },
       "engines": {
-        "node": "^16.10",
-        "npm": "^8.0",
+        "node": "^18.16.0",
+        "npm": "^9.5.1",
         "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
       }
     },

--- a/knowledge-base-public/package.json
+++ b/knowledge-base-public/package.json
@@ -50,8 +50,8 @@
     "tailwindcss": "3.2.2"
   },
   "engines": {
-    "node": "^16.10",
-    "npm": "^8.0",
+    "node": "^18.16.0",
+    "npm": "^9.5.1",
     "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
   }
 }

--- a/pdf/package-lock.json
+++ b/pdf/package-lock.json
@@ -17,6 +17,11 @@
         "express": "^4.18.2",
         "nodemon": "^2.0.20",
         "puppeteer": "^19.2.2"
+      },
+      "engines": {
+        "node": "^18.16.0",
+        "npm": "^9.5.1",
+        "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/pdf/package.json
+++ b/pdf/package.json
@@ -19,5 +19,10 @@
     "@sentry/integrations": "^7.17.4",
     "@sentry/node": "^7.17.4",
     "@sentry/tracing": "^7.17.4"
+  },
+  "engines": {
+    "node": "^18.16.0",
+    "npm": "^9.5.1",
+    "yarn": "🍎 This project uses NPM, please do not use YARN. 🍎"
   }
 }


### PR DESCRIPTION
J'ai essayé de tout passer à Node 18 (app, api, admin, pdf, knowledge, analytics).

Pour tester il faut passer à node 18:

```bash
nvm use 18 
# chez moi ça marche...
```

Ce sera automatique côté clevercloud. Il faut tester en local que ça marche.

Pourquoi ? https://endoflife.date/nodejs (et aussi pour pouvoir utiliser le merveilleux `structuredClone`)