### PR TITLE
fix: young build context

### DIFF
--- a/api/src/controllers/elasticsearch/young.js
+++ b/api/src/controllers/elasticsearch/young.js
@@ -2,6 +2,7 @@ const passport = require("passport");
 const express = require("express");
 const router = express.Router();
 const { ROLES } = require("snu-lib/roles");
+const datesub = require("date-fns/sub");
 const { capture } = require("../../sentry");
 const esClient = require("../../es");
 const { ERRORS } = require("../../utils");
@@ -12,6 +13,7 @@ const { serializeYoungs } = require("../../utils/es-serializer");
 const StructureObject = require("../../models/structure");
 const ApplicationObject = require("../../models/application");
 const SessionPhase1Object = require("../../models/sessionPhase1");
+const { getCohortNamesEndAfter } = require("../../utils/cohort");
 
 async function buildYoungContext(user, showAffectedToRegionOrDep = false) {
   const contextFilters = [];
@@ -27,7 +29,7 @@ async function buildYoungContext(user, showAffectedToRegionOrDep = false) {
   // A head center can only see youngs of their session.
   if (user.role === ROLES.HEAD_CENTER) {
     const sessionPhase1 = await SessionPhase1Object.find({ headCenterId: user._id });
-    if (!sessionPhase1.length) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+    if (!sessionPhase1.length) return { youngContextError: { status: 404, body: { ok: false, code: ERRORS.NOT_FOUND } } };
     contextFilters.push(
       { terms: { "status.keyword": ["VALIDATED", "WITHDRAWN"] } },
       { terms: { "sessionPhase1Id.keyword": sessionPhase1.map((sessionPhase1) => sessionPhase1._id.toString()) } },
@@ -37,19 +39,19 @@ async function buildYoungContext(user, showAffectedToRegionOrDep = false) {
       contextFilters.push({ terms: { "cohort.keyword": visibleCohorts } });
     } else {
       // Tried that to specify when there's just no data or when the head center has no longer access
-      return res.status(404).send({ ok: true, data: "no cohort available" });
+      return { youngContextError: { status: 404, body: { ok: true, code: "no cohort available" } } };
     }
   }
   // A responsible can only see youngs in application of their structure.
   if (user.role === ROLES.RESPONSIBLE) {
-    if (!user.structureId) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+    if (!user.structureId) return { youngContextError: { status: 404, body: { ok: false, code: ERRORS.NOT_FOUND } } };
     const applications = await ApplicationObject.find({ structureId: user.structureId });
     contextFilters.push({ terms: { _id: applications.map((e) => e.youngId) } });
   }
 
   // A supervisor can only see youngs in application of their structures.
   if (user.role === ROLES.SUPERVISOR) {
-    if (!user.structureId) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+    if (!user.structureId) return { youngContextError: { status: 404, body: { ok: false, code: ERRORS.NOT_FOUND } } };
     const structures = await StructureObject.find({ $or: [{ networkId: String(user.structureId) }, { _id: String(user.structureId) }] });
     const applications = await ApplicationObject.find({ structureId: { $in: structures.map((e) => e._id.toString()) } });
     contextFilters.push({ terms: { _id: applications.map((e) => e.youngId) } });
@@ -91,12 +93,11 @@ async function buildYoungContext(user, showAffectedToRegionOrDep = false) {
     }
   }
 
-  // Visitors can only get aggregations and is limited to its region.
+  // Visitors are limited to their region.
   if (user.role === ROLES.VISITOR) {
     contextFilters.push({ term: { "region.keyword": user.region } });
-    body.size = 0;
   }
-  return contextFilters;
+  return { youngContextFilters: contextFilters };
 }
 
 router.post("/in-bus/:ligneId/:action(search|export)", passport.authenticate(["referent"], { session: false, failWithError: true }), async (req, res) => {
@@ -106,9 +107,14 @@ router.post("/in-bus/:ligneId/:action(search|export)", passport.authenticate(["r
     const filterFields = ["meetingPointId.keyword", "meetingPointName.keyword", "meetingPointCity.keyword", "region.keyword", "department.keyword"];
     const sortFields = [];
 
+    const { youngContextFilters, youngContextError } = await buildYoungContext(req.user, true);
+    if (youngContextError) {
+      return res.status(youngContextError.status).send(youngContextError.body);
+    }
+
     // Context filters
     const contextFilters = [
-      ...(await buildYoungContext(req.user, true)),
+      ...youngContextFilters,
       { terms: { "ligneId.keyword": [String(req.params.ligneId)] } },
       { terms: { "status.keyword": ["VALIDATED"] } },
       { bool: { must_not: [{ term: { "cohesionStayPresence.keyword": "false" } }, { term: { "departInform.keyword": "true" } }] } },


### PR DESCRIPTION
Alors, il y a des règles qui ont été désactivées dans ESLint qui empêchent de voir certaines erreurs, du coup j'en ai repéré dans mon fichier elasticsearch.
j'ai une limite à mon build context, c'est que je ne peux plus limiter pour les visiteurs, mais en même temps ça se limitera par les routes directement maintenant donc c'est bon