### PR TITLE
fix(app): Préférences: Amélioration de l'affichage des erreurs dans le formulaire

### DIFF
--- a/app/src/scenes/preferences/View.jsx
+++ b/app/src/scenes/preferences/View.jsx
@@ -26,6 +26,7 @@ export default function View({ young, onSave, saving, onToggleDomain, hasDomainS
             Enregistrer
           </PlainButton>
         </div>
+        {Object.values(errors).length ? <div className="text-center mt-6 text-sm text-[#F71701]">Il y a des erreurs ou des données manquantes dans le formulaire.</div> : null}
         <Section>
           <Title noBorder>Sélectionnez les 3 thématiques qui vous intéressent le plus</Title>
           <div className="grid grid-cols-4 gap-2 md:mx-8 md:grid-cols-2 md:gap-4">

--- a/app/src/scenes/preferences/View.jsx
+++ b/app/src/scenes/preferences/View.jsx
@@ -139,6 +139,7 @@ export default function View({ young, onSave, saving, onToggleDomain, hasDomainS
           <div className="md:mx-8">
             <div className="md:rounded-0 mb-8 rounded-lg border-[1px] border-gray-200 py-6 px-3 md:mb-0 md:border-none md:p-0">
               <MiniTitle>Format préféré</MiniTitle>
+              {errors.missionFormat && <div className="m-2 text-center text-sm text-[#F71701]">{errors.missionFormat}</div>}
               <ToggleGroup
                 className="md:mb-8 md:text-center"
                 value={young.missionFormat}
@@ -149,6 +150,7 @@ export default function View({ young, onSave, saving, onToggleDomain, hasDomainS
             </div>
             <div className="md:rounded-0 mb-8 rounded-lg border-[1px] border-gray-200 py-6 px-3 md:mb-0 md:border-none md:p-0">
               <MiniTitle>Période de réalisation de la mission</MiniTitle>
+              {errors.period && <div className="m-2 text-center text-sm text-[#F71701]">{errors.period}</div>}
               <ToggleGroup
                 className="md:mb-8 md:text-center"
                 value={young.period}
@@ -253,7 +255,8 @@ export default function View({ young, onSave, saving, onToggleDomain, hasDomainS
             </div>
           </div>
         </Section>
-        <div className="mt-10 flex justify-center md:justify-end">
+        {Object.values(errors).length ? <div className="text-center mt-6 text-sm text-[#F71701]">Il y a des erreurs ou des données manquantes dans le formulaire.</div> : null}
+        <div className="mt-6 flex justify-center md:justify-end">
           <PlainButton onClick={onSave} spinner={saving}>
             Enregistrer
           </PlainButton>

--- a/app/src/scenes/preferences/index.jsx
+++ b/app/src/scenes/preferences/index.jsx
@@ -151,7 +151,6 @@ export default function Index() {
       }
     }
 
-    console.log("Errors : ", errors);
     setErrors(errors);
     return validated;
   }


### PR DESCRIPTION
Pour certains champs, il n'y a avait pas d'affichage des erreurs à la validation, donc impossible de savoir pourquoi le formulaire ne s'envoyait pas.
=> ajout d'un message pour les champs qui n'en ont pas
=> ajout d'un message général près des boutons de validation.
https://www.notion.so/jeveuxaider/Impossible-d-enregistrer-les-pr-f-rences-MIG-401861a457e248fdb0b222a171b06ed4?pvs=4