### PR TITLE
feat(app): Mon Compte/Phase 1 - Statut "Affecté" : Affichage dynamique des dates de séjour

### DIFF
--- a/app/src/scenes/phase1/scenes/affected/components/TravelInfo.jsx
+++ b/app/src/scenes/phase1/scenes/affected/components/TravelInfo.jsx
@@ -3,14 +3,12 @@ import dayjs from "dayjs";
 import LongArrow from "../../../../../assets/icons/LongArrow";
 import { ALONE_ARRIVAL_HOUR, ALONE_DEPARTURE_HOUR } from "../utils/steps.utils.js";
 
-export default function TravelInfo({ location, cohortDetails }) {
-  if (!location || !cohortDetails) {
+export default function TravelInfo({ location, goDate, returnDate }) {
+  if (!location) {
     return <></>;
   }
 
-  const goDate = location?.bus?.departuredDate || cohortDetails.dateStart;
   const goHour = location?.ligneToPoint?.meetingHour || ALONE_ARRIVAL_HOUR;
-  const returnDate = location?.bus?.returnDate || cohortDetails.dateEnd;
   const returnHour = location?.ligneToPoint?.returnHour || ALONE_DEPARTURE_HOUR;
 
   return (

--- a/app/src/scenes/phase1/scenes/affected/components/TravelInfo.jsx
+++ b/app/src/scenes/phase1/scenes/affected/components/TravelInfo.jsx
@@ -3,12 +3,14 @@ import dayjs from "dayjs";
 import LongArrow from "../../../../../assets/icons/LongArrow";
 import { ALONE_ARRIVAL_HOUR, ALONE_DEPARTURE_HOUR } from "../utils/steps.utils.js";
 
-export default function TravelInfo({ location, goDate, returnDate }) {
+export default function TravelInfo({ location, cohortDetails }) {
   if (!location) {
     return <></>;
   }
 
+  const goDate = location?.bus?.departuredDate || cohortDetails.dateStart;
   const goHour = location?.ligneToPoint?.meetingHour || ALONE_ARRIVAL_HOUR;
+  const returnDate = location?.bus?.returnDate || cohortDetails.dateEnd;
   const returnHour = location?.ligneToPoint?.returnHour || ALONE_DEPARTURE_HOUR;
 
   return (

--- a/app/src/scenes/phase1/scenes/affected/components/TravelInfo.jsx
+++ b/app/src/scenes/phase1/scenes/affected/components/TravelInfo.jsx
@@ -4,7 +4,7 @@ import LongArrow from "../../../../../assets/icons/LongArrow";
 import { ALONE_ARRIVAL_HOUR, ALONE_DEPARTURE_HOUR } from "../utils/steps.utils.js";
 
 export default function TravelInfo({ location, cohortDetails }) {
-  if (!location) {
+  if (!location || !cohortDetails) {
     return <></>;
   }
 

--- a/app/src/utils/cohorts.js
+++ b/app/src/utils/cohorts.js
@@ -72,9 +72,9 @@ export function isCohortDone(cohortName) {
   return false;
 }
 
-export function getCohortPeriod(cohort) {
-  const startDate = new Date(cohort.dateStart);
-  const endDate = new Date(cohort.dateEnd);
+export function getCohortPeriod(cohort, meetingPoint = null) {
+  const startDate = new Date(meetingPoint?.bus?.departuredDate || cohort.dateStart);
+  const endDate = new Date(meetingPoint?.bus?.returnDate || cohort.dateEnd);
   const endDateformatOptions = { year: "numeric", month: "long", day: "numeric" };
   const startDateformatOptions = { day: "numeric" };
   if (startDate.getMonth() !== endDate.getMonth()) {


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Mon-Compte-Phase-1-Statut-Affect-Rendre-dynamique-la-date-du-titre-index-e-sur-les-dates-du--71232656eebe4fdaa5a163f9a3dfa2fa?pvs=4

Les dates du séjour sont affichées dans cet ordre :
- Si PDR renseigné : dates du PDR,
- Si PDR non renseigné mais cohorte trouvée en DB : dates de la cohorte en DB,
- Sinon : dates de la cohorte dans lib.