### PR TITLE
feat(app): Mon compte/Home - Statut "Sur liste d'attente" : Ajouter liens vers changement de séjour et désistement

### DIFF
--- a/app/src/components/ui/links/LinkInline.jsx
+++ b/app/src/components/ui/links/LinkInline.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const LinkInline = ({ children, to = "/", className = "", ...rest }) => {
+  return (
+    <Link to={to} className={`text-blue-600 underline underline-offset-4 hover:text-blue-800 hover:underline ${className}`} {...rest}>
+      {children}
+    </Link>
+  );
+};
+
+export default LinkInline;

--- a/app/src/scenes/home/Phase1NotDone.jsx
+++ b/app/src/scenes/home/Phase1NotDone.jsx
@@ -178,7 +178,7 @@ function ChangeCohortPrompt() {
         Choisir un nouveau séjour
       </Link>
       <div className="text-xs text-blue-600">
-        <Link to="account?desistement=1" className="flex items-center justify-center gap-4 md:justify-start">
+        <Link to="account/general?desistement=1" className="flex items-center justify-center gap-4 md:justify-start">
           <span>Se désister du SNU</span>
           <ChevronRight />
         </Link>

--- a/app/src/scenes/home/components/WaitingListContent.jsx
+++ b/app/src/scenes/home/components/WaitingListContent.jsx
@@ -1,8 +1,8 @@
 import LinkInline from "../../../components/ui/links/LinkInline";
 import React from "react";
 
-function WaitingListContent(showLinks) {
-  if (showLinks) {
+function WaitingListContent({ showLinks }) {
+  if (showLinks == true) {
     return (
       <>
         <p>

--- a/app/src/scenes/home/components/WaitingListContent.jsx
+++ b/app/src/scenes/home/components/WaitingListContent.jsx
@@ -1,0 +1,23 @@
+import LinkInline from "../../../components/ui/links/LinkInline";
+import React from "react";
+
+function WaitingListContent(showLinks) {
+  if (showLinks) {
+    return (
+      <>
+        <p>
+          Des places peuvent se libérer à tout moment. Si vous le souhaitez, vous pouvez donc être convoqué(e) dans les prochains jours et jusqu’à l’avant-veille du départ en
+          séjour. Pour cela, vous n’avez rien à faire : restez inscrit à ce séjour.
+        </p>
+        <p>
+          Par contre, si vous ne souhaitez pas recevoir une convocation tardive, vous pouvez choisir de vous{" "}
+          <LinkInline to="/changer-de-sejour">positionner sur un séjour à venir</LinkInline> ou bien{" "}
+          <LinkInline to="account/general?desistement=1">retirer votre candidature</LinkInline>.
+        </p>
+      </>
+    );
+  }
+  return <p>Votre inscription au SNU est bien validée. Nous vous recontacterons dès qu’une place se libère dans les prochains jours.</p>;
+}
+
+export default WaitingListContent;

--- a/app/src/scenes/home/waitingList.jsx
+++ b/app/src/scenes/home/waitingList.jsx
@@ -2,22 +2,23 @@ import Img3 from "../../assets/homePhase2Desktop.png";
 import Img2 from "../../assets/homePhase2Mobile.png";
 import React from "react";
 import { useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
 import { translate } from "snu-lib";
-import Check from "../../assets/icons/Check";
 import plausibleEvent from "../../services/plausible";
 import { COHESION_STAY_LIMIT_DATE } from "../../utils";
+import { getCohort } from "../../utils/cohorts";
+import Clock from "../../assets/icons/Clock";
+import LinkInline from "../../components/ui/links/LinkInline";
 
 export default function WaitingList() {
   const young = useSelector((state) => state.Auth.young);
-  const history = useHistory();
+  const cohort = getCohort(young.cohort);
 
   return (
     <>
       {/* DESKTOP */}
       <div className="hidden lg:flex">
-        <div className="m-10 w-full">
-          <div className="flex items-center justify-between overflow-hidden rounded-xl bg-white shadow-sm">
+        <div className="m-8 w-full">
+          <div className="flex items-center justify-between overflow-hidden rounded-xl bg-white shadow-sm max-w-7xl mx-auto">
             <div className="flex w-1/2 flex-col gap-8 py-6 pl-10 pr-3">
               <div className="text-[44px] font-medium leading-tight tracking-tight text-gray-800">
                 <strong>{young.firstName},</strong> bienvenue sur votre compte volontaire.
@@ -27,12 +28,10 @@ export default function WaitingList() {
               </div>
 
               <hr className="text-gray-200" />
-              <div className="flex items-center gap-5">
-                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 p-2">
-                  <Check className="text-gray-600" />
-                </div>
-                <div className="flex-1 text-sm leading-5 text-[#6B7280]">
-                  Votre inscription au SNU est bien validée. Nous vous recontacterons dès qu’une place se libère dans les prochains jours.
+              <div className="flex gap-5">
+                <Clock className="text-gray-600 flex-1 rounded-full bg-gray-100 p-2" />
+                <div className="flex-1 text-sm leading-5 text-gray-500 space-y-6">
+                  <Content showLinks={cohort?.uselessInformation?.showChangeCohortButtonOnHomeWaitingList} />
                 </div>
               </div>
               <hr className="text-gray-200" />
@@ -61,12 +60,10 @@ export default function WaitingList() {
             </div>
 
             <hr className="mt-3 text-gray-200" />
-            <div className="flex items-center gap-2">
-              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 p-2">
-                <Check className="text-gray-600" />
-              </div>
-              <div className="flex-1 text-sm text-[#738297]">
-                Votre inscription au SNU est bien validée. Nous vous recontacterons dès qu’une place se libère dans les prochains jours.
+            <div className="flex gap-2 my-2">
+              <Clock className="text-gray-600 rounded-full bg-gray-100 p-2" />
+              <div className="flex-1 text-sm leading-5 text-gray-500 space-y-4">
+                <Content showLinks={cohort?.uselessInformation?.showChangeCohortButtonOnHomeWaitingList} />
               </div>
             </div>
             <hr className="text-gray-200" />
@@ -85,4 +82,23 @@ export default function WaitingList() {
       </div>
     </>
   );
+}
+
+function Content(showLinks) {
+  if (showLinks) {
+    return (
+      <>
+        <p>
+          Des places peuvent se libérer à tout moment. Si vous le souhaitez, vous pouvez donc être convoqué(e) dans les prochains jours et jusqu’à l’avant-veille du départ en
+          séjour. Pour cela, vous n’avez rien à faire : restez inscrit à ce séjour.
+        </p>
+        <p>
+          Par contre, si vous ne souhaitez pas recevoir une convocation tardive, vous pouvez choisir de vous{" "}
+          <LinkInline to="/changer-de-sejour">positionner sur un séjour à venir</LinkInline> ou bien{" "}
+          <LinkInline to="account/general?desistement=1">retirer votre candidature</LinkInline>.
+        </p>
+      </>
+    );
+  }
+  return <p>Votre inscription au SNU est bien validée. Nous vous recontacterons dès qu’une place se libère dans les prochains jours.</p>;
 }

--- a/app/src/scenes/home/waitingList.jsx
+++ b/app/src/scenes/home/waitingList.jsx
@@ -7,7 +7,7 @@ import plausibleEvent from "../../services/plausible";
 import { COHESION_STAY_LIMIT_DATE } from "../../utils";
 import { getCohort } from "../../utils/cohorts";
 import Clock from "../../assets/icons/Clock";
-import LinkInline from "../../components/ui/links/LinkInline";
+import WaitingListContent from "./components/WaitingListContent";
 
 export default function WaitingList() {
   const young = useSelector((state) => state.Auth.young);
@@ -31,7 +31,7 @@ export default function WaitingList() {
               <div className="flex gap-5">
                 <Clock className="text-gray-600 flex-1 rounded-full bg-gray-100 p-2" />
                 <div className="flex-1 text-sm leading-5 text-gray-500 space-y-6">
-                  <Content showLinks={cohort?.uselessInformation?.showChangeCohortButtonOnHomeWaitingList} />
+                  <WaitingListContent showLinks={cohort?.uselessInformation?.showChangeCohortButtonOnHomeWaitingList} />
                 </div>
               </div>
               <hr className="text-gray-200" />
@@ -63,7 +63,7 @@ export default function WaitingList() {
             <div className="flex gap-2 my-2">
               <Clock className="text-gray-600 rounded-full bg-gray-100 p-2" />
               <div className="flex-1 text-sm leading-5 text-gray-500 space-y-4">
-                <Content showLinks={cohort?.uselessInformation?.showChangeCohortButtonOnHomeWaitingList} />
+                <WaitingListContent showLinks={cohort?.uselessInformation?.showChangeCohortButtonOnHomeWaitingList} />
               </div>
             </div>
             <hr className="text-gray-200" />
@@ -82,23 +82,4 @@ export default function WaitingList() {
       </div>
     </>
   );
-}
-
-function Content(showLinks) {
-  if (showLinks) {
-    return (
-      <>
-        <p>
-          Des places peuvent se libérer à tout moment. Si vous le souhaitez, vous pouvez donc être convoqué(e) dans les prochains jours et jusqu’à l’avant-veille du départ en
-          séjour. Pour cela, vous n’avez rien à faire : restez inscrit à ce séjour.
-        </p>
-        <p>
-          Par contre, si vous ne souhaitez pas recevoir une convocation tardive, vous pouvez choisir de vous{" "}
-          <LinkInline to="/changer-de-sejour">positionner sur un séjour à venir</LinkInline> ou bien{" "}
-          <LinkInline to="account/general?desistement=1">retirer votre candidature</LinkInline>.
-        </p>
-      </>
-    );
-  }
-  return <p>Votre inscription au SNU est bien validée. Nous vous recontacterons dès qu’une place se libère dans les prochains jours.</p>;
 }

--- a/app/src/scenes/phase1/scenes/affected/components/step/stepAgreement.jsx
+++ b/app/src/scenes/phase1/scenes/affected/components/step/stepAgreement.jsx
@@ -139,7 +139,7 @@ const content = ({ handleSubmit, young }) => {
           Changer de séjour &gt;
         </Link>
         <p className="pb-3 text-sm text-gray-600">Je ne souhaite plus participer au SNU</p>
-        <Link to="account?desistement=1" className="whitespace-nowrap text-sm text-blue-600 hover:underline hover:underline-offset-2">
+        <Link to="account/general?desistement=1" className="whitespace-nowrap text-sm text-blue-600 hover:underline hover:underline-offset-2">
           Me désister &gt;
         </Link>
       </div>


### PR DESCRIPTION
- Ticket : https://www.notion.so/jeveuxaider/Adapter-l-cran-des-volontaires-de-la-cohorte-Juin-2023-statut-valid-e-sur-liste-compl-mentaire--24e34946e491435185dfe1a3ef4566de?pvs=4
- Résumé : afficher un texte alternatif et des liens vers la page de changement de séjour et le désistement.
- L'affichage de ce contenu dépend d'une validation de la SD pour chaque cohorte, donc l'affichage est conditionné à un flag à modifier directement dans les données de cohorte.
- Première utilisation : demain pour la cohorte de juin, en coordination avec le pôle marketing.