### PR TITLE
fix(admin/lib):modification systeme de droit de modif PDT pour ref et transporter

### DIFF
--- a/admin/src/scenes/plan-transport/ligne-bus/View/components/BusTeam.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/View/components/BusTeam.jsx
@@ -115,7 +115,7 @@ export default function BusTeam({ bus, setBus, title, role, addOpen, setAddOpen,
     <div className="w-full rounded-xl bg-white p-8">
       <div className="flex items-center justify-between">
         <div className="text-xl leading-6 text-[#242526]">{title}</div>
-        {canEditLigneBusTeam(user) && isBusEditionOpen(user, cohort) ? (
+        {canEditLigneBusTeam(user) || isBusEditionOpen(user, cohort) ? (
           <>
             {!editInfo ? (
               <>

--- a/admin/src/scenes/plan-transport/ligne-bus/View/components/Centre.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/View/components/Centre.jsx
@@ -64,7 +64,7 @@ export default function Centre({ bus, setBus, cohort }) {
     <div className="w-1/2 rounded-xl bg-white p-8">
       <div className="flex items-center justify-between">
         <div className="text-xl leading-6 text-[#242526]">Centre de cohésion</div>
-        {canEditLigneBusCenter(user) && isBusEditionOpen(user, cohort) ? (
+        {canEditLigneBusCenter(user) || isBusEditionOpen(user, cohort) ? (
           <>
             {!editCenter ? (
               <button

--- a/admin/src/scenes/plan-transport/ligne-bus/View/components/Info.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/View/components/Info.jsx
@@ -118,7 +118,7 @@ export default function Info({ bus, setBus, dataForCheck, nbYoung, cohort }) {
     <div className="w-full rounded-xl bg-white p-8">
       <div className="flex items-center justify-between">
         <div className="text-xl leading-6 text-[#242526]">Informations générales</div>
-        {canEditLigneBusGeneralInfo(user) && isBusEditionOpen(user, cohort) ? (
+        {canEditLigneBusGeneralInfo(user) || isBusEditionOpen(user, cohort) ? (
           <>
             {!editInfo ? (
               <button

--- a/admin/src/scenes/plan-transport/ligne-bus/View/components/PointDeRassemblement.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/View/components/PointDeRassemblement.jsx
@@ -167,7 +167,7 @@ export default function PointDeRassemblement({ bus, setBus, index, pdr, volume, 
             <div className="pb-1 text-lg font-medium leading-5 text-gray-900">{volume.find((v) => v.meetingPointId === pdr._id)?.youngsCount || 0} </div>
           </div>
         </div>
-        {canEditLigneBusPointDeRassemblement(user) && isBusEditionOpen(user, cohort) ? (
+        {canEditLigneBusPointDeRassemblement(user) || isBusEditionOpen(user, cohort) ? (
           <>
             {!editPdr ? (
               <button

--- a/packages/lib/roles.js
+++ b/packages/lib/roles.js
@@ -356,15 +356,7 @@ function isPdrEditionOpen(actor, cohort) {
 
 const isBusEditionOpen = (actor, cohort) => {
   switch (actor?.role) {
-    case ROLES.ADMIN:
-      return true;
     case ROLES.TRANSPORTER:
-      return cohort?.busEditionOpenForTransporter;
-    case ROLES.REFERENT_REGION:
-      return cohort?.busEditionOpenForTransporter;
-    case ROLES.REFERENT_DEPARTMENT:
-      return cohort?.busEditionOpenForTransporter;
-    case ROLES.HEAD_CENTER:
       return cohort?.busEditionOpenForTransporter;
     default:
       return false;
@@ -733,19 +725,19 @@ function canExportConvoyeur(actor) {
 }
 
 function canEditLigneBusTeam(actor) {
-  return [ROLES.ADMIN, ROLES.TRANSPORTER, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT, ROLES.HEAD_CENTER].includes(actor.role);
+  return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT, ROLES.HEAD_CENTER].includes(actor.role);
 }
 
 function canEditLigneBusGeneralInfo(actor) {
-  return [ROLES.ADMIN, ROLES.TRANSPORTER].includes(actor.role);
+  return [ROLES.ADMIN].includes(actor.role);
 }
 
 function canEditLigneBusCenter(actor) {
-  return [ROLES.ADMIN, ROLES.TRANSPORTER].includes(actor.role);
+  return [ROLES.ADMIN].includes(actor.role);
 }
 
 function canEditLigneBusPointDeRassemblement(actor) {
-  return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT, ROLES.TRANSPORTER].includes(actor.role);
+  return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT].includes(actor.role);
 }
 
 function ligneBusCanCreateDemandeDeModification(actor) {


### PR DESCRIPTION
Actuellement tous les referent sont soumis au champ isBusEditionOpenForTransporter en DB pour pouvoir modifier les lignes de bus