### PR TITLE
fix(app): improve address search and error mgmt

### DIFF
--- a/app/src/scenes/missions/list/components/MissionFilters.jsx
+++ b/app/src/scenes/missions/list/components/MissionFilters.jsx
@@ -94,7 +94,7 @@ export default function MissionFilters({ filters, setFilters }) {
       if (res?.features?.length) {
         return { lat: res?.features[0]?.geometry?.coordinates[1], lon: res?.features[0]?.geometry?.coordinates[0] };
       }
-      toastr.error("Erreur avec la base adresse nationale", "Impossible de trouver des coordonnées valides pour votre adresse");
+      toastr.error("Erreur avec la base adresse nationale", "Impossible de trouver des coordonnées GPS.", { timeOut: 10_000 });
       return null;
     } catch (e) {
       capture(e);
@@ -311,7 +311,7 @@ export default function MissionFilters({ filters, setFilters }) {
                             id="main-address"
                             name="main-address"
                             type="radio"
-                            checked={filters.location === young?.location}
+                            checked={filters.location === youngLocation}
                             onChange={() => setFilters((prev) => ({ ...prev, location: youngLocation }))}
                             className="hidden"
                           />
@@ -568,7 +568,7 @@ export default function MissionFilters({ filters, setFilters }) {
                         id="main-address"
                         name="main-address"
                         type="radio"
-                        checked={filters.location === young?.location}
+                        checked={filters.location === youngLocation}
                         onChange={() => setFilters((prev) => ({ ...prev, location: youngLocation }))}
                         className="hidden"
                       />

--- a/app/src/services/api-adresse.js
+++ b/app/src/services/api-adresse.js
@@ -28,6 +28,10 @@ const apiAdress = async (query, filters = {}, options = {}) => {
 };
 
 const putLocation = async (query, postcode, signal) => {
+  if (!postcode) {
+    capture(new Error("No postcode"), { extra: { query: query } });
+    return null;
+  }
   let res = await apiAdress(query, { postcode }, { signal });
   if (res?.features?.length) {
     return { lat: res?.features[0]?.geometry?.coordinates[1], lon: res?.features[0]?.geometry?.coordinates[0] };

--- a/app/src/services/api-adresse.js
+++ b/app/src/services/api-adresse.js
@@ -27,6 +27,7 @@ const apiAdress = async (query, filters = {}, options = {}) => {
   }
 };
 
+// TODO: remove this function, seems unused
 const putLocation = async (city, zip) => {
   try {
     if (!city && !zip) return;

--- a/app/src/services/api-adresse.js
+++ b/app/src/services/api-adresse.js
@@ -23,46 +23,21 @@ const apiAdress = async (query, filters = {}, options = {}) => {
     });
     return await res.json();
   } catch (e) {
-    capture(e, { extra: { url: url } });
+    if (e.name !== "AbortError") capture(e, { extra: { url: url } });
   }
 };
 
-// TODO: remove this function, seems unused
-const putLocation = async (city, zip) => {
-  try {
-    if (!city && !zip) return;
-    // try with municipality = city + zip
-    const resMunicipality = await apiAdress(city, { postcode: zip, type: "municipality" });
-    if (resMunicipality?.features?.length > 0) {
-      return {
-        lon: resMunicipality.features[0].geometry.coordinates[0],
-        lat: resMunicipality.features[0].geometry.coordinates[1],
-      };
-    }
-    // try with locality = city + zip
-    const resLocality = await apiAdress(city, { postcode: zip, type: "locality" });
-    if (resLocality?.features?.length > 0) {
-      return {
-        lon: resLocality.features[0].geometry.coordinates[0],
-        lat: resLocality.features[0].geometry.coordinates[1],
-      };
-    }
-    // try with postcode = zip
-    const resPostcode = await apiAdress(city || zip, { postcode: zip });
-    if (resPostcode?.features?.length > 0) {
-      return {
-        lon: resPostcode.features[0].geometry.coordinates[0],
-        lat: resPostcode.features[0].geometry.coordinates[1],
-      };
-    }
-    return {
-      lon: 2.352222,
-      lat: 48.856613,
-    };
-  } catch (e) {
-    console.log("Erreur in putLocation", e);
-    capture(e);
+const putLocation = async (query, postcode, signal) => {
+  let res = await apiAdress(query, { postcode }, { signal });
+  if (res?.features?.length) {
+    return { lat: res?.features[0]?.geometry?.coordinates[1], lon: res?.features[0]?.geometry?.coordinates[0] };
   }
+  // if no result, try with zip code only
+  res = await apiAdress(postcode, { postcode }, { signal });
+  if (res?.features?.length) {
+    return { lat: res?.features[0]?.geometry?.coordinates[1], lon: res?.features[0]?.geometry?.coordinates[0] };
+  }
+  return null;
 };
 
 const getSuggestions = async (address, city, zip) => {


### PR DESCRIPTION
Objectif : réduire les erreurs liés aux calls vers l'API de la Base adresse nationale depuis la page de recherche de missions.
Exemple d'erreur : https://sentry.selego.co/organizations/sentry/issues/33239/?alert_rule_id=3&alert_type=issue&project=13&referrer=slack

Modifications :
- Réduction du nombre de calls : on ne va chercher les coordonnées géographiques du volontaire que si il n'en a pas en DB (environ 1200 sur les 66 000 susceptibles d'utiliser cette page) et on ne va chercher les coordonnées du proche qui l'héberge qu'une seule fois par visite de la page.
- Amélioration de la gestion des erreurs (try catch et toastr).
- Ajout d'un AbortController pour gérer les utilisateurs qui quittent la page avant la réception de la réponse.