### PR TITLE
Feat(BDC-Front): update SeeAs and User.role for referent

### DIFF
--- a/knowledge-base-public/src/components/Wrapper.js
+++ b/knowledge-base-public/src/components/Wrapper.js
@@ -5,11 +5,25 @@ import SeeAsContext from "../contexts/seeAs";
 import { translateRoleBDC } from "../utils/constants";
 import Header from "./Header";
 import Footer from "./Footer";
+import { environment } from "../config";
 
 const Wrapper = ({ home, children }) => {
-  const { user } = useUser();
+  const { user: originalUser } = useUser();
   const { setSeeAs, seeAs } = useContext(SeeAsContext);
-  const withSeeAs = ["admin", "referent_department", "referent_region", "head_center", "structure", "visitor", "dsnj"].includes(user?.role);
+
+  const getModifiedRole = (role) => {
+    return role === "referent_department" || role === "referent_region" ? "referent" : role;
+  };
+
+  const user =
+    environment === "production"
+      ? originalUser
+      : {
+          ...originalUser,
+          role: getModifiedRole(originalUser.role),
+        };
+
+  const withSeeAs = ["admin", "referent", "head_center", "structure", "visitor", "dsnj"].includes(user?.role);
   const withSeeAsPublicAndYoung = ["public", "young"].includes(seeAs);
 
   return (
@@ -20,7 +34,7 @@ const Wrapper = ({ home, children }) => {
           <AiOutlineInfoCircle className="text-blue-500 text-xl flex-none" />
           <p className="text-sm text-blue-800">
             Vous visualisez la base de connaissance en tant que {translateRoleBDC[seeAs]}.{" "}
-            <button onClick={() => setSeeAs("admin")} className="noprint text-sm text-blue-800 underline reset">
+            <button onClick={() => setSeeAs(user?.role)} className="noprint text-sm text-blue-800 underline reset">
               Rétablir la vue par défaut.
             </button>
           </p>

--- a/knowledge-base-public/src/components/navigation/AdminMenu.jsx
+++ b/knowledge-base-public/src/components/navigation/AdminMenu.jsx
@@ -8,13 +8,27 @@ import Link from "next/link";
 import { Popover, Transition } from "@headlessui/react";
 import { translateRoleBDC } from "../../utils/constants";
 import { HiOutlineLogout, HiOutlineUser, HiCheck } from "react-icons/hi";
+import { environment } from "../../config";
 
 export default function AdminMenu() {
-  const { mutate, user } = useUser();
+  const { mutate, user: originalUser } = useUser();
   const { setSeeAs, seeAs, roles } = useContext(SeeAsContext);
-  const categoryAccessibleReferent = ["structure", "head_center", "young", "visitor"];
   const { cache } = useSWRConfig();
-  const withSeeAs = ["admin", "referent_department", "referent_region", "head_center", "structure", "visitor", "dsnj"].includes(user?.role);
+
+  const getModifiedRole = (role) => {
+    return role === "referent_department" || role === "referent_region" ? "referent" : role;
+  };
+
+  const user =
+    environment === "production"
+      ? originalUser
+      : {
+          ...originalUser,
+          role: getModifiedRole(originalUser.role),
+        };
+
+  const categoryAccessibleReferent = ["referent", "admin", "structure", "head_center", "young", "visitor", "public"];
+  const withSeeAs = ["admin", "referent", "head_center", "structure", "visitor", "dsnj"].includes(user?.role);
 
   const onLogout = async (event) => {
     event.preventDefault();


### PR DESCRIPTION
Le rôle référent n'était jusque là pas pris en compte pour la BDC.
C'est maintenant chose faite !
ticket notion : https://www.notion.so/Front-BdC-Refonte-graphique-du-bouton-Voir-les-articles-pour-06e3a1617cdf4278a302efff7174c617
