### PR TITLE
chore(admin): Removing useless css class on Root to access Link

### DIFF
--- a/admin/src/index.css
+++ b/admin/src/index.css
@@ -109,7 +109,6 @@ ul {
 #root {
   display: flex;
   flex-direction: column;
-  height: 100vh;
 }
 
 .main {


### PR DESCRIPTION
ticket notion : https://www.notion.so/jeveuxaider/Remont-e-des-bugs-Bug-tracker-4595662783864331aed5fab8f21b2480?p=04cbbcb6247a48768bd916981250417d&pm=s

Il était très difficile d'accéder au bouton "Renvoyer le lien par email" sur le détail des missions d'un jeune : http://localhost:8082/volontaire/63872bab3c891a1e1f28c45f/phase2/application/651d7dc3b2f9d4292928f22c  

Pour cause la classe 100vh sur root venait prendre le pas sur l'Url.