### PR TITLE
fix(admin): [Safari] Permettre au bouton "Prendre la place" d'ouvrir un nouvel onglet

### DIFF
--- a/admin/src/scenes/inbox/components/ticketInfos.jsx
+++ b/admin/src/scenes/inbox/components/ticketInfos.jsx
@@ -56,7 +56,6 @@ export default function TicketInfos({ ticket }) {
     plausibleEvent("Volontaires/CTA - Prendre sa place");
     const { ok } = await api.post(`/referent/signin_as/young/${young_id}`);
     if (!ok) return toastr.error("Une erreur s'est produite lors de la prise de place du volontaire.");
-    window.open(appURL, "_blank");
   };
 
   const renderInfos = () => {
@@ -70,7 +69,11 @@ export default function TicketInfos({ ticket }) {
             <Link to={`/volontaire/${user._id}/edit`} target="_blank" rel="noopener noreferrer">
               <PanelActionButton icon="pencil" title="Modifier" />
             </Link>
-            <button onClick={() => onPrendreLaPlace(user._id)}>
+            <button
+              onClick={() => {
+                window.open(appURL, "_blank");
+                onPrendreLaPlace(user._id);
+              }}>
               <PanelActionButton icon="impersonate" title="Prendre&nbsp;sa&nbsp;place" />
             </button>
           </div>

--- a/admin/src/scenes/inscription/index.jsx
+++ b/admin/src/scenes/inscription/index.jsx
@@ -370,15 +370,12 @@ const Action = ({ hit }) => {
                 </Link>
                 {[ROLES.ADMIN, ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role) && hit.status !== YOUNG_STATUS.DELETED ? (
                   <Listbox.Option
-                    className={({ active }) => classNames(active ? "bg-blue-600 text-white" : "text-gray-900", "relative cursor-pointer select-none list-none py-2 pl-3 pr-9")}>
-                    <button
-                      className={"block truncate font-normal text-xs"}
-                      onClick={() => {
-                        window.open(appURL, "_blank");
-                        onPrendreLaPlace(hit._id);
-                      }}>
-                      Prendre sa place
-                    </button>
+                    className={({ active }) => classNames(active ? "bg-blue-600 text-white" : "text-gray-900", "relative cursor-pointer select-none list-none py-2 pl-3 pr-9")}
+                    onClick={() => {
+                      window.open(appURL, "_blank");
+                      onPrendreLaPlace(hit._id);
+                    }}>
+                    Prendre sa place
                   </Listbox.Option>
                 ) : null}
               </Listbox.Options>

--- a/admin/src/scenes/inscription/index.jsx
+++ b/admin/src/scenes/inscription/index.jsx
@@ -340,7 +340,6 @@ const Action = ({ hit }) => {
     plausibleEvent("Volontaires/CTA - Prendre sa place");
     const { ok } = await api.post(`/referent/signin_as/young/${young_id}`);
     if (!ok) return toastr.error("Une erreur s'est produite lors de la prise de place du volontaire.");
-    window.open(appURL, "_blank");
   };
 
   return (
@@ -372,7 +371,12 @@ const Action = ({ hit }) => {
                 {[ROLES.ADMIN, ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role) && hit.status !== YOUNG_STATUS.DELETED ? (
                   <Listbox.Option
                     className={({ active }) => classNames(active ? "bg-blue-600 text-white" : "text-gray-900", "relative cursor-pointer select-none list-none py-2 pl-3 pr-9")}>
-                    <button className={"block truncate font-normal text-xs"} onClick={() => onPrendreLaPlace(hit._id)}>
+                    <button
+                      className={"block truncate font-normal text-xs"}
+                      onClick={() => {
+                        window.open(appURL, "_blank");
+                        onPrendreLaPlace(hit._id);
+                      }}>
                       Prendre sa place
                     </button>
                   </Listbox.Option>

--- a/admin/src/scenes/inscription/panel.jsx
+++ b/admin/src/scenes/inscription/panel.jsx
@@ -58,7 +58,6 @@ export default function InscriptionPanel({ onChange, value }) {
     plausibleEvent("Volontaires/CTA - Prendre sa place");
     const { ok } = await api.post(`/referent/signin_as/young/${young_id}`);
     if (!ok) return toastr.error("Une erreur s'est produite lors de la prise de place du volontaire.");
-    window.open(appURL, "_blank");
   };
 
   return (
@@ -88,7 +87,11 @@ export default function InscriptionPanel({ onChange, value }) {
               <Link to={`/volontaire/${value._id}`} onClick={() => plausibleEvent("Inscriptions/CTA - Consulter profil jeune")}>
                 <PanelActionButton icon="eye" title="Consulter" />
               </Link>
-              <button onClick={() => onPrendreLaPlace(value._id)}>
+              <button
+                onClick={() => {
+                  window.open(appURL, "_blank");
+                  onPrendreLaPlace(value._id);
+                }}>
                 <PanelActionButton icon="impersonate" title="Prendre&nbsp;sa&nbsp;place" />
               </button>
               <PanelActionButton onClick={handleDeleteYoung} icon="bin" title="Supprimer" />

--- a/admin/src/scenes/phase0/components/YoungHeader.jsx
+++ b/admin/src/scenes/phase0/components/YoungHeader.jsx
@@ -222,7 +222,6 @@ export default function YoungHeader({ young, tab, onChange, phase = YOUNG_PHASE.
     plausibleEvent("Volontaires/CTA - Prendre sa place");
     const { ok } = await api.post(`/referent/signin_as/young/${young_id}`);
     if (!ok) return toastr.error("Une erreur s'est produite lors de la prise de place du volontaire.");
-    window.open(appURL, "_blank");
   };
 
   return (
@@ -344,7 +343,11 @@ export default function YoungHeader({ young, tab, onChange, phase = YOUNG_PHASE.
                 <Button icon={<Bin fill="red" />} onClick={handleDeleteYoung}>
                   Supprimer
                 </Button>
-                <button onClick={() => onPrendreLaPlace(young._id)}>
+                <button
+                  onClick={() => {
+                    window.open(appURL, "_blank");
+                    onPrendreLaPlace(young._id);
+                  }}>
                   <PanelActionButton icon="impersonate" title="Prendre&nbsp;sa&nbsp;place" />
                 </button>
               </div>


### PR DESCRIPTION
# Description

**Problème** : le bouton "Prendre sa place" ne fonctionne pas sous Safari.
**Impact** : il est plus difficile de tester le parcours volontaire sous Safari, alors que cela représente 40% des visites et qu'il y a des différences d'affichages souvent remontées en retour PO.
**Cause** : Safari ignore les call window.open() dans le cadre des fonctions asynchrones.
**Solution** : sortir le window.open() de la fonction onPrendreLaPlace qui est asynchrone en raison du call permettant d'obtenir un token.


## Checklist

- [x] **⚠️ My code can have side-effects on other part of the code-base** : nope
- [x] I have added the Plausible tags/events : N/A
- [x] I have performed a self-review of my code (and removed console.log)

## Testing instructions

Utiliser les différentes boutons "Prendre sa place" sur différents navigateurs.

## Screenshots

https://github.com/betagouv/service-national-universel/assets/95406348/5afbabe6-9227-4079-92af-7d6d7808b1ee

