### PR TITLE
chore(app): fix error on mobile view (emailValidation)

### DIFF
--- a/app/src/scenes/preinscription/EmailValidation.jsx
+++ b/app/src/scenes/preinscription/EmailValidation.jsx
@@ -109,19 +109,19 @@ export default function StepEmailValidation() {
       <div className="mt-8 flex flex-col gap-1">
         <label>Code d'activation reçu par e-mail</label>
         <Input value={emailValidationToken} onChange={setEmailValidationToken} />
-        <div className="h-2">
-          {error && (
-            <span className="text-sm text-red-500">
-              {error}{" "}
-              <InlineButton className="ml-1 text-sm text-red-500 hover:text-red-700" onClick={handleRequestNewToken}>
-                Recevoir un nouveau code
-              </InlineButton>
-            </span>
-          )}
-        </div>
+      </div>
+      <div className={`h-2 ${error ? "mb-12 md:mb-4 mt-2" : ""}`}>
+        {error && (
+          <span className="text-sm text-red-500">
+            {error}{" "}
+            <InlineButton className="ml-1 text-sm text-red-500 hover:text-red-700" onClick={handleRequestNewToken}>
+              Recevoir un nouveau code
+            </InlineButton>
+          </span>
+        )}
       </div>
       <InlineButton
-        className="mt-3"
+        className="mt-1"
         onClick={() => {
           setDidNotReceiveCodeModalOpen(true);
         }}>


### PR DESCRIPTION
voir conversation Slack : squad jeune (16h44) (Moins prio) Sur IPhone toujours, sur l’écran de vérification de l’adresse e-mail le message d’erreur et le bouton « Je n’ai rien reçu » de superposent