### PR TITLE
feat(app): 1382 - Inscription/étape éligibilité : Améliorer la saisie de l'école

### DIFF
--- a/app/src/components/dsfr/forms/AddressForm/AddressSearch.jsx
+++ b/app/src/components/dsfr/forms/AddressForm/AddressSearch.jsx
@@ -60,7 +60,7 @@ export default function AddressSearch({ getOptions, updateData, error }) {
     <div ref={dropdownRef}>
       <label className="flex flex-col gap-1">
         Rechercher une adresse
-        <span className="text-[#666666] text-xs mb-1">Si votre adresse est introuvable, sélectionnez uniquement une commune ou un code postal.</span>
+        <span className="text-[#666666] text-xs mb-1">Si l'adresse est introuvable, sélectionnez uniquement une commune ou un code postal.</span>
         <div className="relative">
           <input type="text" value={query} onChange={handleChangeQuery} className="w-[100%] border-b-2 border-gray-800 bg-[#EEEEEE] rounded-tl rounded-tr px-3 py-2 pr-5" />
           <span className="material-icons absolute right-5 mt-[12px] text-lg">
@@ -76,7 +76,7 @@ export default function AddressSearch({ getOptions, updateData, error }) {
               <AddressDropdown optionGroups={options} handleSelect={handleSelect} />
             ) : (
               <p className="p-3 text-gray-800 text-center">
-                Votre adresse ne s'affiche pas ? Renseignez une <strong>commune</strong> ou un <strong>code postal</strong>.
+                L'adresse ne s'affiche pas ? Renseignez une <strong>commune</strong> ou un <strong>code postal</strong>.
               </p>
             )}
           </div>

--- a/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
+++ b/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
@@ -82,8 +82,8 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
           onSelectSchool(newData);
         }}
         getOptions={getAddressOptions}
-        error={errors.manualSchool?.adresse}
-        corrections={corrections?.adresse}
+        error={errors.manualAdresse}
+        correction={corrections?.schoolAddress}
       />
       <GhostButton
         name={

--- a/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
+++ b/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
@@ -3,20 +3,11 @@ import api from "../../../services/api";
 import SearchableSelect from "../../../components/dsfr/forms/SearchableSelect";
 import CreatableSelect from "../../../components/CreatableSelect";
 import Input from "./Input";
-import VerifyAddress from "./VerifyAddress";
+import AddressForm from "@/components/dsfr/forms/AddressForm";
 import GhostButton from "../../../components/dsfr/ui/buttons/GhostButton";
 import { FiChevronLeft } from "react-icons/fi";
-import validator from "validator";
-import ErrorMessage from "../../../components/dsfr/forms/ErrorMessage";
 import { toastr } from "react-redux-toastr";
-
-const addressValidationInfo = "Pour valider votre adresse vous devez remplir les champs adresse de résidence, code postale et ville.";
-const addressValidationSuccess = "L'adresse a été vérifiée";
-
-const messageStyles = {
-  info: "info",
-  error: "error",
-};
+import { getAddressOptions } from "@/services/api-adresse";
 
 export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, corrections = null }) {
   const [cities, setCities] = useState([]);
@@ -26,8 +17,6 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
   const [manualFilling, setManualFilling] = useState(school?.fullName && !school?.id);
   const [manualSchool, setManualSchool] = useState(school ?? {});
   const [errors, setErrors] = useState({});
-
-  const isVerifyAddressDisabled = !manualSchool.fullName || !manualSchool.adresse || !manualSchool.city || !manualSchool.postCode;
 
   useEffect(() => {
     async function getCities() {
@@ -60,15 +49,6 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
       if (!manualSchool?.adresse) {
         errors.manualAdresse = "Vous devez renseigner une adresse";
       }
-      if (!manualSchool?.city) {
-        errors.manualCity = "Vous devez renseigner le nom de la ville";
-      }
-      if (!(manualSchool?.postCode && validator.isPostalCode(manualSchool?.postCode, "FR"))) {
-        errors.manualPostCode = "Vous devez sélectionner un code postal";
-      }
-      if (!manualSchool?.addressVerified) {
-        errors.addressVerified = "Merci de vérifier l'adresse";
-      }
     }
 
     setErrors(errors);
@@ -83,80 +63,28 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
     getSchools();
   }, [city]);
 
-  const onVerifyAddress = (isConfirmed) => (suggestion) => {
-    const newSchool = {
-      ...manualSchool,
-      addressVerified: isConfirmed ? "true" : undefined,
-      cityCode: suggestion.cityCode,
-      region: suggestion.region,
-      department: suggestion.department,
-      location: suggestion.location,
-      // if the suggestion is not confirmed we keep the address typed by the user
-      adresse: isConfirmed ? suggestion.address : manualSchool.adresse,
-      postCode: isConfirmed ? suggestion.zip : manualSchool.postCode,
-      city: isConfirmed ? suggestion.city : manualSchool.city,
-    };
-    setManualSchool(newSchool);
-    setErrors({ addressVerified: undefined });
-    onSelectSchool(newSchool);
-  };
-
   return manualFilling ? (
     <>
       <Input
         value={manualSchool.fullName}
         label="Nom de l'établissement"
         onChange={(value) => {
-          setManualSchool({ ...manualSchool, fullName: value, addressVerified: undefined });
+          setManualSchool({ ...manualSchool, fullName: value });
           onSelectSchool(null);
         }}
         error={errors.manualFullName}
         correction={corrections?.schoolName}
       />
-      <Input
-        value={manualSchool.adresse}
-        label="Adresse de l'établissement"
-        onChange={(value) => {
-          setManualSchool({ ...manualSchool, adresse: value, addressVerified: undefined });
-          onSelectSchool(null);
+      <AddressForm
+        data={manualSchool}
+        updateData={(newData) => {
+          setManualSchool({ ...manualSchool, ...newData });
+          onSelectSchool(newData);
         }}
-        error={errors.manualAdresse}
-        correction={corrections?.schoolAddress}
+        getOptions={getAddressOptions}
+        error={errors.manualSchool?.adresse}
+        corrections={corrections?.adresse}
       />
-      <Input
-        value={manualSchool.postCode}
-        label="Code postal de l'établissement"
-        onChange={(value) => {
-          setManualSchool({ ...manualSchool, postCode: value, addressVerified: undefined });
-          onSelectSchool(null);
-        }}
-        error={errors.manualPostCode}
-        correction={corrections?.schoolZip}
-      />
-      <Input
-        value={manualSchool.city}
-        label="Ville de l'établissement"
-        onChange={(value) => {
-          setManualSchool({ ...manualSchool, city: value, addressVerified: undefined });
-          onSelectSchool(null);
-        }}
-        error={errors.manualCity}
-        correction={corrections?.schoolCity}
-      />
-      <VerifyAddress
-        address={manualSchool.adresse}
-        disabled={isVerifyAddressDisabled}
-        zip={manualSchool.postCode}
-        city={manualSchool.city}
-        onSuccess={onVerifyAddress(true)}
-        onFail={onVerifyAddress(false)}
-        isVerified={manualSchool.addressVerified}
-        message={manualSchool.addressVerified === "true" ? addressValidationSuccess : isVerifyAddressDisabled ? addressValidationInfo : errors.addressVerified}
-        messageStyle={manualSchool.addressVerified === "true" || isVerifyAddressDisabled ? messageStyles.info : messageStyles.error}
-      />
-      <div className="flex justify-end">
-        <ErrorMessage>{errors.addressVerified}</ErrorMessage>
-      </div>
       <GhostButton
         name={
           <div className="flex items-center justify-center gap-1 text-center">
@@ -198,7 +126,7 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
         }}
         placeholder="Sélectionnez un établissement"
         onCreateOption={(value) => {
-          setManualSchool({ city: manualSchool.city, fullName: value, addressVerified: undefined });
+          setManualSchool({ fullName: value, addressVerified: undefined });
           onSelectSchool(null);
           setManualFilling(true);
         }}

--- a/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
+++ b/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
@@ -14,7 +14,7 @@ export default function SchoolInFrance({ school, onSelectSchool, errors, correct
   const [city, setCity] = useState(school?.city);
   const [schools, setSchools] = useState([]);
 
-  const [manualFilling, setManualFilling] = useState((school?.fullName && !school?.id) || false);
+  const [manualFilling, setManualFilling] = useState(school?.fullName && !school?.id);
   const [manualSchool, setManualSchool] = useState(school ?? {});
 
   useEffect(() => {

--- a/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
+++ b/app/src/scenes/inscription2023/components/ShoolInFrance.jsx
@@ -9,14 +9,13 @@ import { FiChevronLeft } from "react-icons/fi";
 import { toastr } from "react-redux-toastr";
 import { getAddressOptions } from "@/services/api-adresse";
 
-export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, corrections = null }) {
+export default function SchoolInFrance({ school, onSelectSchool, errors, corrections = null }) {
   const [cities, setCities] = useState([]);
   const [city, setCity] = useState(school?.city);
   const [schools, setSchools] = useState([]);
 
-  const [manualFilling, setManualFilling] = useState(school?.fullName && !school?.id);
+  const [manualFilling, setManualFilling] = useState((school?.fullName && !school?.id) || false);
   const [manualSchool, setManualSchool] = useState(school ?? {});
-  const [errors, setErrors] = useState({});
 
   useEffect(() => {
     async function getCities() {
@@ -29,30 +28,6 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
     }
     getCities();
   }, []);
-
-  useEffect(() => {
-    if (!cities.length) return;
-
-    let errors = {};
-
-    if (!school?.fullName) {
-      errors.fullName = "Vous devez renseigner le nom de l'établissement";
-    }
-    if (!city) {
-      errors.city = "Vous devez renseigner le nom de la ville";
-    }
-
-    if (manualFilling && Object.keys(manualSchool).length) {
-      if (!manualSchool?.fullName) {
-        errors.manualFullName = "Vous devez renseigner le nom de l'établissement";
-      }
-      if (!manualSchool?.adresse) {
-        errors.manualAdresse = "Vous devez renseigner une adresse";
-      }
-    }
-
-    setErrors(errors);
-  }, [toggleVerify]);
 
   useEffect(() => {
     async function getSchools() {
@@ -79,10 +54,10 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
         data={manualSchool}
         updateData={(newData) => {
           setManualSchool({ ...manualSchool, ...newData });
-          onSelectSchool(newData);
+          onSelectSchool({ ...newData, fullName: manualSchool.fullName });
         }}
         getOptions={getAddressOptions}
-        error={errors.manualAdresse}
+        error={errors.school}
         correction={corrections?.schoolAddress}
       />
       <GhostButton
@@ -130,7 +105,7 @@ export default function SchoolInFrance({ school, onSelectSchool, toggleVerify, c
           onSelectSchool(null);
           setManualFilling(true);
         }}
-        error={errors.fullName}
+        error={errors.school}
         correction={corrections?.schoolName}
       />
     </>

--- a/app/src/scenes/preinscription/steps/stepEligibilite.jsx
+++ b/app/src/scenes/preinscription/steps/stepEligibilite.jsx
@@ -70,7 +70,7 @@ export default function StepEligibilite() {
         }
       } else {
         // School
-        if (!data?.school) {
+        if ((!data?.school?.address && !data.school.adresse) || !data?.school?.city || !data?.school?.fullName) {
           // Permet de rentrer dans la gestion d'erreur et ne pas valider le formulaire
           errors.school = "Vous devez renseigner complètement votre établissement scolaire";
         }
@@ -188,7 +188,7 @@ export default function StepEligibilite() {
                 data.isAbroad ? (
                   <SchoolOutOfFrance school={data.school} onSelectSchool={(school) => setData({ ...data, school: school })} toggleVerify={toggleVerify} />
                 ) : (
-                  <SchoolInFrance school={data.school} onSelectSchool={(school) => setData({ ...data, school: school })} toggleVerify={toggleVerify} />
+                  <SchoolInFrance school={data.school} onSelectSchool={(school) => setData({ ...data, school })} errors={error} />
                 )
               ) : !data.isAbroad ? (
                 <div className="flex-start my-4 flex flex-col">


### PR DESCRIPTION
# Description

<!-- Quick description of the PR -->

Fixes [Notion ticket](https://www.notion.so/jeveuxaider/Am-liorer-la-saisie-d-adresse-scolaire-sur-la-pr-inscription-27d6ef8379914fe6b9a146f63d4d02eb?pvs=4)
- **Problème de recherche de ville à Wallis-et-Futuna :** pas pu reproduire.
- **Amélioration de la recherche de ville :** chantier plus long que prévu car il faut modifier l'agrégation de recherche ES sur l'index schoolramses. Peut-être serait-il mieux de transformer ce champ en combobox avec une fuzzy search au fil de la saisie. Elément sorti du ticket comme convenu en stand-up.
- **Remplacement de la saisie d'adresse manuelle de l'établissement** par le composant de recherche d'adresse avec affichage des suggestions.
- Au passage : simplification de la gestion d'erreur sur l'adresse de l'établissement.

## Checklist

- [x] **⚠️ My code can have side-effects on other part of the code-base** => No.
- [x] I have added the Plausible tags/events => N/A.
- [x] I have performed a self-review of my code (and removed console.log)

## Testing instructions

Tester la saisie manuelle d'établissement à l'inscription et à la réinscription.

## Screenshots

<img width="786" alt="Screenshot 2023-11-08 at 11 39 53" src="https://github.com/betagouv/service-national-universel/assets/95406348/b0c065e4-ea83-46ec-9200-ec77b8ccd13b">