### PR TITLE
fix(api): Add 11 hours to bornBefore date for eligibility check

### DIFF
--- a/api/src/utils/cohort.js
+++ b/api/src/utils/cohort.js
@@ -25,7 +25,7 @@ async function getFilteredSessions(young, timeZoneOffset = null) {
       session.eligibility?.zones.includes(region2zone[region]) &&
       session.eligibility?.schoolLevels.includes(young.grade) &&
       session.eligibility?.bornAfter <= young.birthdateAt &&
-      session.eligibility?.bornBefore >= young.birthdateAt &&
+      session.eligibility?.bornBefore.setTime(session.eligibility?.bornBefore.getTime() + 11 * 60 * 60 * 1000) >= young.birthdateAt &&
       !!session.inscriptionStartDate &&
       session.inscriptionStartDate <= now &&
       ((session.inscriptionEndDate && session.inscriptionEndDate > now) ||


### PR DESCRIPTION
# Description

Fixes [Notion ticket](https://www.notion.so/jeveuxaider/Eligibilit-volontaire-n-le-03-07-2009-d9fc13288ba04cf286ccfe8f6202aa9c?pvs=4c)

Cas limite : volontaire née le 3 juillet 2009, date de fin d’éligibilité pour la cohorte de juillet 2024.

Deux problèmes identifiés :

1. Code : l’étape éligibilité envoie au backend la date de naissance suivante : 2009-07-03T**00**:00:00.000Z, alors que l’étape de confirmation (inscription du volontaire) envoie la date suivante : 2009-07-03T**11**:00:00.000Z. La cohorte est configurée pour accepter les volontaires nés le 2009-07-03T00:00:00.000Z **au plus tard**, donc elle apparaît dans les choix à l’étape 1 mais n’est pas valide lors de l’inscription.
Solution : enlever le +11h sur le formulaire ? Attention, cela servait à s’assurer que la date ne changeait pas selon le fuseau horaire. Trouver une autre solution à ce pb là.
2. Métier : le document [recap des dates](https://docs.google.com/spreadsheets/d/1aHS9y5_1tsbDY8_Rht0YEK3QFv1i3HONmfNHgXDNS4s/edit#gid=0) indique que le volontaire doit être né **avant** la date indiquée. Or le volontaire est acceptable s’il a 15 ans au premier jour du séjour ⇒ il doit en fait être né **au plus tard** ce jour là.
Solution : modifier les dates en DB ou bien la logique de vérification de l’éligibilité ?

Solution quick and dirty globale : ajouter +11h à la date configurée pour la cohorte dans la fonction de vérification de l’éligibilité.

## Testing instructions

Tester une inscription de volontaire né le jour correspondant au champ "bornBefore" dans la donnée de la cohorte testée. Il doit avoir accès à la cohorte à l'étape de choix du séjour et pouvoir valider sa préinscription (bouton " Envoyer un mail de vérification").
Un volontaire né un jour plus tôt ne doit pas être éligible.