### PR TITLE
fix(app): 453 - Preinscription CLE : améliorer la validation de la date de naissance

### DIFF
--- a/app/src/scenes/preinscription/steps/stepProfil.jsx
+++ b/app/src/scenes/preinscription/steps/stepProfil.jsx
@@ -50,8 +50,8 @@ export default function StepProfil() {
     if (isCLE && !data?.frenchNationality) {
       errors.frenchNationality = "Ce champ est obligatoire";
     }
-    if (isCLE && !data?.birthDate) {
-      errors.birthDate = "Ce champ est obligatoire";
+    if (isCLE && (!data?.birthDate || !dayjs(data.birthDate).isValid())) {
+      errors.birthDate = "Vous devez saisir une date de naissance valide";
     }
     if (data?.phone && !isPhoneNumberWellFormated(trimmedPhone, data?.phoneZone)) {
       errors.phone = PHONE_ZONES[data?.phoneZone]?.errorMessage;


### PR DESCRIPTION
Alignement de la validation de la date de naissance de l'étape Profil (pour les CLE) avec celle de l'étape Eligibilité (pour les HTS).