### PR TITLE
chore(lib): 1503 - Add Escadrilles Air Jeunesse option to engagement types

### DIFF
--- a/packages/lib/constants.js
+++ b/packages/lib/constants.js
@@ -594,6 +594,7 @@ const ENGAGEMENT_TYPES = [
   "Certification Union Nationale du Sport scolaire (UNSS)",
   "Engagements lycéens",
   "Préparation militaire hors offre MIG des armées",
+  "Escadrilles Air Jeunesse (EAJ)",
 ];
 
 const UNSS_TYPE = [


### PR DESCRIPTION
# Description

Fixes [Notion ticket #1503](https://www.notion.so/jeveuxaider/Ajouter-une-quivalence-de-MIG-Escadrilles-Air-Jeunesse-EAJ-e629021a81b1429b936a14baa615beb2?pvs=4)

## Testing instructions
Créer ou éditer une reconnaissance de MIG ici : http://localhost:8081/phase2/equivalence
Suivre le dossier ici : http://localhost:8082/volontaire/64596d6e8681c6361df6c5af/phase2

## Screenshots
Côté volontaire :
![Screenshot 2023-12-18 at 10 26 10](https://github.com/betagouv/service-national-universel/assets/95406348/985fd5ab-fe10-4243-b7c6-6bbb4e6b3e69)
![Screenshot 2023-12-18 at 10 25 48](https://github.com/betagouv/service-national-universel/assets/95406348/3ba27117-7fd6-4059-b3f6-8d99a76614dd)

Côté admin :
![Screenshot 2023-12-18 at 10 25 36](https://github.com/betagouv/service-national-universel/assets/95406348/b7d896e0-ab7e-4dd4-9957-14dfc21aaf0d)
