### PR TITLE
feat(app): 1591 - Home : Ecran si délai dépassé pour MIG

### DIFF
--- a/app/src/scenes/home/DelaiDepasse.jsx
+++ b/app/src/scenes/home/DelaiDepasse.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Engagement from "./components/Engagement";
+import useAuth from "@/services/useAuth";
+import Loader from "@/components/Loader";
+
+export default function DelaiDepasse() {
+  const { young } = useAuth();
+
+  if (!young) return <Loader />;
+
+  return (
+    <div className="bg-white p-[1rem] md:p-[3.5rem] md:rounded-lg md:m-10 shadow-nina">
+      <h1 className="text-gray-800 text-3xl md:text-5xl my-8">
+        <strong>{young.firstName}</strong>, votre Phase 2 n'a pas été validée.
+      </h1>
+      <p className="text-gray-700 font-semibold">Le délai pour réaliser une mission d'intérêt général a été dépassé.</p>
+      <p className="text-gray-700">Nous vous proposons de découvrir les autres formes d’engagement possible.</p>
+      <hr className="mt-12 mb-8" />
+      <Engagement />
+    </div>
+  );
+}

--- a/app/src/scenes/home/index.jsx
+++ b/app/src/scenes/home/index.jsx
@@ -7,7 +7,7 @@ import { capture } from "@/sentry";
 import API from "@/services/api";
 import { toastr } from "react-redux-toastr";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
-import { YOUNG_STATUS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, getCohortNames, hasAccessToReinscription } from "../../utils";
+import { YOUNG_STATUS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, getCohortNames, hasAccessToReinscription, isCohortOpenForPhase2 } from "../../utils";
 import { cohortAssignmentAnnouncementsIsOpenForYoung } from "../../utils/cohorts";
 import Affected from "./Affected";
 import FutureCohort from "./FutureCohort";
@@ -53,7 +53,7 @@ export default function Home() {
   const renderStep = () => {
     if (young.status === YOUNG_STATUS.REFUSED) return <RefusedV2 />;
 
-    if (["2019", "2020"].includes(young.cohort)) return <DelaiDepasse />;
+    if (!isCohortOpenForPhase2(young)) return <DelaiDepasse />;
 
     if (isReinscriptionOpen === false) {
       if (young.status === YOUNG_STATUS.ABANDONED) return <Withdrawn />;

--- a/app/src/scenes/home/index.jsx
+++ b/app/src/scenes/home/index.jsx
@@ -22,6 +22,7 @@ import WaitingCorrectionV2 from "./waitingCorrectionV2";
 import WaitingValidation from "./waitingValidation";
 import WaitingList from "./waitingList";
 import Withdrawn from "./withdrawn";
+import DelaiDepasse from "./DelaiDepasse";
 
 export default function Home() {
   useDocumentTitle("Accueil");
@@ -51,6 +52,8 @@ export default function Home() {
 
   const renderStep = () => {
     if (young.status === YOUNG_STATUS.REFUSED) return <RefusedV2 />;
+
+    if (["2019", "2020"].includes(young.cohort)) return <DelaiDepasse />;
 
     if (isReinscriptionOpen === false) {
       if (young.status === YOUNG_STATUS.ABANDONED) return <Withdrawn />;

--- a/app/src/utils/index.js
+++ b/app/src/utils/index.js
@@ -61,6 +61,7 @@ export function permissionPhase1(y) {
 
 export function permissionPhase2(y) {
   if (!permissionPhase1(y)) return false;
+  if (!isCohortOpenForPhase2(y)) return false;
   return (
     (y.status !== YOUNG_STATUS.WITHDRAWN &&
       (![YOUNG_PHASE.INSCRIPTION, YOUNG_PHASE.COHESION_STAY].includes(y.phase) ||
@@ -73,6 +74,16 @@ export function permissionPhase2(y) {
 export function permissionPhase3(y) {
   if (!permissionApp(y)) return false;
   return (y.status !== YOUNG_STATUS.WITHDRAWN && y.statusPhase2 === YOUNG_STATUS_PHASE2.VALIDATED) || y.statusPhase3 === YOUNG_STATUS_PHASE3.VALIDATED;
+}
+
+export function isCohortOpenForPhase2(young) {
+  // Users from 2019 and 2020 cannot access phase 2 anymore, except if they have an application currently validated or in progress.
+  const userIsDoingAMission = young.phase2ApplicationStatus.some((status) => ["VALIDATED", "IN_PROGRESS"].includes(status));
+  const cohortIsTooOld = ["2019", "2020"].includes(young.cohort);
+  if (cohortIsTooOld && !userIsDoingAMission) {
+    return false;
+  }
+  return true;
 }
 
 // from the end of the cohort's last day


### PR DESCRIPTION
# Description

Fixes [Notion ticket #1591](https://www.notion.so/jeveuxaider/iii-Fermer-candidatures-MIG-cohortes-2019-2020-Affichage-cran-sp-cifique-3060186624e14f9e992533904d56c754?pvs=4)

- Ecran d'accueil spécifique pour les volontaires des cohortes 2019 et 2020 qui n'ont pas de mission en cours.
- Blocage du bouton "Phase 2" dans le menu.

## Testing instructions

Exemple de volontaire concerné : http://localhost:8082/volontaire/60339130b00e1277e13bc35d/phase2

## Screenshots
![Screenshot 2023-12-19 at 09 30 53](https://github.com/betagouv/service-national-universel/assets/95406348/7a219808-0391-4358-b05f-12c8be08a7f3)