### PR TITLE
chore(api, app): 477 - Add birthdate validation to young signup

### DIFF
--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -92,6 +92,7 @@ class Auth {
 
       const formatedDate = birthdateAt;
       formatedDate.setUTCHours(11, 0, 0);
+      if (!validateBirthDate(formatedDate)) return res.status(400).send({ ok: false, user: null, code: ERRORS.INVALID_PARAMS });
 
       let countDocuments = await this.model.countDocuments({ lastName, firstName, birthdateAt: formatedDate });
       if (countDocuments > 0) return res.status(409).send({ ok: false, code: ERRORS.USER_ALREADY_REGISTERED });

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -7,7 +7,7 @@ const config = require("./config");
 const { sendTemplate, regexp_exception_staging } = require("./sendinblue");
 const { JWT_SIGNIN_MAX_AGE, JWT_TRUST_TOKEN_MAX_AGE, JWT_SIGNIN_VERSION, JWT_TRUST_TOKEN_VERSION, checkJwtTrustTokenVersion } = require("./jwt-options");
 const { COOKIE_SIGNIN_MAX_AGE, COOKIE_TRUST_TOKEN_JWT_MAX_AGE, cookieOptions } = require("./cookie-options");
-const { validatePassword, ERRORS, isYoung, STEPS2023, isReferent } = require("./utils");
+const { validatePassword, ERRORS, isYoung, STEPS2023, isReferent, validateBirthDate } = require("./utils");
 const { SENDINBLUE_TEMPLATES, PHONE_ZONES_NAMES_ARR, isFeatureEnabled, FEATURES_NAME, YOUNG_SOURCE, YOUNG_SOURCE_LIST } = require("snu-lib");
 const { serializeYoung, serializeReferent } = require("./utils/serializer");
 const { validateFirstName } = require("./utils/validator");
@@ -206,6 +206,7 @@ class Auth {
 
       const formatedDate = birthdateAt;
       formatedDate.setUTCHours(11, 0, 0);
+      if (!validateBirthDate(formatedDate)) return res.status(400).send({ ok: false, user: null, code: ERRORS.INVALID_PARAMS });
 
       let countDocuments = await this.model.countDocuments({ lastName, firstName, birthdateAt: formatedDate });
       if (countDocuments > 0) return res.status(409).send({ ok: false, code: ERRORS.USER_ALREADY_REGISTERED });

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -37,6 +37,7 @@ const {
 const { YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, SENDINBLUE_TEMPLATES, YOUNG_STATUS, APPLICATION_STATUS, FILE_STATUS_PHASE1, ROLES, SUB_ROLES } = require("snu-lib");
 const { capture } = require("../sentry");
 const { getCohortDateInfo } = require("./cohort");
+const dayjs = require("dayjs");
 
 // Timeout a promise in ms
 const timeout = (prom, time) => {
@@ -945,6 +946,14 @@ const STEPS2023 = {
   DONE: "DONE",
 };
 
+const validateBirthDate = (date) => {
+  const d = dayjs(date);
+  if (!d.isValid()) return false;
+  if (d.isBefore(dayjs(new Date(2000, 0, 1)))) return false;
+  if (d.isAfter(dayjs())) return false;
+  return true;
+};
+
 module.exports = {
   timeout,
   uploadFile,
@@ -992,4 +1001,5 @@ module.exports = {
   getTransporter,
   getMetaDataFile,
   deleteFilesByList,
+  validateBirthDate,
 };

--- a/app/src/scenes/inscription2023/utils/index.js
+++ b/app/src/scenes/inscription2023/utils/index.js
@@ -12,6 +12,7 @@ import passport from "../../../assets/IDProof/passport.jpg";
 import passportDate from "../../../assets/IDProof/passportDate.jpg";
 import API from "@/services/api";
 import { capture } from "@/sentry";
+import dayjs from "dayjs";
 
 countries.registerLocale(fr);
 const countriesList = countries.getNames("fr", { select: "official" });
@@ -120,4 +121,12 @@ export async function getSchools(city) {
   } catch (e) {
     capture(e);
   }
+}
+
+export function validateBirthDate(date) {
+  const d = dayjs(date);
+  if (!d.isValid()) return false;
+  if (d.isBefore(dayjs(new Date(2000, 0, 1)))) return false;
+  if (d.isAfter(dayjs())) return false;
+  return true;
 }

--- a/app/src/scenes/preinscription/steps/stepEligibilite.jsx
+++ b/app/src/scenes/preinscription/steps/stepEligibilite.jsx
@@ -29,6 +29,7 @@ import ProgressBar from "../components/ProgressBar";
 import { supportURL } from "@/config";
 import ErrorMessage from "@/components/dsfr/forms/ErrorMessage";
 import InlineButton from "@/components/dsfr/ui/buttons/InlineButton";
+import { validateBirthDate } from "@/scenes/inscription2023/utils";
 
 export default function StepEligibilite() {
   const isLoggedIn = !!useSelector((state) => state?.Auth?.young);
@@ -70,7 +71,7 @@ export default function StepEligibilite() {
       errors.scolarity = "Choisissez un niveau de scolarité";
     }
     // Birthdate
-    if (!data?.birthDate || !dayjs(data.birthDate).isValid()) {
+    if (!data?.birthDate || !validateBirthDate(data?.birthDate)) {
       errors.birthDate = "Vous devez saisir une date de naissance valide";
     }
 

--- a/app/src/scenes/preinscription/steps/stepProfil.jsx
+++ b/app/src/scenes/preinscription/steps/stepProfil.jsx
@@ -26,6 +26,7 @@ import API from "@/services/api";
 import { setYoung } from "@/redux/auth/actions";
 import { capture } from "@/sentry";
 import { RiInformationLine } from "react-icons/ri";
+import { validateBirthDate } from "@/scenes/inscription2023/utils";
 
 export default function StepProfil() {
   const [data, setData] = React.useContext(PreInscriptionContext);
@@ -50,7 +51,7 @@ export default function StepProfil() {
     if (isCLE && !data?.frenchNationality) {
       errors.frenchNationality = "Ce champ est obligatoire";
     }
-    if (isCLE && (!data?.birthDate || !dayjs(data.birthDate).isValid())) {
+    if (isCLE && (!data?.birthDate || !validateBirthDate(data?.birthDate))) {
       errors.birthDate = "Vous devez saisir une date de naissance valide";
     }
     if (data?.phone && !isPhoneNumberWellFormated(trimmedPhone, data?.phoneZone)) {


### PR DESCRIPTION
Fixes [Notion ticket](https://www.notion.so/jeveuxaider/CLE-Format-de-la-date-de-naissance-figer-b857a39ae3444651b250e9252b825fa6?pvs=4)

Ajout de la règle suivante sur la validation du formulaire en front et la validation des paramètres en back : la date de naissance doit être comprise entre le 1er janvier 2000 et la date du jour.