### PR TITLE
TF : Image_tags output & CI concurrency improved

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 jobs:
 
   prepare:
@@ -73,6 +69,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [prepare, build]
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
     env:
       SCW_ACCESS_KEY: ${{ secrets.SCW_CI_DEPLOY_ACCESS_KEY }}
       SCW_SECRET_KEY: ${{ secrets.SCW_CI_DEPLOY_SECRET_KEY }}

--- a/.github/workflows/deploy-custom-env.yml
+++ b/.github/workflows/deploy-custom-env.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: false
-
 jobs:
 
   prepare:
@@ -85,6 +81,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [prepare, build]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: false
     env:
       SCW_ACCESS_KEY: ${{ secrets.SCW_CI_DEPLOY_ACCESS_KEY }}
       SCW_SECRET_KEY: ${{ secrets.SCW_CI_DEPLOY_SECRET_KEY }}

--- a/.github/workflows/destroy-custom-env.yml
+++ b/.github/workflows/destroy-custom-env.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: false
-
 
 jobs:
 
@@ -61,6 +57,9 @@ jobs:
   destroy:
     runs-on: ubuntu-latest
     needs: [prepare]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: false
     env:
       SCW_ACCESS_KEY: ${{ secrets.SCW_CI_DEPLOY_ACCESS_KEY }}
       SCW_SECRET_KEY: ${{ secrets.SCW_CI_DEPLOY_SECRET_KEY }}

--- a/terraform/environments/ci/main.tf
+++ b/terraform/environments/ci/main.tf
@@ -59,6 +59,24 @@ resource "scaleway_registry_namespace" "main" {
   is_public   = false
 }
 
+data "scaleway_registry_image" "api" {
+  name = "api"
+  namespace_id = scaleway_registry_namespace.main.id
+  project_id = scaleway_account_project.main.id
+}
+
+data "scaleway_registry_image" "admin" {
+  name = "admin"
+  namespace_id = scaleway_registry_namespace.main.id
+  project_id = scaleway_account_project.main.id
+}
+
+data "scaleway_registry_image" "app" {
+  name = "app"
+  namespace_id = scaleway_registry_namespace.main.id
+  project_id = scaleway_account_project.main.id
+}
+
 # Application user
 resource "scaleway_iam_application" "main" {
   name        = "snu-deploy-${local.env}"
@@ -302,4 +320,13 @@ output "admin_endpoint" {
 }
 output "image_tag" {
   value = split(":", scaleway_container.api.registry_image)[1]
+}
+output "api_image_tags" {
+  value = data.scaleway_registry_image.api.tags
+}
+output "admin_image_tags" {
+  value = data.scaleway_registry_image.admin.tags
+}
+output "app_image_tags" {
+  value = data.scaleway_registry_image.app.tags
 }

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -37,6 +37,23 @@ resource "scaleway_registry_namespace" "main" {
   description = "SNU registry for production"
   is_public   = false
 }
+data "scaleway_registry_image" "api" {
+  name = "api"
+  namespace_id = scaleway_registry_namespace.main.id
+  project_id = scaleway_account_project.main.id
+}
+
+data "scaleway_registry_image" "admin" {
+  name = "admin"
+  namespace_id = scaleway_registry_namespace.main.id
+  project_id = scaleway_account_project.main.id
+}
+
+data "scaleway_registry_image" "app" {
+  name = "app"
+  namespace_id = scaleway_registry_namespace.main.id
+  project_id = scaleway_account_project.main.id
+}
 
 # Application user
 resource "scaleway_iam_application" "main" {
@@ -81,4 +98,13 @@ output "project_id" {
 }
 output "registry_endpoint" {
   value = scaleway_registry_namespace.main.endpoint
+}
+output "api_image_tags" {
+  value = data.scaleway_registry_image.api.tags
+}
+output "admin_image_tags" {
+  value = data.scaleway_registry_image.admin.tags
+}
+output "app_image_tags" {
+  value = data.scaleway_registry_image.app.tags
 }


### PR DESCRIPTION
- Concurrency is set at the deploy job level in order to allow build step to be done in parallel
- TF stack outputs are updated to provides tag associated with docker image