### PR TITLE
fix(api): GET referent - do not crash when resource to populate is not found

### DIFF
--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -1067,13 +1067,13 @@ router.get("/:id", passport.authenticate("referent", { session: false, failWithE
       let valueField = { $in: [referent._id] };
       if (referent.role === ROLES.REFERENT_CLASSE) {
         const classe = await ClasseModel.find({ referentClasseIds: { $in: referent._id } });
-        if (!classe) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+        if (!classe) return referent;
         valueField = classe[0].etablissementId;
         referent.classe = classe;
       }
       query[searchField] = valueField;
       const etablissement = await EtablissementModel.findOne(query)?.lean();
-      if (!etablissement) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+      if (!etablissement) return referent;
       referent.etablissement = etablissement;
       return referent;
     };

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -1080,6 +1080,7 @@ router.get("/:id", passport.authenticate("referent", { session: false, failWithE
 
     if ([ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE].includes(referent.role)) {
       referent = await populateWithCLE(referent);
+      if (!referent.etablissement || !referent.classe) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
     }
 
     return res.status(200).send({ ok: true, data: referent });

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -1061,26 +1061,33 @@ router.get("/:id", passport.authenticate("referent", { session: false, failWithE
     if (!canViewReferent(req.user, referent)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     referent = serializeReferent(referent, req.user);
 
-    const populateWithCLE = async (referent) => {
-      const searchField = referent.role === ROLES.REFERENT_CLASSE ? "_id" : referent.subRole === SUB_ROLES.referent_etablissement ? "referentEtablissementIds" : "coordinateurIds";
-      const query = {};
-      let valueField = { $in: [referent._id] };
-      if (referent.role === ROLES.REFERENT_CLASSE) {
-        const classe = await ClasseModel.find({ referentClasseIds: { $in: referent._id } });
-        if (!classe) return referent;
-        valueField = classe[0].etablissementId;
-        referent.classe = classe;
-      }
-      query[searchField] = valueField;
-      const etablissement = await EtablissementModel.findOne(query)?.lean();
-      if (!etablissement) return referent;
+    // Populate les chefs d'établissement avec leur établissement
+    if (referent.subRole === SUB_ROLES.referent_etablissement) {
+      const etablissement = await EtablissementModel.findOne({ referentEtablissementIds: referent._id }).lean();
+      if (!etablissement) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+      // Do not return res() in a helper function, only at the root of the route handler.
       referent.etablissement = etablissement;
-      return referent;
-    };
+    }
 
-    if ([ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE].includes(referent.role)) {
-      referent = await populateWithCLE(referent);
-      if (!referent.etablissement || !referent.classe) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+    // Populate les coordos avec leur établissement et leurs classes le cas échéant
+    if (referent.subRole === SUB_ROLES.coordinateur_cle) {
+      const etablissement = await EtablissementModel.findOne({ coordinateurIds: referent._id }).lean();
+      if (!etablissement) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+      referent.etablissement = etablissement;
+
+      const classes = await ClasseModel.find({ referentClasseIds: referent._id }).lean();
+      referent.classe = classes;
+    }
+
+    // Populate les référents de classe avec leur établissement et leurs classes
+    if (referent.role === ROLES.REFERENT_CLASSE) {
+      const classes = await ClasseModel.find({ referentClasseIds: referent._id }).lean();
+      if (!classes) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+      referent.classe = classes;
+
+      const etablissement = await EtablissementModel.findById(classes[0].etablissementId).lean();
+      if (!etablissement) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+      referent.etablissement = etablissement;
     }
 
     return res.status(200).send({ ok: true, data: referent });


### PR DESCRIPTION
https://sentry.selego.co/organizations/sentry/discover/snu-production:69da2d9b965f4a8da79f343fb143ae9e/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=Error%3A+Cannot+set+headers+after+they+are+sent+to+the+client&project=13&query=issue%3ASNU-PRODUCTION-990&sort=-timestamp&statsPeriod=7d&yAxis=count%28%29