### PR TITLE
feat(api): HTS > CLE keep phase2 open if phase has been DONE

### DIFF
--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -310,6 +310,13 @@ const Schema = new mongoose.Schema({
       description: "Date de dernière modification du statut lié à la seconde phase",
     },
   },
+  statusPhase2OpenedAt: {
+    type: Date,
+    immutable: true,
+    documentation: {
+      description: "Date d'ouverture de la seconde phase",
+    },
+  },
   statusPhase2ValidatedAt: {
     type: Date,
     documentation: {

--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -312,7 +312,6 @@ const Schema = new mongoose.Schema({
   },
   statusPhase2OpenedAt: {
     type: Date,
-    immutable: true,
     documentation: {
       description: "Date d'ouverture de la seconde phase",
     },

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -719,7 +719,7 @@ async function updateStatusPhase1(young, validationDateWithDays, user) {
         if (young?.departSejourMotif === "Exclusion") {
           young.set({ statusPhase1: "NOT_DONE" });
         } else {
-          young.set({ statusPhase1: "DONE" });
+          young.set({ statusPhase1: "DONE", statusPhase2OpenedAt: now });
         }
       } else {
         // Sinon on ne valide pas sa phase 1.

--- a/app/src/utils/index.js
+++ b/app/src/utils/index.js
@@ -89,6 +89,7 @@ export function hasAccessToPhase2(young) {
 
 // from the end of the cohort's last day
 export function isYoungCanApplyToPhase2Missions(young) {
+  if (young.statusPhase2OpenedAt && new Date(young.statusPhase2OpenedAt) < new Date()) return true;
   const hasYoungPhase1DoneOrExempted = [YOUNG_STATUS_PHASE1.DONE, YOUNG_STATUS_PHASE1.EXEMPTED].includes(young.statusPhase1);
   return isCohortDone(young.cohort, 1) && hasYoungPhase1DoneOrExempted;
 }

--- a/app/src/utils/index.js
+++ b/app/src/utils/index.js
@@ -60,7 +60,8 @@ export function permissionPhase1(y) {
 }
 
 export function permissionPhase2(y) {
-  if (!permissionPhase1(y)) return false;
+  if (!y) return false;
+  if (y.statusPhase2OpenedAt && new Date(y.statusPhase2OpenedAt) < new Date()) return true;
   if (!hasAccessToPhase2(y)) return false;
   return (
     (y.status !== YOUNG_STATUS.WITHDRAWN &&

--- a/packages/lib/sessions.js
+++ b/packages/lib/sessions.js
@@ -234,6 +234,7 @@ function shouldForceRedirectToInscription(young, isInscriptionModificationOpen =
 
 //@todo : for browser apps better logic in app isYoungCanApplyToPhase2Missions (also takes into account timezone)
 function canApplyToPhase2(young, cohort) {
+  if (young.statusPhase2OpenedAt && new Date(young.statusPhase2OpenedAt) < new Date()) return true;
   const now = new Date();
   const dateEnd = getCohortEndDate(young, cohort);
   return ["DONE", "EXEMPTED"].includes(young.statusPhase1) && now >= dateEnd;


### PR DESCRIPTION
Fixes [Notion: Passage HTS phase 1 validé et phase 2 en cours vers CLE](https://www.notion.so/jeveuxaider/Passage-HTS-phase-1-valid-et-phase-2-en-cours-vers-CLE-60ccb825abf94736b1a2aa8ada346026)

PR côté Script https://github.com/selego/service-national-universel-scripts/pull/44