### PR TITLE
CI terraform : lock-timeout option

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -107,12 +107,13 @@ jobs:
 
       - name: Terraform plan
         working-directory: ${{ env.ci_directory }}
+        # add -lock-timeout option until https://github.com/hashicorp/terraform/issues/33217 is fixed
         run: |
-          terraform plan -no-color -input=false \
+          terraform plan -no-color -input=false  -lock-timeout=15m \
             -var="image_tag=${{ needs.prepare.outputs.image_tag }}"
 
       - name: Terraform auto-apply
         working-directory: ${{ env.ci_directory }}
         run: |
-          terraform apply -no-color -input=false -auto-approve \
+          terraform apply -no-color -input=false -auto-approve -lock-timeout=15m \
             -var="image_tag=${{ needs.prepare.outputs.image_tag }}"

--- a/.github/workflows/deploy-custom-env.yml
+++ b/.github/workflows/deploy-custom-env.yml
@@ -182,14 +182,15 @@ jobs:
 
       - name: Terraform plan
         working-directory: ${{ env.custom_directory }}
+        # add -lock-timeout option until https://github.com/hashicorp/terraform/issues/33217 is fixed
         run: |
-          terraform plan -no-color -input=false \
+          terraform plan -no-color -input=false -lock-timeout=15m \
             -var="image_tag=${{ needs.prepare.outputs.image_tag }}"
 
       - name: Terraform auto-apply
         working-directory: ${{ env.custom_directory }}
         run: |
-          terraform apply -no-color -input=false -auto-approve \
+          terraform apply -no-color -input=false -auto-approve -lock-timeout=15m \
             -var="image_tag=${{ needs.prepare.outputs.image_tag }}"
 
       - name: Add comment to PR


### PR DESCRIPTION
Add lock-timeout option to plan et apply tf step in CI.

Prevent failure of actions, when CI and Custom Environment are deployed simultaneously, [due to a terraform bug on pg backend](https://github.com/hashicorp/terraform/issues/33217)


