### PR TITLE
fix(api): passage du statut du jeune en WA apres consentement par un ref

### DIFF
--- a/api/src/controllers/young-edition.js
+++ b/api/src/controllers/young-edition.js
@@ -492,6 +492,7 @@ function generateChanges(value, young) {
   };
 
   setIfTrue(value.consent, "parentAllowSNU", "true");
+  setIfTrue(value.consent, "status", YOUNG_STATUS.WAITING_VALIDATION);
   setIfTrue(value.consent, "parent1AllowSNU", "true");
   setIfTrue(value.consent, "parent1ValidationDate", new Date());
 


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Le-volontaire-ne-passe-pas-en-attente-de-validation-lorsque-le-consentement-est-donn-depuis-admin-4898c99c8be64ecd89fa3502dafd51c8?pvs=4