### PR TITLE
fix(lib/admin): 1810 - Dev mode & env by domain

### DIFF
--- a/admin/src/app.jsx
+++ b/admin/src/app.jsx
@@ -249,10 +249,8 @@ const Home = (props) => {
               <RestrictedRoute path="/mes-eleves" component={VolontaireCle} />
               <RestrictedRoute path="/mes-contacts" component={Contact} />
               {/* Only for developper eyes... */}
-              {isFeatureEnabled(FEATURES_NAME.DEVELOPERS_MODE, user?.role, environment) ? (
-                <RestrictedRoute path="/develop-assets" component={DevelopAssetsPresentationPage} />
-              ) : null}
-              {isFeatureEnabled(FEATURES_NAME.DEVELOPERS_MODE, user?.role, environment) ? <RestrictedRoute path="/design-system" component={DesignSystemPage} /> : null}
+              {isFeatureEnabled(FEATURES_NAME.DEVELOPERS_MODE, user?.role) ? <RestrictedRoute path="/develop-assets" component={DevelopAssetsPresentationPage} /> : null}
+              {isFeatureEnabled(FEATURES_NAME.DEVELOPERS_MODE, user?.role) ? <RestrictedRoute path="/design-system" component={DesignSystemPage} /> : null}
               {/* DASHBOARD */}
               <RestrictedRoute path="/dashboard" component={renderDashboardV2} />
               <RestrictedRoute path="/" component={renderDashboardV2} />

--- a/admin/src/components/drawer/SideBar.jsx
+++ b/admin/src/components/drawer/SideBar.jsx
@@ -216,7 +216,7 @@ const SideBar = (props) => {
   //Components to display depending on user role
   const godItems = [Dashboard, Volontaire, Inscriptions, SejoursGod, Engagement, Utilisateurs, Dev];
   const adminItems = [Dashboard, Volontaire, Inscriptions, SejoursAdmin, Engagement, Utilisateurs];
-  isFeatureEnabled(FEATURES_NAME.DEVELOPERS_MODE) && adminItems.push(Dev);
+  isFeatureEnabled(FEATURES_NAME.DEVELOPERS_MODE, user?.role) && adminItems.push(Dev);
   const refItems = [Dashboard, Volontaire, Inscriptions, SejoursRef, Engagement, Admisnistrateur];
   const headCenterItems = [Dashboard, VolontaireHeadCenter, CentresHeadCenter, PlanDeTransport, Contenus, Utilisateurs];
   const transporteurItems = [Point, Centre, Schema, PlanDeTransport];
@@ -224,7 +224,6 @@ const SideBar = (props) => {
   const supervisorItems = [Dashboard, Candidature, Network, StructureSupervisor, Missions, Utilisateurs];
   const visitorItems = [Dashboard];
   const dsnjItems = [ExportDsnj];
-  // FIXME [CLE]: remove dev mode
   const institutionItems = [Institution, Classe, VolontaireCle, Contact];
 
   const getItems = () => {

--- a/packages/lib/features.js
+++ b/packages/lib/features.js
@@ -1,5 +1,3 @@
-import { ROLES } from "snu-lib";
-
 const ENVS = {
   development: "development",
   staging: "staging",
@@ -34,10 +32,9 @@ const features = {
   },
 };
 
-//Force redeploy
-
 function isFeatureEnabled(featureName, userRole, environment) {
   const feature = features[featureName];
+  environment = environment || getEnvFromDomain();
   if (!feature || !ENVS[environment]) {
     return false;
   }
@@ -45,6 +42,19 @@ function isFeatureEnabled(featureName, userRole, environment) {
   // If the environment is not defined then the feature is enabled
   // or if the environment is defined and the user has the role
   return !feature[environment] || feature[environment].includes(userRole);
+}
+
+function getEnvFromDomain() {
+  if (!window) throw new Error("Cannot be called outside of the browser");
+
+  const domain = window.location.hostname;
+  if (domain.includes("snu.gouv.fr")) {
+    return ENVS.production;
+  }
+  if (domain.includes("beta-snu.dev")) {
+    return ENVS.staging;
+  }
+  return ENVS.development;
 }
 
 export { FEATURES_NAME, isFeatureEnabled };


### PR DESCRIPTION
Fixs [Notion: DevMode actif partout sauf en prod](https://www.notion.so/jeveuxaider/DevMode-actif-partout-sauf-en-prod-2114c27c13f14bf5ac46073031fe7f5e)

J'ai écris cette fonction car depuis la Dockerisation, nos environnements sont tous de `PRODUCTION` bien qu'ils soient sur différents domaines et servent différentes fonctions.

| Name | Domain | Envrionment |
|---|---|---|
| Production | *.snu.gouv.fr | `production` |
| Staging / Demo | *.beta-snu.dev | `staging` |
| CI | *.ci.beta-snu.dev | `staging` |
| Custom env | **.ci.beta-snu.dev | `staging` |
| Local | localhost:**** |`development`|

```javascript
function getEnvFromDomain() {
  if (!window) throw new Error("Cannot be called outside of the browser");

  const domain = window.location.hostname;
  if (domain.includes("snu.gouv.fr")) {
    return ENVS.production;
  }
  if (domain.includes("beta-snu.dev")) {
    return ENVS.staging;
  }
  return ENVS.development;
}
```