### PR TITLE
fix(api): probleme pour la date de peremption des CNI

### DIFF
--- a/api/src/controllers/young-edition.js
+++ b/api/src/controllers/young-edition.js
@@ -44,6 +44,7 @@ const config = require("../config");
 const YoungObject = require("../models/young");
 const LigneDeBusModel = require("../models/PlanDeTransport/ligneBus");
 const SessionPhase1Model = require("../models/sessionPhase1");
+const CohortModel = require("../models/cohort");
 const { APP_URL } = require("../config");
 
 const youngEmployedSituationOptions = [YOUNG_SITUATIONS.EMPLOYEE, YOUNG_SITUATIONS.INDEPENDANT, YOUNG_SITUATIONS.SELF_EMPLOYED, YOUNG_SITUATIONS.ADAPTED_COMPANY];
@@ -130,6 +131,11 @@ router.put("/:id/identite", passport.authenticate("referent", { session: false, 
     }
 
     if (value.birthdateAt) value.birthdateAt = value.birthdateAt.setUTCHours(11, 0, 0);
+
+    if (value.latestCNIFileExpirationDate) {
+      const cohort = await CohortModel.findOne({ name: young.cohort });
+      value.CNIFileNotValidOnStart = value.latestCNIFileExpirationDate < new Date(cohort.dateStart);
+    }
 
     // test de déménagement.
     if (young.department !== value.department && value.department !== null && value.department !== undefined && young.department !== null && young.department !== undefined) {

--- a/api/src/controllers/young-edition.js
+++ b/api/src/controllers/young-edition.js
@@ -134,7 +134,7 @@ router.put("/:id/identite", passport.authenticate("referent", { session: false, 
 
     if (value.latestCNIFileExpirationDate) {
       const cohort = await CohortModel.findOne({ name: young.cohort });
-      value.CNIFileNotValidOnStart = value.latestCNIFileExpirationDate < new Date(cohort.dateStart);
+      value.CNIFileNotValidOnStart = new Date(value.latestCNIFileExpirationDate) < new Date(cohort.dateStart);
     }
 
     // test de déménagement.

--- a/api/src/controllers/young/documents.js
+++ b/api/src/controllers/young/documents.js
@@ -246,7 +246,7 @@ router.post(
         category: Joi.string(),
         expirationDate: Joi.date(),
         side: Joi.string().valid("recto", "verso"),
-      }).validate(req.body, { stripUnknown: true });
+      }).validate(JSON.parse(req.body.body), { stripUnknown: true });
       if (bodyError) {
         capture(bodyError);
         return res.status(400).send({ ok: false, code: ERRORS.INVALID_BODY });


### PR DESCRIPTION
probleme constaté :
 - lorsqu'on trie les jeune selon si leur CNI est périmée ou non, beaucoup de jeune qui sortent ont en fait une CNI valide
 Investigation : 
 -probleme du au router post young/document/:key, ou lorsqu'une CNI est uploadé le body qui contient la categorie et la date de peremption est vide --> champ young.CNIFileNotValidOnStart: "true"
 resolution : 
 -le body envoyé est une string, le parsé pour avoir un objet
 - faire un script de rattrapage des jeunes
 
 lien du script de rattrapage des 800 jeunes impactés :
 https://github.com/selego/service-national-universel-scripts/blob/main/fixes/fix-young-CNI/fix-young-CNI-expirationdate.js
 