### PR TITLE
feat(api): Fix some error on DeleteCNICron

### DIFF
--- a/api/src/crons/deleteCNIAndSpecificAmenagementType.js
+++ b/api/src/crons/deleteCNIAndSpecificAmenagementType.js
@@ -10,7 +10,7 @@ exports.handler = async () => {
   const finishedCohortNames = await getCohortsFinishedSinceYesterday();
 
   const where = {
-    statusPhase1: { $in: ["DONE", "NOT_DONE", "WITHDRAWN"] },
+    statusPhase1: { $in: ["DONE", "NOT_DONE", "WITHDRAWN", "VALIDATED"] },
     status: { $in: ["WITHDRAWN", "ABANDONED", "REFUSED", "NOT_ELIGIBLE", "NOT_AUTORISED"] },
     cohort: { $in: finishedCohortNames },
     latestCNIFileCategory: { $ne: "deleted" },

--- a/api/src/crons/deleteCNIAndSpecificAmenagementType.js
+++ b/api/src/crons/deleteCNIAndSpecificAmenagementType.js
@@ -10,8 +10,8 @@ exports.handler = async () => {
   const finishedCohortNames = await getCohortsFinishedSinceYesterday();
 
   const where = {
-    statusPhase1: { $in: ["DONE", "NOT_DONE", "WITHDRAWN", "VALIDATED"] },
-    status: { $in: ["WITHDRAWN", "ABANDONED", "REFUSED", "NOT_ELIGIBLE", "NOT_AUTORISED"] },
+    statusPhase1: { $in: ["DONE", "NOT_DONE", "WITHDRAWN"] },
+    status: { $in: ["WITHDRAWN", "ABANDONED", "REFUSED", "NOT_ELIGIBLE", "NOT_AUTORISED", "VALIDATED"] },
     cohort: { $in: finishedCohortNames },
     latestCNIFileCategory: { $ne: "deleted" },
   };

--- a/api/src/services/gdpr.js
+++ b/api/src/services/gdpr.js
@@ -13,8 +13,10 @@ async function deleteSensitiveData(youngId, mode = "save") {
       return { Key: e.Key };
     });
     console.log("Deleting files: ", CNIFileArray);
-    await deleteFilesByList(CNIFileArray);
-    fileStatus = "DELETED";
+    if (mode === "save") {
+      await deleteFilesByList(CNIFileArray);
+      fileStatus = "DELETED";
+    }
   } catch (error) {
     fileStatus = "NOT_FOUND";
     console.log(error);


### PR DESCRIPTION
Règles :
On doit supprimé automatiquement les CNI et Specific amenagement des cohortes qui se finissent !
```
  statusPhase1: { $in: ["DONE", "NOT_DONE", "WITHDRAWN"] },
    status: { $in: ["WITHDRAWN", "ABANDONED", "REFUSED", "NOT_ELIGIBLE", "NOT_AUTORISED", "VALIDATED"] },
``` 
Pour moi il manquait le VALIDATED, car on supprimait bien les CNI mais pas des jeunes qui avaient validés leur séjour finit.

petit warning, on mode test on écrasait les CNI car il manquait cette condition :
```
   if (mode === "save") {
      await deleteFilesByList(CNIFileArray);
      fileStatus = "DELETED";
    }
``` 