### PR TITLE
chore(misc): config renovate to auto merge minor dependancies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "automergeType": "pr",
-      "automergeSchedule": ["before 8am on Tuesdays"]
+      "automergeSchedule": ["before 11am on Tuesdays"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "extends": [":semanticCommitTypeAll(chore)", ":semanticCommitScope(lib)"],
   "packageRules": [
     {
       "description": "Automerge non-major updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeSchedule": ["before 8am on Tuesdays"]
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

Configuration du bot renovate pour merger automatiquement les mise à jour de dépendances mineurs tous les mardi matin.

**Todo**

- [x] Mise en place de l'auto-merge le mardi (minor)
- [x] Renommage des PR de type deps pour etre compliant au title checker

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Strat-gie-de-merge-des-PR-de-type-deps-d76bfa0c0819462a8bed8a2d20aacd59
