### PR TITLE
chore(github): bump codeql-action to v3

### DIFF
--- a/.github/workflows/eslint_report.yml
+++ b/.github/workflows/eslint_report.yml
@@ -52,7 +52,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ matrix.directory }}/eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -82,6 +82,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
**Description**

https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

![image](https://github.com/betagouv/service-national-universel/assets/6529851/1c2bbbb2-9884-46df-b36e-187828138469)
