### PR TITLE
fix(admin): 664 - reduire la taille des requetes volontaires

### DIFF
--- a/admin/src/components/buttons/MailAttestationButton.jsx
+++ b/admin/src/components/buttons/MailAttestationButton.jsx
@@ -37,7 +37,7 @@ export default function MailAttestationButton({ young, children, type, template,
           setModal({
             isOpen: true,
             onConfirm,
-            title: "Envoie de document par mail",
+            title: "Envoi de document par mail",
             message: `Êtes-vous sûr de vouloir transmettre le document "${placeholder}" par mail à ${young.email} ?`,
           });
         }}>

--- a/admin/src/components/filters-system-v2/components/filters/utils.js
+++ b/admin/src/components/filters-system-v2/components/filters/utils.js
@@ -105,6 +105,9 @@ export const saveTitle = (selectedFilters, filters) => {
 };
 
 export function normalizeString(s) {
+  if (typeof s !== "string") {
+    return "";
+  }
   return s
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")

--- a/admin/src/scenes/phase0/utils/index.js
+++ b/admin/src/scenes/phase0/utils/index.js
@@ -1,109 +1,83 @@
-import Joi from "joi";
-import { PHONE_ZONES_NAMES_ARR, YOUNG_SITUATIONS, GRADES } from "snu-lib";
-
 export function filterDataObject(data, section) {
-  const filteredData = {};
   let bodySchema = {};
-
   if (section === "identite") {
-    bodySchema = Joi.object().keys({
-      firstName: Joi.string().trim(),
-      lastName: Joi.string().uppercase(),
-      gender: Joi.string().valid("male", "female"),
-      email: Joi.string().lowercase().trim(),
-      phone: Joi.string().trim(),
-      phoneZone: Joi.string()
-        .trim()
-        .valid(...PHONE_ZONES_NAMES_ARR)
-        .allow("", null),
-      latestCNIFileExpirationDate: Joi.date().allow(null),
-      latestCNIFileCategory: Joi.string().trim(),
-      frenchNationality: Joi.string().trim(),
-      birthdateAt: Joi.date(),
-      birthCity: Joi.string().trim(),
-      birthCityZip: Joi.string().trim(),
-      birthCountry: Joi.string().trim(),
-      address: Joi.string().trim(),
-      zip: Joi.string().trim(),
-      city: Joi.string().trim(),
-      country: Joi.string().trim().allow(""),
-      cityCode: Joi.string().trim().allow(""),
-      region: Joi.string().trim().allow(""),
-      department: Joi.string().trim().allow(""),
-      location: Joi.any(),
-      addressVerified: Joi.boolean(),
-      foreignAddress: Joi.string().trim().allow(""),
-      foreignZip: Joi.string().trim().allow(""),
-      foreignCity: Joi.string().trim().allow(""),
-      foreignCountry: Joi.string().trim().allow(""),
-    });
+    bodySchema = {
+      firstName: data.firstName,
+      lastName: data.lastName,
+      gender: data.gender,
+      email: data.email,
+      phone: data.phone,
+      phoneZone: data.phoneZone,
+      latestCNIFileExpirationDate: data.latestCNIFileExpirationDate,
+      latestCNIFileCategory: data.latestCNIFileCategory,
+      frenchNationality: data.frenchNationality,
+      birthdateAt: data.birthdateAt,
+      birthCity: data.birthCity,
+      birthCityZip: data.birthCityZip,
+      birthCountry: data.birthCountry,
+      address: data.address,
+      zip: data.zip,
+      city: data.city,
+      country: data.country,
+      cityCode: data.cityCode,
+      region: data.region,
+      department: data.department,
+      location: data.location,
+      addressVerified: data.addressVerified,
+      foreignAddress: data.foreignAddress,
+      foreignZip: data.foreignZip,
+      foreignCity: data.foreignCity,
+      foreignCountry: data.foreignCountry,
+    };
   } else if (section === "parent") {
-    bodySchema = Joi.object().keys({
-      situation: Joi.string().valid(...Object.keys(YOUNG_SITUATIONS)),
-      schoolId: Joi.string().trim().allow(""),
-      schoolName: Joi.string().trim().allow(""),
-      schoolCity: Joi.string().trim().allow(""),
-      schoolCountry: Joi.string().trim().allow(""),
-      schoolType: Joi.string().trim().allow(""),
-      schoolAddress: Joi.string().trim().allow(""),
-      schoolComplementAdresse: Joi.string().trim().allow(""),
-      schoolZip: Joi.string().trim().allow(""),
-      schoolDepartment: Joi.string().trim().allow(""),
-      schoolRegion: Joi.string().trim().allow(""),
-      grade: Joi.string().valid(...Object.keys(GRADES)),
-      sameSchoolCLE: Joi.string().trim(),
-
-      parent1Status: Joi.string().trim().allow(""),
-      parent1LastName: Joi.string().trim().allow(""),
-      parent1FirstName: Joi.string().trim().allow(""),
-      parent1Email: Joi.string().trim().allow(""),
-      parent1Phone: Joi.string().trim().allow(""),
-      parent1PhoneZone: Joi.string()
-        .trim()
-        .valid(...PHONE_ZONES_NAMES_ARR)
-        .allow("", null),
-      parent1OwnAddress: Joi.string().trim().valid("true", "false").allow(""),
-      parent1Address: Joi.string().trim().allow(""),
-      parent1Zip: Joi.string().trim().allow(""),
-      parent1City: Joi.string().trim().allow(""),
-      parent1Country: Joi.string().trim().allow(""),
-
-      parent2Status: Joi.string().trim().allow(""),
-      parent2LastName: Joi.string().trim().allow(""),
-      parent2FirstName: Joi.string().trim().allow(""),
-      parent2Email: Joi.string().trim().allow(""),
-      parent2Phone: Joi.string().trim().allow(""),
-      parent2PhoneZone: Joi.string()
-        .trim()
-        .valid(...PHONE_ZONES_NAMES_ARR)
-        .allow("", null),
-      parent2OwnAddress: Joi.string().trim().valid("true", "false").allow(""),
-      parent2Address: Joi.string().trim().allow(""),
-      parent2Zip: Joi.string().trim().allow(""),
-      parent2City: Joi.string().trim().allow(""),
-      parent2Country: Joi.string().trim().allow(""),
-
-      qpv: Joi.string().trim().valid("true", "false").allow("", null),
-      handicap: Joi.string().trim().valid("true", "false").allow("", null),
-      ppsBeneficiary: Joi.string().trim().valid("true", "false").allow("", null),
-      paiBeneficiary: Joi.string().trim().valid("true", "false").allow("", null),
-      specificAmenagment: Joi.string().trim().valid("true", "false").allow("", null),
-      specificAmenagmentType: Joi.string().trim().allow(""),
-      reducedMobilityAccess: Joi.string().trim().valid("true", "false").allow("", null),
-      handicapInSameDepartment: Joi.string().trim().valid("true", "false").allow("", null),
-      allergies: Joi.string().trim().valid("true", "false").allow("", null),
-
-      // old cohorts
-      imageRightFilesStatus: Joi.string().trim().valid("TO_UPLOAD", "WAITING_VERIFICATION", "WAITING_CORRECTION", "VALIDATED"),
-    });
+    bodySchema = {
+      situation: data.situation,
+      schoolId: data.schoolId,
+      schoolName: data.schoolName,
+      schoolCity: data.schoolCity,
+      schoolCountry: data.schoolCountry,
+      schoolType: data.schoolType,
+      schoolAddress: data.schoolAddress,
+      schoolComplementAdresse: data.schoolComplementAdresse,
+      schoolZip: data.schoolZip,
+      schoolDepartment: data.schoolDepartment,
+      schoolRegion: data.schoolRegion,
+      grade: data.grade,
+      sameSchoolCLE: data.sameSchoolCLE,
+      parent1Status: data.parent1Status,
+      parent1LastName: data.parent1LastName,
+      parent1FirstName: data.parent1FirstName,
+      parent1Email: data.parent1Email,
+      parent1Phone: data.parent1Phone,
+      parent1PhoneZone: data.parent1PhoneZone,
+      parent1OwnAddress: data.parent1OwnAddress,
+      parent1Address: data.parent1Address,
+      parent1Zip: data.parent1Zip,
+      parent1City: data.parent1City,
+      parent1Country: data.parent1Country,
+      parent2Status: data.parent2Status,
+      parent2LastName: data.parent2LastName,
+      parent2FirstName: data.parent2FirstName,
+      parent2Email: data.parent2Email,
+      parent2Phone: data.parent2Phone,
+      parent2PhoneZone: data.parent2PhoneZone,
+      parent2OwnAddress: data.parent2OwnAddress,
+      parent2Address: data.parent2Address,
+      parent2Zip: data.parent2Zip,
+      parent2City: data.parent2City,
+      parent2Country: data.parent2Country,
+      qpv: data.qpv,
+      handicap: data.handicap,
+      ppsBeneficiary: data.ppsBeneficiary,
+      paiBeneficiary: data.paiBeneficiary,
+      specificAmenagment: data.specificAmenagment,
+      specificAmenagmentType: data.specificAmenagmentType,
+      reducedMobilityAccess: data.reducedMobilityAccess,
+      handicapInSameDepartment: data.handicapInSameDepartment,
+      allergies: data.allergies,
+      imageRightFilesStatus: data.imageRightFilesStatus,
+    };
   }
 
-  Object.keys(data).forEach((key) => {
-    const { error } = bodySchema.validate({ [key]: data[key] });
-    if (!error) {
-      filteredData[key] = data[key];
-    }
-  });
-
-  return filteredData;
+  return bodySchema;
 }

--- a/admin/src/scenes/phase0/utils/index.js
+++ b/admin/src/scenes/phase0/utils/index.js
@@ -1,7 +1,7 @@
-export function filterDataObject(data, section) {
-  let bodySchema = {};
+export function filterDataForYoungSection(data, section) {
+  let bodyYoungSection = {};
   if (section === "identite") {
-    bodySchema = {
+    bodyYoungSection = {
       firstName: data.firstName,
       lastName: data.lastName,
       gender: data.gender,
@@ -30,7 +30,7 @@ export function filterDataObject(data, section) {
       foreignCountry: data.foreignCountry,
     };
   } else if (section === "parent") {
-    bodySchema = {
+    bodyYoungSection = {
       situation: data.situation,
       schoolId: data.schoolId,
       schoolName: data.schoolName,
@@ -79,5 +79,5 @@ export function filterDataObject(data, section) {
     };
   }
 
-  return bodySchema;
+  return bodyYoungSection;
 }

--- a/admin/src/scenes/phase0/utils/index.js
+++ b/admin/src/scenes/phase0/utils/index.js
@@ -1,0 +1,109 @@
+import Joi from "joi";
+import { PHONE_ZONES_NAMES_ARR, YOUNG_SITUATIONS, GRADES } from "snu-lib";
+
+export function filterDataObject(data, section) {
+  const filteredData = {};
+  let bodySchema = {};
+
+  if (section === "identite") {
+    bodySchema = Joi.object().keys({
+      firstName: Joi.string().trim(),
+      lastName: Joi.string().uppercase(),
+      gender: Joi.string().valid("male", "female"),
+      email: Joi.string().lowercase().trim(),
+      phone: Joi.string().trim(),
+      phoneZone: Joi.string()
+        .trim()
+        .valid(...PHONE_ZONES_NAMES_ARR)
+        .allow("", null),
+      latestCNIFileExpirationDate: Joi.date().allow(null),
+      latestCNIFileCategory: Joi.string().trim(),
+      frenchNationality: Joi.string().trim(),
+      birthdateAt: Joi.date(),
+      birthCity: Joi.string().trim(),
+      birthCityZip: Joi.string().trim(),
+      birthCountry: Joi.string().trim(),
+      address: Joi.string().trim(),
+      zip: Joi.string().trim(),
+      city: Joi.string().trim(),
+      country: Joi.string().trim().allow(""),
+      cityCode: Joi.string().trim().allow(""),
+      region: Joi.string().trim().allow(""),
+      department: Joi.string().trim().allow(""),
+      location: Joi.any(),
+      addressVerified: Joi.boolean(),
+      foreignAddress: Joi.string().trim().allow(""),
+      foreignZip: Joi.string().trim().allow(""),
+      foreignCity: Joi.string().trim().allow(""),
+      foreignCountry: Joi.string().trim().allow(""),
+    });
+  } else if (section === "parent") {
+    bodySchema = Joi.object().keys({
+      situation: Joi.string().valid(...Object.keys(YOUNG_SITUATIONS)),
+      schoolId: Joi.string().trim().allow(""),
+      schoolName: Joi.string().trim().allow(""),
+      schoolCity: Joi.string().trim().allow(""),
+      schoolCountry: Joi.string().trim().allow(""),
+      schoolType: Joi.string().trim().allow(""),
+      schoolAddress: Joi.string().trim().allow(""),
+      schoolComplementAdresse: Joi.string().trim().allow(""),
+      schoolZip: Joi.string().trim().allow(""),
+      schoolDepartment: Joi.string().trim().allow(""),
+      schoolRegion: Joi.string().trim().allow(""),
+      grade: Joi.string().valid(...Object.keys(GRADES)),
+      sameSchoolCLE: Joi.string().trim(),
+
+      parent1Status: Joi.string().trim().allow(""),
+      parent1LastName: Joi.string().trim().allow(""),
+      parent1FirstName: Joi.string().trim().allow(""),
+      parent1Email: Joi.string().trim().allow(""),
+      parent1Phone: Joi.string().trim().allow(""),
+      parent1PhoneZone: Joi.string()
+        .trim()
+        .valid(...PHONE_ZONES_NAMES_ARR)
+        .allow("", null),
+      parent1OwnAddress: Joi.string().trim().valid("true", "false").allow(""),
+      parent1Address: Joi.string().trim().allow(""),
+      parent1Zip: Joi.string().trim().allow(""),
+      parent1City: Joi.string().trim().allow(""),
+      parent1Country: Joi.string().trim().allow(""),
+
+      parent2Status: Joi.string().trim().allow(""),
+      parent2LastName: Joi.string().trim().allow(""),
+      parent2FirstName: Joi.string().trim().allow(""),
+      parent2Email: Joi.string().trim().allow(""),
+      parent2Phone: Joi.string().trim().allow(""),
+      parent2PhoneZone: Joi.string()
+        .trim()
+        .valid(...PHONE_ZONES_NAMES_ARR)
+        .allow("", null),
+      parent2OwnAddress: Joi.string().trim().valid("true", "false").allow(""),
+      parent2Address: Joi.string().trim().allow(""),
+      parent2Zip: Joi.string().trim().allow(""),
+      parent2City: Joi.string().trim().allow(""),
+      parent2Country: Joi.string().trim().allow(""),
+
+      qpv: Joi.string().trim().valid("true", "false").allow("", null),
+      handicap: Joi.string().trim().valid("true", "false").allow("", null),
+      ppsBeneficiary: Joi.string().trim().valid("true", "false").allow("", null),
+      paiBeneficiary: Joi.string().trim().valid("true", "false").allow("", null),
+      specificAmenagment: Joi.string().trim().valid("true", "false").allow("", null),
+      specificAmenagmentType: Joi.string().trim().allow(""),
+      reducedMobilityAccess: Joi.string().trim().valid("true", "false").allow("", null),
+      handicapInSameDepartment: Joi.string().trim().valid("true", "false").allow("", null),
+      allergies: Joi.string().trim().valid("true", "false").allow("", null),
+
+      // old cohorts
+      imageRightFilesStatus: Joi.string().trim().valid("TO_UPLOAD", "WAITING_VERIFICATION", "WAITING_CORRECTION", "VALIDATED"),
+    });
+  }
+
+  Object.keys(data).forEach((key) => {
+    const { error } = bodySchema.validate({ [key]: data[key] });
+    if (!error) {
+      filteredData[key] = data[key];
+    }
+  });
+
+  return filteredData;
+}

--- a/admin/src/scenes/phase0/view.jsx
+++ b/admin/src/scenes/phase0/view.jsx
@@ -622,24 +622,12 @@ function FooterNoRequest({ processing, onProcess, young, footerClass }) {
   );
 }
 
-function SectionIdentite({ young, cohort, onStartRequest, currentRequest, onCorrectionRequestChange, requests, globalMode, onChange, readonly = false, user }) {
+function SectionIdentite({ young, cohort, onStartRequest, currentRequest, onCorrectionRequestChange, requests, globalMode, onChange, readonly = false }) {
   const [sectionMode, setSectionMode] = useState(globalMode);
-  const [data, setData] = useState({});
+  const [data, setData] = useState(filterDataObject(young, "identite"));
   const [saving, setSaving] = useState(false);
   const birthDate = getBirthDate();
   const [errors, setErrors] = useState({});
-
-  useEffect(() => {
-    if (young) {
-      setData({ ...young });
-    } else {
-      setData({});
-    }
-  }, [young]);
-
-  useEffect(() => {
-    setSectionMode(globalMode);
-  }, [globalMode]);
 
   function getBirthDate() {
     if (data && data.birthdateAt) {
@@ -1197,7 +1185,7 @@ function SectionParents({ young, onStartRequest, currentRequest, onCorrectionReq
   const [currentParent, setCurrentParent] = useState(1);
   const [hasSpecificSituation, setHasSpecificSituation] = useState(false);
   const [sectionMode, setSectionMode] = useState(globalMode);
-  const [data, setData] = useState({});
+  const [data, setData] = useState(filterDataObject(young, "parent"));
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState({});
   const [youngAge, setYoungAge] = useState(0);
@@ -1222,10 +1210,6 @@ function SectionParents({ young, onStartRequest, currentRequest, onCorrectionReq
       setYoungAge(0);
     }
   }, [young]);
-
-  useEffect(() => {
-    setSectionMode(globalMode);
-  }, [globalMode]);
 
   function onSectionChangeMode(mode) {
     setSectionMode(mode === "default" ? globalMode : mode);

--- a/admin/src/scenes/phase0/view.jsx
+++ b/admin/src/scenes/phase0/view.jsx
@@ -60,6 +60,7 @@ import { Link } from "react-router-dom";
 import { Button, ModalConfirmation } from "@snu/ds/admin";
 import { FaCheck } from "react-icons/fa6";
 import { IoShieldCheckmarkOutline } from "react-icons/io5";
+import { filterDataObject } from "./utils";
 
 const REJECTION_REASONS = {
   NOT_FRENCH: "Le volontaire n'est pas de nationalité française",
@@ -671,7 +672,8 @@ function SectionIdentite({ young, cohort, onStartRequest, currentRequest, onCorr
       try {
         // eslint-disable-next-line no-unused-vars
         const { applications, ...dataToSend } = data;
-        const result = await api.put(`/young-edition/${young._id}/identite`, dataToSend);
+        const filteredDataToSend = filterDataObject(dataToSend, "identite");
+        const result = await api.put(`/young-edition/${young._id}/identite`, filteredDataToSend);
         if (result.ok) {
           toastr.success("Les données ont bien été enregistrées.");
           setSectionMode(globalMode);
@@ -1268,21 +1270,6 @@ function SectionParents({ young, onStartRequest, currentRequest, onCorrectionReq
         if (data.parent2Phone) data.parent2Phone = trimmedPhones[2];
 
         if (data.grade === GRADES.NOT_SCOLARISE) {
-          const request = await api.put(`/young-edition/${young._id}/situationparents`, {
-            schooled: "false",
-            schoolName: "",
-            schoolType: "",
-            schoolAddress: "",
-            schoolComplementAdresse: "",
-            schoolZip: "",
-            schoolCity: "",
-            schoolDepartment: "",
-            schoolRegion: "",
-            schoolCountry: "",
-            schoolLocation: null,
-            schoolId: "",
-            academy: "",
-          });
           data.schoolName = "";
           data.schoolType = "";
           data.schoolAddress = "";
@@ -1295,13 +1282,10 @@ function SectionParents({ young, onStartRequest, currentRequest, onCorrectionReq
           data.schoolLocation = null;
           data.schoolId = "";
           data.academy = "";
-
-          if (!request.ok) {
-            toastr.error("Erreur !", "Nous n'avons pas pu enregistrer les modifications. Veuillez réessayer dans quelques instants.");
-          }
         }
 
-        const result = await api.put(`/young-edition/${young._id}/situationparents`, data);
+        const filteredDataToSend = filterDataObject(data, "parent");
+        const result = await api.put(`/young-edition/${young._id}/situationparents`, filteredDataToSend);
         if (result.ok) {
           toastr.success("Les données ont bien été enregistrées.");
           setSectionMode(globalMode);

--- a/admin/src/scenes/phase0/view.jsx
+++ b/admin/src/scenes/phase0/view.jsx
@@ -626,7 +626,7 @@ function SectionIdentite({ young, cohort, onStartRequest, currentRequest, onCorr
   const [sectionMode, setSectionMode] = useState(globalMode);
   const [data, setData] = useState({});
   const [saving, setSaving] = useState(false);
-  const [birthDate, setBirthDate] = useState({ day: "", month: "", year: "" });
+  const birthDate = getBirthDate();
   const [errors, setErrors] = useState({});
 
   useEffect(() => {
@@ -641,12 +641,14 @@ function SectionIdentite({ young, cohort, onStartRequest, currentRequest, onCorr
     setSectionMode(globalMode);
   }, [globalMode]);
 
-  useEffect(() => {
+  function getBirthDate() {
     if (data && data.birthdateAt) {
       const date = dayjs(data.birthdateAt);
-      setBirthDate({ day: date.date(), month: date.format("MMMM"), year: date.year() });
+      return { day: date.date(), month: date.format("MMMM"), year: date.year() };
+    } else {
+      return { day: "", month: "", year: "" };
     }
-  }, [data]);
+  }
 
   function onSectionChangeMode(mode) {
     setSectionMode(mode === "default" ? globalMode : mode);

--- a/admin/src/scenes/phase0/view.jsx
+++ b/admin/src/scenes/phase0/view.jsx
@@ -38,7 +38,6 @@ import XCircle from "../../assets/icons/XCircle";
 import ConfirmationModal from "./components/ConfirmationModal";
 import { countryOptions, SPECIFIC_SITUATIONS_KEY, YOUNG_SCHOOLED_SITUATIONS, YOUNG_ACTIVE_SITUATIONS } from "./commons";
 import Check from "../../assets/icons/Check";
-import MiniSwitch from "./components/MiniSwitch";
 import FranceConnect from "../../assets/icons/FranceConnect";
 import SchoolEditor from "./components/SchoolEditor";
 import validator from "validator";
@@ -60,7 +59,7 @@ import { Link } from "react-router-dom";
 import { Button, ModalConfirmation } from "@snu/ds/admin";
 import { FaCheck } from "react-icons/fa6";
 import { IoShieldCheckmarkOutline } from "react-icons/io5";
-import { filterDataObject } from "./utils";
+import { filterDataForYoungSection } from "./utils";
 
 const REJECTION_REASONS = {
   NOT_FRENCH: "Le volontaire n'est pas de nationalité française",
@@ -624,7 +623,7 @@ function FooterNoRequest({ processing, onProcess, young, footerClass }) {
 
 function SectionIdentite({ young, cohort, onStartRequest, currentRequest, onCorrectionRequestChange, requests, globalMode, onChange, readonly = false }) {
   const [sectionMode, setSectionMode] = useState(globalMode);
-  const [data, setData] = useState(filterDataObject(young, "identite"));
+  const [data, setData] = useState(filterDataForYoungSection(young, "identite"));
   const [saving, setSaving] = useState(false);
   const birthDate = getBirthDate();
   const [errors, setErrors] = useState({});
@@ -662,8 +661,7 @@ function SectionIdentite({ young, cohort, onStartRequest, currentRequest, onCorr
       try {
         // eslint-disable-next-line no-unused-vars
         const { applications, ...dataToSend } = data;
-        const filteredDataToSend = filterDataObject(dataToSend, "identite");
-        const result = await api.put(`/young-edition/${young._id}/identite`, filteredDataToSend);
+        const result = await api.put(`/young-edition/${young._id}/identite`, dataToSend);
         if (result.ok) {
           toastr.success("Les données ont bien été enregistrées.");
           setSectionMode(globalMode);
@@ -1185,7 +1183,7 @@ function SectionParents({ young, onStartRequest, currentRequest, onCorrectionReq
   const [currentParent, setCurrentParent] = useState(1);
   const [hasSpecificSituation, setHasSpecificSituation] = useState(false);
   const [sectionMode, setSectionMode] = useState(globalMode);
-  const [data, setData] = useState(filterDataObject(young, "parent"));
+  const [data, setData] = useState(filterDataForYoungSection(young, "parent"));
   const [saving, setSaving] = useState(false);
   const [errors, setErrors] = useState({});
   const [youngAge, setYoungAge] = useState(0);
@@ -1270,8 +1268,7 @@ function SectionParents({ young, onStartRequest, currentRequest, onCorrectionReq
           data.academy = "";
         }
 
-        const filteredDataToSend = filterDataObject(data, "parent");
-        const result = await api.put(`/young-edition/${young._id}/situationparents`, filteredDataToSend);
+        const result = await api.put(`/young-edition/${young._id}/situationparents`, data);
         if (result.ok) {
           toastr.success("Les données ont bien été enregistrées.");
           setSectionMode(globalMode);

--- a/admin/src/scenes/volontaires/components/phase1/Phase1Header.jsx
+++ b/admin/src/scenes/volontaires/components/phase1/Phase1Header.jsx
@@ -83,7 +83,7 @@ const Phase1Header = ({ setLoading, young = null, editing = false, setEditing, l
               onClickMail={() =>
                 setModal({
                   isOpen: true,
-                  title: "Envoie de document par mail",
+                  title: "Envoi de document par mail",
                   message: `Êtes-vous sûr de vouloir transmettre le document Convocation par mail à ${young.email} ?`,
                   onConfirm: handleSendConvocationByEmail,
                 })

--- a/admin/src/scenes/volontaires/utils/index.js
+++ b/admin/src/scenes/volontaires/utils/index.js
@@ -260,7 +260,7 @@ export const getFilterArray = (user, bus, session, classes, etablissements) => {
       missingLabel: "Non renseigné",
       translate: (item) => {
         if (item === "N/A" || !bus?.length) return item;
-        return bus.find((option) => option._id.toString() === item)?.busId;
+        return bus.find((option) => option._id.toString() === item)?.busId || item;
       },
     },
     {


### PR DESCRIPTION
Reduire la taille des requete du controller young-edition, car cela declenche une alerte du pare-feu baleen

<!--
- [ ] ${{ gérer les requete en front }}
- [ ] ${{ désactiver l'exception baleen }}
-->

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

https://www.notion.so/jeveuxaider/R-duire-le-volume-de-requ-tes-d-dition-de-volontaire-4b54e37a70044b5ba2627dcffbdf7d6f?pvs=4


**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [1] ${{ modifier un jeune, checker son réseau }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
