### PR TITLE
fix(admin/api): 2200 - revoir les regles de validation manuelle de la phase 2

### DIFF
--- a/admin/src/components/selectStatus.jsx
+++ b/admin/src/components/selectStatus.jsx
@@ -53,7 +53,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
   const user = useSelector((state) => state.Auth.user);
   const [modalConfirm, setModalConfirm] = useState({ isOpen: false, onConfirm: null });
   const [modalGoal, setModalGoal] = useState({ isOpen: false, onConfirm: null });
-  const [modalValidatePhase2, setModalValidatePhase2] = useState(false);
+  const [isModalValidatePhase2Open, setModalValidatePhase2] = useState(false);
   const [newStatus, setNewStatus] = useState(null);
 
   const getInscriptionGoalReachedNormalized = async ({ department, cohort }) => {

--- a/admin/src/components/selectStatus.jsx
+++ b/admin/src/components/selectStatus.jsx
@@ -54,6 +54,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
   const [modalConfirm, setModalConfirm] = useState({ isOpen: false, onConfirm: null });
   const [modalGoal, setModalGoal] = useState({ isOpen: false, onConfirm: null });
   const [modalValidatePhase2, setModalValidatePhase2] = useState(false);
+  const [newStatus, setNewStatus] = useState(null);
 
   const getInscriptionGoalReachedNormalized = async ({ department, cohort }) => {
     const { data, ok, code } = await api.get(`/inscription-goal/${encodeURIComponent(cohort)}/department/${encodeURIComponent(department)}`);
@@ -77,6 +78,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
 
   const handleClickStatus = async (status) => {
     if (statusName === "statusPhase2" && status === YOUNG_STATUS_PHASE2.VALIDATED) {
+      setNewStatus(status);
       setModalValidatePhase2(true);
     } else {
       setModalConfirm({
@@ -161,7 +163,10 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         inscriptionRefusedMessage,
         withdrawnReason,
       });
-      if (!ok) return toastr.error("Une erreur s'est produite :", translate(code));
+      if (!ok) {
+        setModalValidatePhase2(false);
+        return toastr.error("Une erreur s'est produite :", translate(code));
+      }
 
       const validationTemplate = isCle(young) ? SENDINBLUE_TEMPLATES.young.INSCRIPTION_VALIDATED_CLE : SENDINBLUE_TEMPLATES.young.INSCRIPTION_VALIDATED;
 
@@ -173,11 +178,13 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         await api.post(`/young/${young._id}/email/${SENDINBLUE_TEMPLATES.young.INSCRIPTION_WAITING_LIST}`);
       }
       setYoung(newYoung);
+      setModalValidatePhase2(false);
       toastr.success("Mis à jour!");
       callback();
     } catch (e) {
       console.log(e);
       toastr.error("Oups, une erreur est survenue :", translate(e.code));
+      setModalValidatePhase2(false);
     }
   };
 
@@ -274,7 +281,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         text="Cette action entraînera l'abandon des candidatures et des demandes d'équivalence encore en cours. Êtes-vous sûr de vouloir continuer ?"
         actions={[
           { title: "Annuler", isCancel: true },
-          { title: "Confirmer", onClick: () => setStatus(status) },
+          { title: "Confirmer", onClick: () => setStatus(newStatus) },
         ]}
       />
 

--- a/admin/src/components/selectStatus.jsx
+++ b/admin/src/components/selectStatus.jsx
@@ -90,16 +90,16 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
             if (fillingRate >= 1)
               return setModalGoal({
                 isOpen: true,
-                onConfirm: () => setStatus(YOUNG_STATUS.WAITING_LIST),
+                onConfirm: () => handleChangeStatus(YOUNG_STATUS.WAITING_LIST),
                 confirmText: "Placer en liste complémentaire",
-                onConfirm2: () => setStatus(YOUNG_STATUS.VALIDATED),
+                onConfirm2: () => handleChangeStatus(YOUNG_STATUS.VALIDATED),
                 confirmText2: "Valider quand même",
                 title: "Jauge de candidats atteinte",
                 message:
                   "Attention, vous avez atteint la jauge, merci de placer le candidat sur liste complémentaire ou de vous rapprocher de votre coordinateur régional avant de valider la candidature.",
               });
           }
-          setStatus(status);
+          handleChangeStatus(status);
         },
         title: "Modification de statut",
         message: "Êtes-vous sûr(e) de vouloir modifier le statut de ce profil?\nUn email sera automatiquement envoyé à l'utilisateur.",
@@ -107,7 +107,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
     }
   };
 
-  const setStatus = async (status, values) => {
+  const handleChangeStatus = async (status, values) => {
     const prevStatus = young.status;
     if (status === "WITHDRAWN") {
       young.historic.push({
@@ -222,7 +222,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         value={young}
         onChange={() => setModal(false)}
         onSend={(note) => {
-          setStatus(YOUNG_STATUS.WAITING_CORRECTION, { note });
+          handleChangeStatus(YOUNG_STATUS.WAITING_CORRECTION, { note });
           setModal(null);
         }}
       />
@@ -231,7 +231,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         value={young}
         onChange={() => setModal(false)}
         onSend={(note) => {
-          setStatus(YOUNG_STATUS.REFUSED, { note });
+          handleChangeStatus(YOUNG_STATUS.REFUSED, { note });
           setModal(null);
         }}
       />
@@ -243,7 +243,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         placeholder="Précisez en quelques mots les raisons du désistement du volontaire"
         onChange={() => setModal(false)}
         onConfirm={(values) => {
-          setStatus(YOUNG_STATUS.WITHDRAWN, values);
+          handleChangeStatus(YOUNG_STATUS.WITHDRAWN, values);
           setModal(null);
         }}
       />
@@ -271,7 +271,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         }}
       />
       <ModalConfirmation
-        isOpen={modalValidatePhase2}
+        isOpen={isModalValidatePhase2Open}
         onClose={() => {
           setModalValidatePhase2(false);
         }}
@@ -281,7 +281,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
         text="Cette action entraînera l'abandon des candidatures et des demandes d'équivalence encore en cours. Êtes-vous sûr de vouloir continuer ?"
         actions={[
           { title: "Annuler", isCancel: true },
-          { title: "Confirmer", onClick: () => setStatus(newStatus) },
+          { title: "Confirmer", onClick: () => handleChangeStatus(newStatus) },
         ]}
       />
 

--- a/admin/src/components/selectStatus.jsx
+++ b/admin/src/components/selectStatus.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import { DropdownItem, DropdownMenu, DropdownToggle, UncontrolledDropdown } from "reactstrap";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
+import { ModalConfirmation } from "@snu/ds/admin";
+import { IoWarningOutline } from "react-icons/io5";
 
 import api from "../services/api";
 
@@ -25,7 +27,7 @@ import ModalWithdrawn from "./modals/ModalWithdrawn";
 import Chevron from "./Chevron";
 import ModalConfirm from "./modals/ModalConfirm";
 import ModalConfirmMultiAction from "./modals/ModalConfirmMultiAction";
-import { isCle, translateInscriptionStatus } from "snu-lib";
+import { YOUNG_STATUS_PHASE2, isCle, translateInscriptionStatus } from "snu-lib";
 
 const lookUpAuthorizedStatus = ({ status, role }) => {
   switch (status) {
@@ -51,6 +53,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
   const user = useSelector((state) => state.Auth.user);
   const [modalConfirm, setModalConfirm] = useState({ isOpen: false, onConfirm: null });
   const [modalGoal, setModalGoal] = useState({ isOpen: false, onConfirm: null });
+  const [modalValidatePhase2, setModalValidatePhase2] = useState(false);
 
   const getInscriptionGoalReachedNormalized = async ({ department, cohort }) => {
     const { data, ok, code } = await api.get(`/inscription-goal/${encodeURIComponent(cohort)}/department/${encodeURIComponent(department)}`);
@@ -73,29 +76,33 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
   if (!young) return <i style={{ color: colors.darkPurple }}>Chargement...</i>;
 
   const handleClickStatus = async (status) => {
-    setModalConfirm({
-      isOpen: true,
-      onConfirm: async () => {
-        if ([YOUNG_STATUS.WAITING_CORRECTION, YOUNG_STATUS.REFUSED, YOUNG_STATUS.WITHDRAWN].includes(status)) return setModal(status);
-        if (status === YOUNG_STATUS.VALIDATED && phase === YOUNG_PHASE.INSCRIPTION) {
-          const fillingRate = await getInscriptionGoalReachedNormalized({ department: young.department, cohort: young.cohort });
-          if (fillingRate >= 1)
-            return setModalGoal({
-              isOpen: true,
-              onConfirm: () => setStatus(YOUNG_STATUS.WAITING_LIST),
-              confirmText: "Placer en liste complémentaire",
-              onConfirm2: () => setStatus(YOUNG_STATUS.VALIDATED),
-              confirmText2: "Valider quand même",
-              title: "Jauge de candidats atteinte",
-              message:
-                "Attention, vous avez atteint la jauge, merci de placer le candidat sur liste complémentaire ou de vous rapprocher de votre coordinateur régional avant de valider la candidature.",
-            });
-        }
-        setStatus(status);
-      },
-      title: "Modification de statut",
-      message: "Êtes-vous sûr(e) de vouloir modifier le statut de ce profil?\nUn email sera automatiquement envoyé à l'utilisateur.",
-    });
+    if (statusName === "statusPhase2" && status === YOUNG_STATUS_PHASE2.VALIDATED) {
+      setModalValidatePhase2(true);
+    } else {
+      setModalConfirm({
+        isOpen: true,
+        onConfirm: async () => {
+          if ([YOUNG_STATUS.WAITING_CORRECTION, YOUNG_STATUS.REFUSED, YOUNG_STATUS.WITHDRAWN].includes(status)) return setModal(status);
+          if (status === YOUNG_STATUS.VALIDATED && phase === YOUNG_PHASE.INSCRIPTION) {
+            const fillingRate = await getInscriptionGoalReachedNormalized({ department: young.department, cohort: young.cohort });
+            if (fillingRate >= 1)
+              return setModalGoal({
+                isOpen: true,
+                onConfirm: () => setStatus(YOUNG_STATUS.WAITING_LIST),
+                confirmText: "Placer en liste complémentaire",
+                onConfirm2: () => setStatus(YOUNG_STATUS.VALIDATED),
+                confirmText2: "Valider quand même",
+                title: "Jauge de candidats atteinte",
+                message:
+                  "Attention, vous avez atteint la jauge, merci de placer le candidat sur liste complémentaire ou de vous rapprocher de votre coordinateur régional avant de valider la candidature.",
+              });
+          }
+          setStatus(status);
+        },
+        title: "Modification de statut",
+        message: "Êtes-vous sûr(e) de vouloir modifier le statut de ce profil?\nUn email sera automatiquement envoyé à l'utilisateur.",
+      });
+    }
   };
 
   const setStatus = async (status, values) => {
@@ -113,6 +120,7 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
     const now = new Date();
     young.lastStatusAt = now.toISOString();
     if (statusName === "statusPhase2") young.statusPhase2UpdatedAt = now.toISOString();
+    if (statusName === "statusPhase2" && status === YOUNG_STATUS_PHASE2.VALIDATED) young.statusPhase2ValidatedAt = now.toISOString();
     if (statusName === "statusPhase3") young.statusPhase3UpdatedAt = now.toISOString();
     if (status === "WITHDRAWN" && (values?.withdrawnReason || values?.withdrawnMessage)) {
       young.withdrawnReason = values?.withdrawnReason;
@@ -255,6 +263,21 @@ export default function SelectStatus({ hit, options = Object.keys(YOUNG_STATUS),
           setModal(null);
         }}
       />
+      <ModalConfirmation
+        isOpen={modalValidatePhase2}
+        onClose={() => {
+          setModalValidatePhase2(false);
+        }}
+        className="md:max-w-[700px]"
+        icon={<IoWarningOutline className="text-amber-500" size={40} />}
+        title="Attention, vous êtes sur le point de valider la phase 2 de ce volontaire"
+        text="Cette action entraînera l'abandon des candidatures et des demandes d'équivalence encore en cours. Êtes-vous sûr de vouloir continuer ?"
+        actions={[
+          { title: "Annuler", isCancel: true },
+          { title: "Confirmer", onClick: () => setStatus(status) },
+        ]}
+      />
+
       <ActionBox color={YOUNG_STATUS_COLORS[young[statusName]]}>
         <UncontrolledDropdown setActiveFromChild>
           <DropdownToggle tag="button" disabled={disabled || !options.length}>

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -551,7 +551,9 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       const pendingApplication = applications.filter((a) => [APPLICATION_STATUS.WAITING_VALIDATION, APPLICATION_STATUS.WAITING_VERIFICATION].includes(a.status));
 
       const equivalences = await MissionEquivalenceModel.find({ youngId: young._id });
-      const pendingEquivalence = equivalences.filter((equivalence) => [EQUIVALENCE_STATUS.WAITING_CORRECTION, EQUIVALENCE_STATUS.WAITING_VERIFICATION].includes(equivalence.status));
+      const pendingEquivalences = equivalences.filter((equivalence) =>
+        [EQUIVALENCE_STATUS.WAITING_CORRECTION, EQUIVALENCE_STATUS.WAITING_VERIFICATION].includes(equivalence.status),
+      );
 
       await cancelPendingApplications(pendingApplication, req.user);
       await cancelPendingEquivalence(pendingEquivalences, req.user);

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -551,7 +551,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       const pendingApplication = applications.filter((a) => [APPLICATION_STATUS.WAITING_VALIDATION, APPLICATION_STATUS.WAITING_VERIFICATION].includes(a.status));
 
       const equivalences = await MissionEquivalenceModel.find({ youngId: young._id });
-      const pendingEquivalence = equivalence.filter((e) => [EQUIVALENCE_STATUS.WAITING_CORRECTION, EQUIVALENCE_STATUS.WAITING_VERIFICATION].includes(e.status));
+      const pendingEquivalence = equivalences.filter((equivalence) => [EQUIVALENCE_STATUS.WAITING_CORRECTION, EQUIVALENCE_STATUS.WAITING_VERIFICATION].includes(equivalence.status));
 
       await cancelPendingApplications(pendingApplication, req.user);
       await cancelPendingEquivalence(pendingEquivalence, req.user);

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -550,7 +550,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       const applications = await ApplicationModel.find({ youngId: young._id });
       const pendingApplication = applications.filter((a) => [APPLICATION_STATUS.WAITING_VALIDATION, APPLICATION_STATUS.WAITING_VERIFICATION].includes(a.status));
 
-      const equivalence = await MissionEquivalenceModel.find({ youngId: young._id });
+      const equivalences = await MissionEquivalenceModel.find({ youngId: young._id });
       const pendingEquivalence = equivalence.filter((e) => [EQUIVALENCE_STATUS.WAITING_CORRECTION, EQUIVALENCE_STATUS.WAITING_VERIFICATION].includes(e.status));
 
       await cancelPendingApplications(pendingApplication, req.user);

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -546,7 +546,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
     }
 
     // when changing statusPhase2, we check applications and equivalence
-    if (newYoung.statusPhase2 && newYoung.statusPhase2 === YOUNG_STATUS_PHASE2.VALIDATED) {
+    if (newYoung.statusPhase2 === YOUNG_STATUS_PHASE2.VALIDATED) {
       const applications = await ApplicationModel.find({ youngId: young._id });
       const pendingApplication = applications.filter((a) => [APPLICATION_STATUS.WAITING_VALIDATION, APPLICATION_STATUS.WAITING_VERIFICATION].includes(a.status));
 

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -554,8 +554,8 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       const pendingEquivalence = equivalences.filter((equivalence) => [EQUIVALENCE_STATUS.WAITING_CORRECTION, EQUIVALENCE_STATUS.WAITING_VERIFICATION].includes(equivalence.status));
 
       await cancelPendingApplications(pendingApplication, req.user);
-      await cancelPendingEquivalence(pendingEquivalence, req.user);
-      if (pendingEquivalence.length > 0) {
+      await cancelPendingEquivalence(pendingEquivalences, req.user);
+      if (pendingEquivalences.length > 0) {
         newYoung.status_equivalence = EQUIVALENCE_STATUS.REFUSED;
       }
     }

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -555,6 +555,9 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
 
       await cancelPendingApplications(pendingApplication, req.user);
       await cancelPendingEquivalence(pendingEquivalence, req.user);
+      if (pendingEquivalence.length > 0) {
+        newYoung.status_equivalence = EQUIVALENCE_STATUS.REFUSED;
+      }
     }
 
     young.set(newYoung);

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -34,7 +34,17 @@ const {
   PUBLIC_BUCKET_NAME_SUPPORT,
   translateFileStatusPhase1,
 } = require("../config");
-const { YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, SENDINBLUE_TEMPLATES, YOUNG_STATUS, APPLICATION_STATUS, FILE_STATUS_PHASE1, ROLES, SUB_ROLES } = require("snu-lib");
+const {
+  YOUNG_STATUS_PHASE1,
+  YOUNG_STATUS_PHASE2,
+  SENDINBLUE_TEMPLATES,
+  YOUNG_STATUS,
+  APPLICATION_STATUS,
+  FILE_STATUS_PHASE1,
+  ROLES,
+  SUB_ROLES,
+  EQUIVALENCE_STATUS,
+} = require("snu-lib");
 const { capture, captureMessage } = require("../sentry");
 const { getCohortDateInfo } = require("./cohort");
 const dayjs = require("dayjs");
@@ -564,6 +574,13 @@ async function cancelPendingApplications(pendingApplication, fromUser) {
   }
 }
 
+async function cancelPendingEquivalence(pendingEquivalence, fromUser) {
+  for (const equivalence of pendingEquivalence) {
+    equivalence.set({ status: EQUIVALENCE_STATUS.REFUSED, message: "La phase 2 a été validée" });
+    await equivalence.save({ fromUser });
+  }
+}
+
 async function sendNotificationApplicationClosedBecausePhase2Validated(application) {
   if (application.tutorId) {
     const responsible = await ReferentModel.findById(application.tutorId);
@@ -1000,6 +1017,7 @@ module.exports = {
   getReferentManagerPhase2,
   SUPPORT_BUCKET_CONFIG,
   cancelPendingApplications,
+  cancelPendingEquivalence,
   updateYoungApplicationFilesType,
   updateHeadCenter,
   getTransporter,

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -574,7 +574,7 @@ async function cancelPendingApplications(pendingApplication, fromUser) {
   }
 }
 
-async function cancelPendingEquivalence(pendingEquivalence, fromUser) {
+async function cancelPendingEquivalence(pendingEquivalences, fromUser) {
   for (const equivalence of pendingEquivalence) {
     equivalence.set({ status: EQUIVALENCE_STATUS.REFUSED, message: "La phase 2 a été validée" });
     await equivalence.save({ fromUser });

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -575,7 +575,7 @@ async function cancelPendingApplications(pendingApplication, fromUser) {
 }
 
 async function cancelPendingEquivalence(pendingEquivalences, fromUser) {
-  for (const equivalence of pendingEquivalence) {
+  for (const equivalence of pendingEquivalences) {
     equivalence.set({ status: EQUIVALENCE_STATUS.REFUSED, message: "La phase 2 a été validée" });
     await equivalence.save({ fromUser });
   }


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->
Validé la pahse 2 d'un jeune a la main n'entrainait pas l'annulation de ses candidatures et de ses demandes d'équivalence, ce qui posait proleme pour les filtres.
**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**
https://www.notion.so/jeveuxaider/Volontaires-bloqu-s-sur-une-liste-qu-ils-ne-devraient-pas-cot-r-f-rent-2948bc9050344876afa27275af13515c?pvs=4
<!-- If you have a Notion Ticket / GitHub Issue -->
<!-- Fixes [Notion ticket #123](https://notion.so/abc) -->

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
--> 1 - trouver un jeune avec une demande d'equivalence en attente de verification ou de correction et validé sa phase 2 a la main
