### PR TITLE
chore(github): change @semantic-release schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   schedule:
-    - cron: "23 23 * * *"
+    - cron: "0 14 * * 5"
 
 jobs:
   release:


### PR DESCRIPTION
**Description**

Les release Github ne sont pas synchronisées avec les déploiements sur les différents environnements et n'ont donc pour l'instant aucun sens.

Cette PR change dans un premier temps la planification pour la rendre hebdomadaire plutôt que journalière et pour être au plus proche du vrai change log généré par la suite.

Idéalement il faudrait inclure `.github/workflows/release.yml` dans `.github/workflows/deploy-production.yml`
