### PR TITLE
feat(api,app): 2347 - Remove self delete for youngs

### DIFF
--- a/api/src/__tests__/young.test.ts
+++ b/api/src/__tests__/young.test.ts
@@ -117,10 +117,10 @@ describe("Young", () => {
       expect(res.statusCode).toEqual(404);
     });
 
-    it("should be accessible by referents or young", async () => {
+    it("should be accessible by referents only", async () => {
       const passport = require("passport");
       await request(getAppHelper()).delete("/young/" + notExistingYoungId);
-      expect(passport.lastTypeCalledOnAuthenticate).toEqual(["referent", "young"]);
+      expect(passport.lastTypeCalledOnAuthenticate).toEqual(["referent"]);
     });
   });
 

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -816,7 +816,7 @@ router.post("/france-connect/user-info", async (req, res) => {
 
 // Delete one user (only admin can delete user)
 // And apparently referent in same geography as well (see canDeleteYoung())
-router.put("/:id/soft-delete", passport.authenticate(["referent", "young"], { session: false, failWithError: true }), async (req, res) => {
+router.put("/:id/soft-delete", passport.authenticate(["referent"], { session: false, failWithError: true }), async (req, res) => {
   try {
     const { error, value: id } = validateId(req.params.id);
     if (error) {

--- a/app/src/scenes/account/components/WithdrawalModal.jsx
+++ b/app/src/scenes/account/components/WithdrawalModal.jsx
@@ -1,22 +1,20 @@
 import React, { useState } from "react";
 import Modal from "../../../components/ui/modals/Modal";
-import { YOUNG_STATUS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, translate, WITHRAWN_REASONS } from "../../../utils";
+import { YOUNG_STATUS, YOUNG_STATUS_PHASE1, translate, WITHRAWN_REASONS } from "../../../utils";
 import { useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { toastr } from "react-redux-toastr";
 import { setYoung } from "../../../redux/auth/actions";
-import { ACTION_ABANDON, ACTION_DELETE_ACCOUNT, ACTION_WITHDRAW, CONTENT_CHANGE_DATE, CONTENT_CONFIRM, CONTENT_FORM, steps } from "../utils";
+import { ACTION_ABANDON, ACTION_WITHDRAW, CONTENT_CHANGE_DATE, CONTENT_CONFIRM, CONTENT_FORM, steps } from "../utils";
 import WithdrawFormModalContent from "./WithdrawFormModalContent";
 import WithdrawOrChangeDateModalContent from "./WithdrawOrChangeDateModalContent";
 import ConfirmationModalContent from "./ConfirmationModalContent";
 import Close from "../../../assets/Close";
-import { abandonYoungAccount, deleteYoungAccount, withdrawYoungAccount } from "../../../services/young.service";
-import useAuth from "@/services/useAuth";
+import { abandonYoungAccount, withdrawYoungAccount } from "../../../services/young.service";
 
 const WithdrawalModal = ({ isOpen, onCancel: onCancelProps, young }) => {
   const history = useHistory();
   const dispatch = useDispatch();
-  const { logout } = useAuth();
 
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState("");
@@ -35,28 +33,12 @@ const WithdrawalModal = ({ isOpen, onCancel: onCancelProps, young }) => {
     onCancelProps();
   };
 
-  const mandatoryPhasesDone = young.statusPhase1 === YOUNG_STATUS_PHASE1.DONE && young.statusPhase2 === YOUNG_STATUS_PHASE2.VALIDATED;
-
-  const action = mandatoryPhasesDone
-    ? ACTION_DELETE_ACCOUNT
-    : [YOUNG_STATUS.IN_PROGRESS, YOUNG_STATUS.WAITING_VALIDATION, YOUNG_STATUS.WAITING_CORRECTION].includes(young.status)
-    ? ACTION_ABANDON
-    : ACTION_WITHDRAW;
+  const action = [YOUNG_STATUS.IN_PROGRESS, YOUNG_STATUS.WAITING_VALIDATION, YOUNG_STATUS.WAITING_CORRECTION].includes(young.status) ? ACTION_ABANDON : ACTION_WITHDRAW;
 
   const onConfirm = async () => {
     setIsLoading(true);
 
     try {
-      if (action === ACTION_DELETE_ACCOUNT) {
-        setLoadingMessage(
-          "Merci de patienter, la suppression de votre compte devrait prendre moins d'une minute. Vous serez immédiatement déconnecté(e) une fois la suppression effectuée.",
-        );
-        const { ok, code } = await deleteYoungAccount(young._id);
-        if (!ok) return toastr.error("Une erreur est survenu lors du traitement de votre demande :", translate(code));
-        toastr.success("Compte supprimé:", "Votre compte a été suppromé avec succès.");
-        await logout();
-      }
-
       if (action === ACTION_WITHDRAW) {
         const { ok, data, code } = await withdrawYoungAccount({ withdrawnMessage, withdrawnReason });
         if (!ok) return toastr.error("Une erreur est survenu lors du traitement de votre demande :", translate(code));
@@ -117,7 +99,7 @@ const WithdrawalModal = ({ isOpen, onCancel: onCancelProps, young }) => {
             isLoading={isLoading}
             loadingMessage={loadingMessage}
             onConfirm={onConfirm}
-            onBack={action === ACTION_DELETE_ACCOUNT ? onCancel : () => setStep(step - 1)}
+            onBack={() => setStep(step - 1)}
             title={title}
             subTitle={subTitle}
           />

--- a/app/src/scenes/account/scenes/general/components/Withdrawal.jsx
+++ b/app/src/scenes/account/scenes/general/components/Withdrawal.jsx
@@ -1,12 +1,11 @@
 import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
-import { YOUNG_STATUS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2 } from "snu-lib";
+import { YOUNG_STATUS } from "snu-lib";
 import WithdrawalModal from "../../../components/WithdrawalModal";
 
 const Withdrawal = ({ young }) => {
-  const mandatoryPhasesDone = young.statusPhase1 === YOUNG_STATUS_PHASE1.DONE && young.statusPhase2 === YOUNG_STATUS_PHASE2.VALIDATED;
   const inscriptionStatus = [YOUNG_STATUS.IN_PROGRESS, YOUNG_STATUS.WAITING_VALIDATION, YOUNG_STATUS.WAITING_CORRECTION].includes(young.status);
-  const getWithdrawalButtonLabel = () => (mandatoryPhasesDone ? "Supprimer mon compte" : inscriptionStatus ? "Abandonner mon inscription" : "Se désister du SNU");
+  const getWithdrawalButtonLabel = () => (inscriptionStatus ? "Abandonner mon inscription" : "Se désister du SNU");
 
   const search = useLocation().search;
   const isWithdrawalModalOpenDefault = new URLSearchParams(search).get("desistement") === "1";

--- a/app/src/scenes/account/scenes/general/index.jsx
+++ b/app/src/scenes/account/scenes/general/index.jsx
@@ -3,7 +3,7 @@ import queryString from "query-string";
 import { BiLoaderAlt } from "react-icons/bi";
 import { Link, useLocation } from "react-router-dom";
 import { toastr } from "react-redux-toastr";
-import { youngCanChangeSession, youngCanDeleteAccount } from "snu-lib";
+import { youngCanChangeSession, youngCanWithdraw } from "snu-lib";
 import { PHONE_ZONES } from "snu-lib/phone-number";
 import { useDispatch, useSelector } from "react-redux";
 import { setYoung } from "@/redux/auth/actions";
@@ -201,7 +201,7 @@ const AccountGeneralPage = () => {
             Changer de séjour
           </Link>
         ) : null}
-        {youngCanDeleteAccount(young) ? <Withdrawal young={young} /> : null}
+        {youngCanWithdraw(young) ? <Withdrawal young={young} /> : null}
       </div>
     </>
   );

--- a/app/src/scenes/account/utils.js
+++ b/app/src/scenes/account/utils.js
@@ -35,11 +35,4 @@ export const steps = {
       subTitle: "Vous vous apprêtez à abandonner votre inscription au SNU. Cette action est irréversible, souhaitez-vous confirmer cette action ?",
     },
   ],
-  [ACTION_DELETE_ACCOUNT]: [
-    {
-      content: CONTENT_CONFIRM,
-      title: "Suppression du compte SNU",
-      subTitle: "Vous êtes sur le point de supprimer votre compte. Vous serez immédiatement déconnecté(e). Souhaitez-vous réellement supprimer votre compte ?",
-    },
-  ],
 };

--- a/app/src/services/young.service.js
+++ b/app/src/services/young.service.js
@@ -4,7 +4,6 @@ import { download, translate } from "snu-lib";
 
 export const logoutYoung = async () => await api.post("/young/logout");
 
-export const deleteYoungAccount = (youngId) => api.put(`/young/${youngId}/soft-delete`);
 export const withdrawYoungAccount = ({ withdrawnMessage, withdrawnReason }) => api.put(`/young/withdraw`, { withdrawnMessage, withdrawnReason });
 export const abandonYoungAccount = ({ withdrawnMessage, withdrawnReason }) => api.put(`/young/abandon`, { withdrawnMessage, withdrawnReason });
 

--- a/packages/lib/index.js
+++ b/packages/lib/index.js
@@ -1,4 +1,4 @@
-import { WITHRAWN_REASONS, YOUNG_STATUS, YOUNG_STATUS_PHASE1 } from "./constants";
+import { WITHRAWN_REASONS, YOUNG_STATUS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2 } from "./constants";
 import translation from "./translation";
 import { ROLES } from "./roles";
 import sanitizeHtml from "sanitize-html";
@@ -142,8 +142,11 @@ const youngCanChangeSession = ({ statusPhase1, status, sessionPhase1Id, source }
   return false;
 };
 
-const youngCanDeleteAccount = (young) => {
+const youngCanWithdraw = (young) => {
   if (young.source === YOUNG_SOURCE.CLE) return false;
+  if ([YOUNG_STATUS_PHASE1.DONE, YOUNG_STATUS_PHASE1.EXEMPTED].includes(young.statusPhase1) && [YOUNG_STATUS_PHASE2.VALIDATED].includes(young.statusPhase2)) {
+    return false;
+  }
   return true;
 };
 
@@ -190,7 +193,7 @@ export {
   canUpdateYoungStatus,
   canUserUpdateYoungStatus,
   youngCanChangeSession,
-  youngCanDeleteAccount,
+  youngCanWithdraw,
   isYoungInReinscription,
   formatPhoneNumberFR,
   formatMessageForReadingInnerHTML,


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

- [x] Remove delete button on web app
- [x] Remove young authorization strategy from soft delete route

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

Fixes [Notion ticket #2347](https://www.notion.so/jeveuxaider/Sprint-Mon-Compte-S17-18-fd62eef5fd4149b2b5c56ca00d44be2d?p=f074537995474b509d130fbd493c2f0b&pm=s)

**Testing instructions**

Prendre la place d'un volontaire qui a terminé ses phases 1 et 2. Verifier qu'il ne peut plus supprimer son compte depuis son profil. Vérifier que autres volontaires inscrits peuvent toujours se désister et que les volontaires en cours d'inscription peuvent toujours abandonner leur inscription.