### PR TITLE
fix(api,app): 2349 - Fix tracking for API Engagement

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -42,7 +42,7 @@ const FILE_ENCRYPTION_SECRET = process.env.FILE_ENCRYPTION_SECRET || "";
 const QPV_USERNAME = process.env.QPV_USERNAME || "";
 const QPV_PASSWORD = process.env.QPV_PASSWORD || "";
 
-const API_ENGAGEMENT_URL = process.env.API_ENGAGEMENT_URL || "https://api.api-engagement.beta.gouv.fr";
+const API_ENGAGEMENT_URL = process.env.API_ENGAGEMENT_URL || "";
 const API_ENGAGEMENT_KEY = process.env.API_ENGAGEMENT_KEY || "";
 
 const API_ASSOCIATION_ES_ENDPOINT = process.env.API_ASSOCIATION_ES_ENDPOINT || "";

--- a/api/src/controllers/application.js
+++ b/api/src/controllers/application.js
@@ -163,7 +163,6 @@ router.post("/", passport.authenticate(["young", "referent"], { session: false, 
 
     // On vérifie si les candidatures sont ouvertes.
     if (mission.visibility === "HIDDEN") {
-      console.log("visibility", mission.visibility);
       return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
     }
 
@@ -175,7 +174,6 @@ router.post("/", passport.authenticate(["young", "referent"], { session: false, 
     if (isYoung(req.user)) {
       const { canApply, message } = await getAuthorizationToApply(mission, young);
       if (!canApply) {
-        console.log(message);
         return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED, message });
       }
     }
@@ -216,6 +214,7 @@ router.post("/", passport.authenticate(["young", "referent"], { session: false, 
       return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
     }
 
+    // Send tracking data to API Engagement
     if (mission.apiEngagementId) {
       const data = await apiEngagement.create(value, mission.apiEngagementId, clickId);
       value.apiEngagementId = data?._id;
@@ -372,6 +371,7 @@ router.put("/", passport.authenticate(["referent", "young"], { session: false, f
     application.set(value);
 
     if (application.isJvaMission === "true") {
+      // When a young accepts a mission proposed by a ref, it counts as an application creation in API Engagement
       if (originalStatus === APPLICATION_STATUS.WAITING_ACCEPTATION && application.status === APPLICATION_STATUS.WAITING_VALIDATION) {
         const mission = await MissionObject.findById(application.missionId);
         const data = await apiEngagement.create(application, mission.apiEngagementId, null);

--- a/api/src/services/gouv.fr/api-engagement.js
+++ b/api/src/services/gouv.fr/api-engagement.js
@@ -48,7 +48,6 @@ const apiEngagement = {
     try {
       if (config.ENVIRONMENT !== "production") return;
 
-      // We only track application creation, validation and completion (not cancelation, refusal, etc.)
       if (!Object.keys(statusMap).includes(application.status)) return;
 
       if (!application.apiEngagementId) {

--- a/api/src/services/gouv.fr/api-engagement.js
+++ b/api/src/services/gouv.fr/api-engagement.js
@@ -3,10 +3,12 @@
 const { APPLICATION_STATUS } = require("snu-lib");
 const config = require("../../config");
 
-const apiEngagementStatus = {
+const statusMap = {
   [APPLICATION_STATUS.WAITING_VALIDATION]: "PENDING",
   [APPLICATION_STATUS.VALIDATED]: "VALIDATED",
-  [APPLICATION_STATUS.DONE]: "DONE",
+  [APPLICATION_STATUS.DONE]: "CARRIED_OUT",
+  [APPLICATION_STATUS.CANCEL]: "CANCEL",
+  [APPLICATION_STATUS.REFUSED]: "REFUSED",
 };
 
 const apiEngagement = {
@@ -18,12 +20,12 @@ const apiEngagement = {
    */
   create: async (application, missionId, clickId) => {
     try {
-      if (config.ENVIRONMENT !== "production") return;
+      if (!config.ENVIRONMENT !== "production") return;
 
-      if (application.status !== APPLICATION_STATUS.WAITING_VALIDATION) return;
+      // When a ref proposes a mission, it does not count as an application creation in API Engagement
+      if (application.status === APPLICATION_STATUS.WAITING_ACCEPTATION) return;
 
       let url = config.API_ENGAGEMENT_URL + "/v2/activity/" + missionId + "/apply?tag=MIG";
-      if (clickId) url += `&clickId=${clickId}`;
 
       const options = {
         method: "POST",
@@ -31,6 +33,7 @@ const apiEngagement = {
       };
 
       const res = await fetch(url, options);
+      if (clickId) url += `&clickId=${clickId}`;
       const { ok, data, code } = await res.json();
 
       if (!ok) throw new Error(code);
@@ -46,7 +49,7 @@ const apiEngagement = {
       if (config.ENVIRONMENT !== "production") return;
 
       // We only track application creation, validation and completion (not cancelation, refusal, etc.)
-      if (!Object.keys(apiEngagementStatus).includes(application.status)) return;
+      if (!Object.keys(statusMap).includes(application.status)) return;
 
       if (!application.apiEngagementId) {
         throw new Error("No API Engagement ID found for application" + application._id);
@@ -60,7 +63,7 @@ const apiEngagement = {
           "X-API-KEY": config.API_ENGAGEMENT_KEY,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ status: apiEngagementStatus[application.status] }),
+        body: JSON.stringify({ status: statusMap[application.status] }),
       };
 
       const res = await fetch(url, options);

--- a/app/src/scenes/missions/utils.js
+++ b/app/src/scenes/missions/utils.js
@@ -7,7 +7,7 @@ export async function apiEngagement(missionId) {
   try {
     if (environment !== "production") return;
 
-    const url = `${API_ENGAGEMENT_URL}/v2/activity/${missionId}/${API_ENGAGEMENT_SNU_ID}/click`;
+    const url = `${API_ENGAGEMENT_URL}/v2/activity/${missionId}/${API_ENGAGEMENT_SNU_ID}/click?tag=MIG`;
     const options = { method: "POST" };
     const res = await fetch(url, options);
     const { ok, data, code } = await res.json();


### PR DESCRIPTION
**Description**

Voir ticket.

**Todo**

- [x]  Débuguer le tracking des **candidatures**.
- [x]  Investiguer le pb du tag sur le tracking des **redirections**.
- [ ]  Investiguer les différences entre **l’export** réalisé et les données présentes sur metabase (peu prio car écart < 1%).
- [x]  Rajouter les autres types d’événements au tracking des candidatures (annulations, refus, abandons):
    - [x]  DONE --> CARRIED_OUT
    - [x]  CANCEL --> CANCEL
    - [x]  REFUSED --> REFUSED
- [ ]  Refaire un export avec les nouveaux événements => Sortir cette PR d'abord puis faire la commande suivante :
```
select evenement_nom, evenement_valeur, date, "JVAMissionId"
from log_applications
join mongo_missions_jva on log_applications.candidature_mission_id = mongo_missions_jva."ID"
where raw_data->>'isJvaMission' = 'true'
and evenement_valeur not in ('IN_PROGRESS', 'WAITING_ACCEPTATION');
```

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

Fixes [Notion ticket #2349](https://www.notion.so/jeveuxaider/Sprint-Mon-Compte-S17-18-fd62eef5fd4149b2b5c56ca00d44be2d?p=a630c086b621425b980ecdfe86eb3031&pm=s)

**Testing instructions**

1. Créer une mission en DB avec un apiEngagementId. Créer une candidature en tant que jeune. Vérifier que la candidature a bien ensuite son propre apiEngagementId.
2. Valider la candidature en tant que ref. Vérifier que l'activity a bien été envoyée à API Engagement (lien de la doc dans le code).
3. Idem mais en proposant une mission en tant que ref et en l'acceptant en tant que jeune (l'événement de création doit être créé au moment de l'acceptation).