### PR TITLE
chore(misc): front sentry config

### DIFF
--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig(({ command, mode }) => {
         authToken: env.SENTRY_AUTH_TOKEN,
         url: "https://sentry.selego.co/",
         environment: mode,
+        release: env.RELEASE,
         deploy: {
           env: mode,
         },

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => {
         authToken: env.SENTRY_AUTH_TOKEN,
         url: "https://sentry.selego.co/",
         environment: mode,
+        release: env.RELEASE,
         deploy: {
           env: mode,
         },


### PR DESCRIPTION
**Description**

pour le front (app/admin), les sourcemap sont envoyés lors du `npm run build`, sauf dans le container docker il semble que nous n'ayons pas accès à la variable d'environnement `SENTRY_AUTH_TOKEN`.

par ailleurs il faut lui préciser la release dans la config de sentryVitePlugin

exemple d'output https://github.com/betagouv/service-national-universel/actions/runs/8816590755/job/24201209849#step:4:231
```
#25 1.434 admin:build: [sentry-vite-plugin] Warning: No release name provided. Will not inject release. Please set the `release.name` option to identify your release.
#25 1.434 admin:build: [sentry-vite-plugin] Warning: No release name provided. Will not create release. Please set the `release.name` option to identify your release.
#25 1.434 admin:build: [sentry-vite-plugin] Warning: No auth token provided. Will not upload source maps. Please set the `authToken` option. You can find information on how to generate a 
```

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Checklist**

- [ ] **⚠️ My code can have side-effects on other part of the code-base**
- [ ] I have added the Plausible tags/events
- [ ] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

<!-- If you have a Notion Ticket / GitHub Issue -->
<!-- Fixes [Notion ticket #123](https://notion.so/abc) -->

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
