### PR TITLE
fix(admin): 2446 - info message default value and empty filter

### DIFF
--- a/admin/src/components/filters-system-v2/components/filters/FilterPopOver.jsx
+++ b/admin/src/components/filters-system-v2/components/filters/FilterPopOver.jsx
@@ -40,6 +40,7 @@ export const DropDown = ({ isShowing, filter, selectedFilters, setSelectedFilter
   const ref = React.useRef(null);
 
   React.useEffect(() => {
+    if (!data) return;
     let temp = data;
     if (filter?.filter) {
       temp.filter(filter.filter);
@@ -48,8 +49,8 @@ export const DropDown = ({ isShowing, filter, selectedFilters, setSelectedFilter
       filter.sort(temp);
     }
 
-    const naIndex = data.findIndex((item) => item.key === "N/A");
-    const emptyIndex = data.findIndex((item) => item.key === "");
+    const naIndex = data.findIndex((item) => item?.key === "N/A");
+    const emptyIndex = data.findIndex((item) => item?.key === "");
 
     // Concatenate the arrays if both 'N/A' and '' are found
     if (naIndex !== -1 && emptyIndex !== -1) {
@@ -62,7 +63,7 @@ export const DropDown = ({ isShowing, filter, selectedFilters, setSelectedFilter
     }
 
     setOptionsVisible(temp);
-  }, [data]);
+  }, [data, filter]);
 
   React.useEffect(() => {
     // normalize search

--- a/admin/src/scenes/dashboardV2/components/ui/InfoMessage.tsx
+++ b/admin/src/scenes/dashboardV2/components/ui/InfoMessage.tsx
@@ -2,8 +2,13 @@ import React from "react";
 import { HiInformationCircle, HiExclamationCircle, HiExclamation } from "react-icons/hi";
 import cx from "classnames";
 
-export default function InfoMessage({ message, priority }) {
-  let Icon = null;
+interface Props {
+  message: string;
+  priority?: "normal" | "important" | "urgent";
+}
+
+export default function InfoMessage({ message, priority }: Props) {
+  let Icon = HiInformationCircle;
   switch (priority) {
     case "normal":
       Icon = HiInformationCircle;

--- a/admin/src/scenes/missions/view/details.jsx
+++ b/admin/src/scenes/missions/view/details.jsx
@@ -3,14 +3,13 @@ import { useHistory } from "react-router-dom";
 import ReactSelect from "react-select";
 import AsyncSelect from "react-select/async";
 import CreatableSelect from "react-select/creatable";
-
+import { useSelector } from "react-redux";
 import validator from "validator";
 
 import { useAddress, MISSION_STATUS } from "snu-lib";
 import { AddressForm } from "@snu/ds/common";
 import { useDebounce } from "@uidotdev/usehooks";
 import InfoMessage from "../../dashboardV2/components/ui/InfoMessage";
-import InfoCircleMission from "@/assets/icons/InfoCircleMission";
 
 import { translate, ROLES, MISSION_DOMAINS, PERIOD, MISSION_PERIOD_DURING_HOLIDAYS, MISSION_PERIOD_DURING_SCHOOL, SENDINBLUE_TEMPLATES, ENABLE_PM } from "@/utils";
 import MissionView from "./wrapper";
@@ -27,7 +26,6 @@ import { adminURL } from "../../../config";
 import ExternalLink from "../../../assets/icons/ExternalLink";
 import ViewStructureLink from "../../../components/buttons/ViewStructureLink";
 import { isPossiblePhoneNumber } from "libphonenumber-js";
-import { useSelector } from "react-redux";
 
 export default function DetailsView({ mission, setMission, getMission }) {
   const [values, setValues] = useState(mission);
@@ -278,18 +276,10 @@ export default function DetailsView({ mission, setMission, getMission }) {
           </div>
         ) : null}
         {mission.status === MISSION_STATUS.WAITING_VALIDATION ? (
-          <InfoMessage
-            bg="bg-blue-700"
-            Icon={InfoCircleMission}
-            message="La mission est en attente de validation. Son contenu va être vérifié par un référent SNU du département dans lequel se déroulera la mission dans les jours à venir."
-          />
+          <InfoMessage message="La mission est en attente de validation. Son contenu va être vérifié par un référent SNU du département dans lequel se déroulera la mission dans les jours à venir." />
         ) : null}
         {mission.status === MISSION_STATUS.DRAFT ? (
-          <InfoMessage
-            bg="bg-blue-700"
-            Icon={InfoCircleMission}
-            message='Si la mission reste au statut brouillon celle-ci ne sera pas étudiée et par conséquent le volontaire ne pourra pas y candidater. Pensez à modifier son statut en la passant "En attente de validation". (bouton en haut à droite de votre écran)'
-          />
+          <InfoMessage message='Si la mission reste au statut brouillon celle-ci ne sera pas étudiée et par conséquent le volontaire ne pourra pas y candidater. Pensez à modifier son statut en la passant "En attente de validation". (bouton en haut à droite de votre écran)' />
         ) : null}
         <div className="mb-8 rounded-xl bg-white pt-2 mt-8">
           <div className="flex flex-col rounded-xl bg-white px-8 pb-12">

--- a/admin/src/scenes/plan-transport/ligne-bus/View/View.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/View/View.jsx
@@ -2,7 +2,9 @@ import React from "react";
 import { HiOutlineBell, HiOutlineChatAlt } from "react-icons/hi";
 import { useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
+
 import { ROLES, canExportLigneBus, isLigneBusDemandeDeModificationOpen, ligneBusCanCreateDemandeDeModification, translate } from "snu-lib";
+
 import Bus from "../../../../assets/icons/Bus";
 import Breadcrumbs from "../../../../components/Breadcrumbs";
 import Loader from "../../../../components/Loader";
@@ -19,7 +21,6 @@ import Itineraire from "./components/Itineraire";
 import Modification from "./components/Modification";
 import PointDeRassemblement from "./components/PointDeRassemblement";
 import InfoMessage from "../../../dashboardV2/components/ui/InfoMessage";
-import { AiOutlineExclamationCircle } from "react-icons/ai";
 
 export default function View(props) {
   const [data, setData] = React.useState(null);
@@ -218,8 +219,7 @@ export default function View(props) {
         </div>
         {data.delayedForth === "true" || data.delayedBack === "true" ? (
           <InfoMessage
-            bg="bg-[#B45309]"
-            Icon={AiOutlineExclamationCircle}
+            priority="important"
             message={`Le départ de cette ligne de bus est retardé ${
               data.delayedForth === "true" && data.delayedBack === "true" ? "à l'aller et au retour" : data.delayedForth === "true" ? "à l'aller" : "au retour"
             }.`}

--- a/admin/src/scenes/volontaires/view/phase1.jsx
+++ b/admin/src/scenes/volontaires/view/phase1.jsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from "react";
 import { ImQuotesLeft } from "react-icons/im";
 import { useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
-import ModalConfirm from "@/components/modals/ModalConfirm";
 
 import { YOUNG_SOURCE } from "snu-lib";
+
+import ModalConfirm from "@/components/modals/ModalConfirm";
 import dayjs from "@/utils/dayjs.utils";
-import { AiOutlineExclamationCircle } from "react-icons/ai";
 import ExternalLink from "@/assets/icons/ExternalLink";
 import Refresh from "@/assets/icons/Refresh";
 import { adminURL } from "@/config";
@@ -14,6 +14,7 @@ import { capture } from "@/sentry";
 import api from "@/services/api";
 import { getCohortByName } from "@/services/cohort.service";
 import { YOUNG_STATUS_PHASE1, canAssignManually, translate, youngCheckinField } from "@/utils";
+
 import InfoMessage from "../../dashboardV2/components/ui/InfoMessage";
 import YoungHeader from "../../phase0/components/YoungHeader";
 import ModalAffectations from "../components/ModalAffectation";
@@ -112,8 +113,7 @@ export default function Phase1(props) {
       <div className="p-[30px]">
         {meetingPoint?.bus?.delayedForth === "true" || meetingPoint?.bus?.delayedBack === "true" ? (
           <InfoMessage
-            bg="bg-[#B45309]"
-            Icon={AiOutlineExclamationCircle}
+            priority="important"
             message={`Le départ de la ligne de bus de ce jeune est retardé ${
               meetingPoint?.bus?.delayedForth === "true" && meetingPoint?.bus?.delayedBack === "true"
                 ? "à l'Aller et au Retour"


### PR DESCRIPTION
**Description**

Correction des erreurs sentry.

**Todo**

- [x] Lors de l'harmonisation du composant InfoMessage (page /mission etc), la valeur par défaut n'étant pas précisé les anciens composants qui l'appel ne fournissait pas les bonnes props.
- [x] L'affichage du filtre sans `data` ne doit pas planter 

**Ticket / Issue**

- https://sentry.selego.co/organizations/sentry/issues/44994/events/5423e3d432c54199b21ebfbc893e1df0/?project=140&query=release%3A587d1657a&referrer=next-event
- https://sentry.selego.co/organizations/sentry/issues/44992/?project=140&query=release%3A587d1657a&referrer=release-issue-stream
- https://sentry.selego.co/organizations/sentry/issues/45024/?project=140&query=release%3A587d1657a&referrer=release-issue-stream
- https://sentry.selego.co/organizations/sentry/issues/45076/?alert_rule_id=161&alert_type=issue&environment=production&notification_uuid=e2480437-adcd-414f-a48e-757feb504f82&project=140&referrer=slack

https://www.notion.so/jeveuxaider/BUG-Admin-Oops-Page-sur-les-missions-ac260d2fe648495a985b6dd04fcd87db
