### PR TITLE
fix(admin): 2446 - Fix info message component

### DIFF
--- a/admin/src/scenes/dashboardV2/components/ui/InfoMessage.jsx
+++ b/admin/src/scenes/dashboardV2/components/ui/InfoMessage.jsx
@@ -14,6 +14,8 @@ export default function InfoMessage({ message, priority }) {
     case "urgent":
       Icon = HiExclamation;
       break;
+    default:
+      Icon = HiInformationCircle;
   }
   return (
     <div


### PR DESCRIPTION
Fix : https://www.notion.so/jeveuxaider/BUG-Admin-Oops-Page-sur-les-missions-ac260d2fe648495a985b6dd04fcd87db?pvs=4

Avant
<img width="1338" alt="Screenshot 2024-04-30 at 16 35 46" src="https://github.com/betagouv/service-national-universel/assets/95406348/46c54fce-c234-48f7-8095-51f346479e08">

Après
<img width="1342" alt="Screenshot 2024-04-30 at 16 35 26" src="https://github.com/betagouv/service-national-universel/assets/95406348/edb716a9-4643-461b-8e97-4594f35d029d">