### PR TITLE
fix(admin,app,lib): 2410 - Affichage de la bonne date de cohort independament de la timezone

### DIFF
--- a/admin/src/scenes/classe/view.jsx
+++ b/admin/src/scenes/classe/view.jsx
@@ -22,6 +22,7 @@ import {
   translateStatusClasse,
   COHORT_TYPE,
   IS_INSCRIPTION_OPEN_CLE,
+  formatDateFRTimezoneUTC,
 } from "snu-lib";
 import { FUNCTIONAL_ERRORS } from "snu-lib/functionalErrors";
 import { useSelector } from "react-redux";
@@ -268,10 +269,10 @@ export default function View() {
                   <p className="text-left text-sm  text-gray-800">Dates</p>
                   <div className="flex items-center">
                     <p className="text-left text-xs text-gray-500 flex-1">
-                      Début : <strong>{classe?.cohort ? dayjs(cohorts.find((c) => c.name === classe?.cohort)?.dateStart).format("DD/MM/YYYY") : ""}</strong>
+                      Début : <strong>{formatDateFRTimezoneUTC(cohorts?.find((c) => c.name === classe?.cohort)?.dateStart)}</strong>
                     </p>
                     <p className="text-left text-xs text-gray-500 flex-1">
-                      Fin : <strong>{classe?.cohort ? dayjs(cohorts.find((c) => c.name === classe?.cohort)?.dateEnd).format("DD/MM/YYYY") : ""}</strong>
+                      Fin : <strong>{formatDateFRTimezoneUTC(cohorts?.find((c) => c.name === classe?.cohort)?.dateEnd)}</strong>
                     </p>
                   </div>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21348,6 +21348,7 @@
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^25.0.3",
+        "date-fns-tz": "^3.1.3",
         "sanitize-html": "^2.12.1"
       },
       "devDependencies": {
@@ -21360,6 +21361,24 @@
       },
       "peerDependencies": {
         "@tanstack/react-query": "^5.29.0"
+      }
+    },
+    "packages/lib/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "packages/lib/node_modules/date-fns-tz": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.1.3.tgz",
+      "integrity": "sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0"
       }
     },
     "packages/lib/node_modules/rollup": {

--- a/packages/lib/.eslintrc.js
+++ b/packages/lib/.eslintrc.js
@@ -4,7 +4,8 @@ module.exports = {
     browser: true,
     es2021: true,
   },
-  extends: "eslint:recommended",
+  extends: ["eslint:recommended", "plugin:jest/recommended"],
+  plugins: ["jest", "prettier"],
   overrides: [],
   parserOptions: {
     ecmaVersion: "latest",

--- a/packages/lib/date.js
+++ b/packages/lib/date.js
@@ -1,3 +1,5 @@
+const { toZonedTime } = require("date-fns-tz");
+
 const MONTHS = ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"];
 
 const formatDay = (date) => {
@@ -143,6 +145,11 @@ const formatDateForPostGre = (date) => {
   const day = d.getDate().toString().padStart(2, "0");
 
   return `${year}-${month}-${day}`;
+};
+
+export const getZonedDate = (date, timeZone = "Europe/Paris") => {
+  const zonedDate = toZonedTime(new Date(date), timeZone);
+  return zonedDate;
 };
 
 export {

--- a/packages/lib/date.js
+++ b/packages/lib/date.js
@@ -1,4 +1,4 @@
-const { toZonedTime } = require("date-fns-tz");
+import { toZonedTime } from "date-fns-tz";
 
 const MONTHS = ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"];
 

--- a/packages/lib/date.spec.js
+++ b/packages/lib/date.spec.js
@@ -1,0 +1,11 @@
+import { getZonedDate } from "./date";
+
+describe("dates", () => {
+  it("should return zoned date", () => {
+    let date = getZonedDate("2024-06-03T00:00:00.000+00:00");
+    expect(date.toISOString()).toBe("2024-06-03T00:00:00.000Z");
+
+    date = getZonedDate("2024-05-26T00:00:00.000Z", "America/Martinique");
+    expect(date.toISOString()).toBe("2024-05-25T18:00:00.000Z");
+  });
+});

--- a/packages/lib/date.spec.js
+++ b/packages/lib/date.spec.js
@@ -1,4 +1,4 @@
-import { getZonedDate } from "./date";
+import { formatDateFRTimezoneUTC, getZonedDate } from "./date";
 
 describe("dates", () => {
   it("should return zoned date", () => {
@@ -7,5 +7,15 @@ describe("dates", () => {
 
     date = getZonedDate("2024-05-26T00:00:00.000Z", "America/Martinique");
     expect(date.toISOString()).toBe("2024-05-25T18:00:00.000Z");
+  });
+  it("formatDateFRTimezoneUTC", () => {
+    let date = formatDateFRTimezoneUTC("2024-06-03T23:00:00.000+00:00");
+    expect(date).toBe("03/06/2024");
+    date = formatDateFRTimezoneUTC("2024-06-03T01:00:00.000+00:00");
+    expect(date).toBe("03/06/2024");
+    date = formatDateFRTimezoneUTC("2024-06-03T00:00:00.000+00:00");
+    expect(date).toBe("03/06/2024");
+    date = formatDateFRTimezoneUTC("2024-06-03T18:00:00.000+00:00");
+    expect(date).toBe("03/06/2024");
   });
 });

--- a/packages/lib/jest.config.js
+++ b/packages/lib/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  globals: {
+    "js-jest": {
+      isolatedModules: true,
+    },
+  },
+  moduleFileExtensions: ["js", "json"],
+  modulePaths: ["<rootDir>"],
+  testRegex: ".*.spec.js$",
+  testPathIgnorePatterns: ["/(common-js|node_modules)/"],
+  testEnvironment: "node",
+};

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .js,.jsx",
     "lint:fix": "eslint . --ext .js --fix",
     "lint:report": "eslint . --ext .js --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --env=node --detectOpenHandles --verbose --forceExit --testTimeout=20000 --maxWorkers=2",
     "clean": "rm -fr node_modules .turbo common-js .swc"
   },
   "author": "",
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@rollup/plugin-commonjs": "^25.0.3",
+    "date-fns-tz": "^3.1.3",
     "sanitize-html": "^2.12.1"
   },
   "peerDependencies": {

--- a/packages/lib/sessions.js
+++ b/packages/lib/sessions.js
@@ -1,6 +1,8 @@
 import { regionsListDROMS } from "./region-and-departments";
 import { YOUNG_STATUS, YOUNG_STATUS_PHASE1 } from "./constants";
 import { isCle } from "./young";
+import { getZonedDate } from "./date";
+
 const oldSessions = [{ name: "2019" }, { name: "2020" }, { name: "2021" }, { name: "2022" }, { name: "Février 2022" }, { name: "Juin 2022" }, { name: "Juillet 2022" }];
 
 const sessions2023CohortNames = ["Février 2023 - C", "Avril 2023 - A", "Avril 2023 - B", "Juin 2023", "Juillet 2023", "Octobre 2023 - NC"];
@@ -184,8 +186,9 @@ const getCohortYear = (cohort) => cohort?.dateStart?.slice(0, 4);
 
 const getCohortPeriod = (cohort, withBold = false) => {
   if (!cohort.dateStart || !cohort.dateEnd) return cohort.name || cohort;
-  const startDate = new Date(cohort.dateStart);
-  const endDate = new Date(cohort.dateEnd);
+  const startDate = getZonedDate(cohort.dateStart);
+  const endDate = getZonedDate(cohort.dateEnd);
+
   const endDateformatOptions = { year: "numeric", month: "long", day: "numeric" };
   const startDateformatOptions = { day: "numeric" };
   if (startDate.getMonth() !== endDate.getMonth()) {
@@ -203,8 +206,9 @@ const getCohortPeriod = (cohort, withBold = false) => {
 };
 
 const formatShortCohortPeriod = (cohort) => {
-  var startDate = new Date(cohort.dateStart);
-  var endDate = new Date(cohort.dateEnd);
+  if (!cohort.dateStart || !cohort.dateEnd) return cohort.name || cohort;
+  const startDate = getZonedDate(cohort.dateStart);
+  const endDate = getZonedDate(cohort.dateEnd);
 
   var startDateformatOptions = {
     day: "numeric",

--- a/packages/lib/sessions.spec.js
+++ b/packages/lib/sessions.spec.js
@@ -1,0 +1,19 @@
+import { formatCohortPeriod, getCohortPeriod } from "./sessions";
+
+describe("sessions", () => {
+  it("cohort period should return valid formatted period", () => {
+    let formattedPeriod = getCohortPeriod({ name: "MyCohort", dateStart: "2024-06-03T00:00:00.000+00:00", dateEnd: "2024-06-14T00:00:00.000+00:00" });
+    expect(formattedPeriod).toBe("du 3 au 14 juin 2024");
+    formattedPeriod = getCohortPeriod({ name: "MyCohort", dateStart: "2024-06-03T00:00:00.000+00:00", dateEnd: "2024-06-14T00:00:00.000+00:00" }, true);
+    expect(formattedPeriod).toBe("du <b>3 au 14 juin 2024</b>");
+  });
+
+  it("cohort period should return valid short formatted period", () => {
+    let formattedPeriod = formatCohortPeriod({ name: "MyCohort", dateStart: "2024-05-26T00:00:00.000Z", dateEnd: "2024-06-07T00:00:00.000Z" }, "long");
+    expect(formattedPeriod).toBe("du 26 mai au 7 juin 2024");
+    formattedPeriod = formatCohortPeriod({ name: "MyCohort", dateStart: "2024-05-26T00:00:00.000Z", dateEnd: "2024-06-07T00:00:00.000Z" }, "short");
+    expect(formattedPeriod).toBe("26/05 > 07/06");
+    formattedPeriod = formatCohortPeriod({ name: "MyCohort", dateStart: "2024-05-26T00:00:00.000Z", dateEnd: "2024-06-07T00:00:00.000Z" });
+    expect(formattedPeriod).toBe("26/05 > 07/06");
+  });
+});


### PR DESCRIPTION
**Description**

Gestion de l'affichage des dates de séjours indépendamment de la timezone.

**Todo**

- [x] Formatage de la période de cohort en fonction 
- [x] Ajout test unitaire

**Ticket / Issue**

https://www.notion.so/jeveuxaider/BUG-ADMIN-UTC-Martinique-f65f1efe4ef04ab88abfc03d42e7b6ce

**Testing instructions**

Changer sa timezone pour être en UTC de Martinique, vérifier que la date des cohorts est la bonne.
