### PR TITLE
fix(admin): Corrections de l'affichage des données de session

### DIFF
--- a/admin/src/components/ui/forms/dateForm/ToggleDate.jsx
+++ b/admin/src/components/ui/forms/dateForm/ToggleDate.jsx
@@ -30,10 +30,10 @@ export default function ToggleDate({ value, onChange, range, onChangeRange, disa
       </div>
       <div className="flex items-center justify-between">
         <p className="text-left text-xs text-gray-500">
-          Début : <strong>{range?.from ? dayjs(range?.from).format("DD/MM/YYYY") : ""}</strong>
+          Début : <strong>{value ? dayjs(range?.from).format("DD/MM/YYYY") : ""}</strong>
         </p>
         <p className="text-left text-xs text-gray-500">
-          Fin : <strong>{range?.to ? dayjs(range?.to).format("DD/MM/YYYY") : ""}</strong>
+          Fin : <strong>{value ? dayjs(range?.to).format("DD/MM/YYYY") : ""}</strong>
         </p>
         <Popover className="relative">
           {({ open }) => (

--- a/admin/src/scenes/centersV2/components/sessions/OccupationCard.jsx
+++ b/admin/src/scenes/centersV2/components/sessions/OccupationCard.jsx
@@ -1,26 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
 import { canCreateOrUpdateCohesionCenter } from "@/utils";
 import Trash from "@/assets/icons/Trash";
 
 import ModalConfirmDelete from "../ModalConfirmDelete";
 
-export default function OccupationCard({ placesLeft, placesTotalModified, placesTotal, canBeDeleted, user, handleSessionDelete, modalDelete, setModalDelete }) {
+export default function OccupationCard({ placesLeft, placesTotal, canBeDeleted, user, handleSessionDelete, modalDelete, setModalDelete }) {
   let height = `h-0`;
-  const getOccupationPercentage = () => {
-    if (isNaN(placesTotalModified) || placesTotalModified === "" || placesTotalModified < 0) return 0.1;
-    const percentage = (((placesTotal - placesLeft) * 100) / placesTotalModified).toFixed(2);
-    if (percentage < 0 || percentage === Number.NEGATIVE_INFINITY) return 0.1;
-    if (isNaN(percentage)) return 0.1;
-    return percentage;
-  };
-  const [occupationPercentage, setOccupationPercentage] = useState(0);
-  const placesLeftModified = !isNaN(placesLeft + parseInt(placesTotalModified) - placesTotal) ? placesLeft + parseInt(placesTotalModified) - placesTotal : 0;
-  useEffect(() => {
-    setOccupationPercentage(getOccupationPercentage());
-  }, [placesTotalModified]);
+  const occupationPercentage = ((placesTotal - placesLeft) * 100) / placesTotal;
 
-  if (occupationPercentage < 20) height = "h-[20%]";
+  if (occupationPercentage === 0) height = "h-[10%]";
+  else if (occupationPercentage < 20) height = "h-[20%]";
   else if (occupationPercentage < 30) height = "h-[30%]";
   else if (occupationPercentage < 40) height = "h-[40%]";
   else if (occupationPercentage < 50) height = "h-[50%]";
@@ -33,7 +23,7 @@ export default function OccupationCard({ placesLeft, placesTotalModified, places
   let bgColor = "bg-blue-800";
   if (occupationPercentage > 100) bgColor = "bg-red-500";
   if (isNaN(occupationPercentage)) return <></>;
-  return occupationPercentage ? (
+  return (
     <div className="flex flex-1 flex-col items-center justify-center py-4 px-8">
       <ModalConfirmDelete
         isOpen={modalDelete.isOpen}
@@ -65,7 +55,7 @@ export default function OccupationCard({ placesLeft, placesTotalModified, places
             <div className="h-6 w-2 rounded-full bg-gray-200" />
             <div>
               <div className="text-xs font-normal">Places libres</div>
-              <div className="text-base font-bold">{placesLeftModified}</div>
+              <div className="text-base font-bold">{placesLeft}</div>
             </div>
           </div>
         </div>
@@ -87,5 +77,5 @@ export default function OccupationCard({ placesLeft, placesTotalModified, places
         </div>
       )}
     </div>
-  ) : null;
+  );
 }

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
@@ -261,17 +261,19 @@ export default function SessionList({ center, sessions, user, focusedSession, on
                       <ToggleDate
                         label="Dates spécifiques"
                         tooltipText={
-                          focusedCohortData ? (
-                            <p>
-                              Les dates de cette session diffèrent des dates officielles :{" "}
-                              <strong>{`${dayjs(focusedCohortData.dateStart).format("DD")} - ${dayjs(focusedCohortData.dateEnd).format("DD MMMM YYYY")}`}</strong>.
-                            </p>
-                          ) : null
+                          <p>
+                            Les dates de cette session diffèrent des dates officielles :{" "}
+                            <strong>{`${dayjs(focusedCohortData?.dateStart).format("DD")} - ${dayjs(focusedCohortData?.dateEnd).format("DD MMMM YYYY")}`}</strong>.
+                          </p>
                         }
                         readOnly={!editingBottom || !canPutSpecificDateOnSessionPhase1(user)}
                         value={editingBottom ? editInfoSession.hasSpecificDate : focusedSession.hasSpecificDate}
                         onChange={() => setEditInfoSession({ ...editInfoSession, hasSpecificDate: !editInfoSession.hasSpecificDate })}
-                        range={getSpecificDate()}
+                        range={
+                          editingBottom
+                            ? { from: editInfoSession.dateStart, to: editInfoSession.dateEnd }
+                            : { from: focusedSession.dateStart || focusedCohortData?.dateStart, to: focusedSession.dateEnd || focusedCohortData?.dateEnd }
+                        }
                         onChangeRange={(range) => {
                           setEditInfoSession({
                             ...editInfoSession,

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
@@ -201,7 +201,6 @@ export default function SessionList({ center, sessions, user, focusedSession, on
                 <OccupationCard
                   canBeDeleted={focusedSession.canBeDeleted}
                   placesTotal={focusedSession.placesTotal}
-                  placesTotalModified={editInfoSession.placesTotal}
                   placesLeft={focusedSession.placesLeft}
                   user={user}
                   modalDelete={modalDelete}

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
@@ -138,6 +138,25 @@ export default function SessionList({ center, sessions, user, focusedSession, on
     }
   };
 
+  const getSpecificDate = () => {
+    if (editingBottom && editInfoSession?.hasSpecificDate) {
+      return {
+        from: editInfoSession?.dateStart || focusedCohortData.dateStart,
+        to: editInfoSession?.dateEnd || focusedCohortData.dateEnd,
+      };
+    }
+    if (!editingBottom && focusedSession?.hasSpecificDate) {
+      return {
+        from: focusedSession.dateStart,
+        to: focusedSession.dateEnd,
+      };
+    }
+    return {
+      from: undefined,
+      to: undefined,
+    };
+  };
+
   if (!sessions || sessions.length === 0) return null;
   return (
     <div className="flex flex-col gap-4 mx-8">
@@ -250,12 +269,9 @@ export default function SessionList({ center, sessions, user, focusedSession, on
                           ) : null
                         }
                         readOnly={!editingBottom || !canPutSpecificDateOnSessionPhase1(user)}
-                        value={editInfoSession.hasSpecificDate}
+                        value={editingBottom ? editInfoSession.hasSpecificDate : focusedSession.hasSpecificDate}
                         onChange={() => setEditInfoSession({ ...editInfoSession, hasSpecificDate: !editInfoSession.hasSpecificDate })}
-                        range={{
-                          from: editInfoSession?.dateStart || undefined,
-                          to: editInfoSession?.dateEnd || undefined,
-                        }}
+                        range={getSpecificDate()}
                         onChangeRange={(range) => {
                           setEditInfoSession({
                             ...editInfoSession,

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
@@ -230,7 +230,7 @@ export default function SessionList({ center, sessions, user, focusedSession, on
                       error={errors.placesTotal}
                       readOnly={!editingBottom || !canCreateOrUpdateCohesionCenter(user)}
                       label="Places ouvertes"
-                      value={editInfoSession.placesTotal}
+                      value={editingBottom ? editInfoSession.placesTotal : focusedSession.placesTotal}
                       onChange={(e) => setEditInfoSession({ ...editInfoSession, placesTotal: e.target.value })}
                       tooltips={
                         "C’est le nombre de places proposées sur un séjour. Cette donnée doit être inférieure ou égale à la capacité maximale d’accueil, elle ne peut lui être supérieure."

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
@@ -149,6 +149,7 @@ export default function SessionList({ center, sessions, user, focusedSession, on
             withBadge
             filterFn={(c) => sessions.find((s) => s.cohort === c.name)}
             onChange={(cohortName) => {
+              setEditingBottom(false);
               const session = sessions.find((s) => s.cohort === cohortName);
               if (session) onFocusedSessionChange(session);
               history.replace({ search: `?cohort=${cohortName}` });

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.jsx
@@ -138,25 +138,6 @@ export default function SessionList({ center, sessions, user, focusedSession, on
     }
   };
 
-  const getSpecificDate = () => {
-    if (editingBottom && editInfoSession?.hasSpecificDate) {
-      return {
-        from: editInfoSession?.dateStart || focusedCohortData.dateStart,
-        to: editInfoSession?.dateEnd || focusedCohortData.dateEnd,
-      };
-    }
-    if (!editingBottom && focusedSession?.hasSpecificDate) {
-      return {
-        from: focusedSession.dateStart,
-        to: focusedSession.dateEnd,
-      };
-    }
-    return {
-      from: undefined,
-      to: undefined,
-    };
-  };
-
   if (!sessions || sessions.length === 0) return null;
   return (
     <div className="flex flex-col gap-4 mx-8">


### PR DESCRIPTION
- Problème d'affichage du nombre de places dans une session : on affiche 0 au lieu de la donnée en DB. Il fallait cliquer sur "modifier" puis "Annuler" pour afficher les bonnes données.
- Problème d'affichage des dates spécifiques de séjour (qui supplantent les dates de cohorte) : elles ne doivent apparaître que si des dates spécifiques sont sélectionnées. Actuellement si on clique sur "Modifier" puis "Annuler", les dates de la cohorte s'affichent à tord.