### PR TITLE
feat(admin,api): 2458 - supprimer le droit a supprimer des jeunes pour les refs dep / reg 

### DIFF
--- a/admin/src/scenes/inscription/panel.jsx
+++ b/admin/src/scenes/inscription/panel.jsx
@@ -2,8 +2,9 @@ import Img3 from "../../assets/close_icon.png";
 import Img2 from "../../assets/pencil.svg";
 import React, { useEffect, useState } from "react";
 import { Link, useHistory } from "react-router-dom";
+import { useSelector } from "react-redux";
 
-import { formatDateFR } from "snu-lib";
+import { formatDateFR, ROLES } from "snu-lib";
 import Badge from "../../components/Badge";
 import DownloadButton from "../../components/buttons/DownloadButton";
 import PanelActionButton from "../../components/buttons/PanelActionButton";
@@ -24,6 +25,7 @@ export default function InscriptionPanel({ onChange, value }) {
   const [young, setYoung] = useState(null);
   const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = useState(false);
   const history = useHistory();
+  const user = useSelector((state) => state.Auth.user);
 
   useEffect(() => {
     (async () => {
@@ -87,7 +89,7 @@ export default function InscriptionPanel({ onChange, value }) {
               </div>
             ) : null}
             {value.frenchNationality === "true" ? <div style={{ fontStyle: "italic", fontSize: "0.9rem" }}>🇫🇷 Nationalité française</div> : null}
-            <div style={{ display: "flex", flexWrap: "wrap" }}>
+            <div className="flex flex-wrap justify-around">
               <Link to={`/volontaire/${value._id}`} onClick={() => plausibleEvent("Inscriptions/CTA - Consulter profil jeune")}>
                 <PanelActionButton icon="eye" title="Consulter" />
               </Link>
@@ -98,7 +100,7 @@ export default function InscriptionPanel({ onChange, value }) {
                 }}>
                 <PanelActionButton icon="impersonate" title="Prendre&nbsp;sa&nbsp;place" />
               </button>
-              <PanelActionButton onClick={handleDeleteYoung} icon="bin" title="Supprimer" />
+              {user.role === ROLES.ADMIN && <PanelActionButton onClick={handleDeleteYoung} icon="bin" title="Supprimer" />}
             </div>
             {value.status === YOUNG_STATUS.WITHDRAWN && <div className="mt-3">⚠️ Désistement : &quot;{value.withdrawnMessage}&quot;</div>}
           </div>

--- a/admin/src/scenes/phase0/components/YoungHeader.jsx
+++ b/admin/src/scenes/phase0/components/YoungHeader.jsx
@@ -362,9 +362,11 @@ export default function YoungHeader({ young, tab, onChange, phase = YOUNG_PHASE.
 
             {young.status !== YOUNG_STATUS.DELETED && ![ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE].includes(user.role) && (
               <div className="my-[15px] flex items-center justify-between">
-                <Button icon={<Bin fill="red" />} onClick={handleDeleteYoung}>
-                  Supprimer
-                </Button>
+                {user.role === ROLES.ADMIN && (
+                  <Button icon={<Bin fill="red" />} onClick={handleDeleteYoung}>
+                    Supprimer
+                  </Button>
+                )}
                 <button
                   onClick={() => {
                     window.open(appURL, "_blank");

--- a/admin/src/scenes/volontaires/panel.jsx
+++ b/admin/src/scenes/volontaires/panel.jsx
@@ -105,7 +105,7 @@ export default function VolontairePanel({ onChange, value }) {
                 à {young.birthZip} {young.birthCity}, {young.birthCountry}
               </div>
             ) : null}
-            <div style={{ display: "flex", flexWrap: "wrap" }}>
+            <div className="flex flex-wrap justify-around">
               <Link to={`/volontaire/${young._id}`} onClick={() => plausibleEvent("Volontaires/CTA - Consulter profil volontaire")}>
                 <PanelActionButton icon="eye" title="Consulter" />
               </Link>
@@ -114,7 +114,7 @@ export default function VolontairePanel({ onChange, value }) {
                   <button onClick={() => onPrendreLaPlace(young._id)}>
                     <PanelActionButton icon="impersonate" title="Prendre&nbsp;sa&nbsp;place" />
                   </button>
-                  <PanelActionButton onClick={handleDeleteYoung} icon="bin" title="Supprimer" />
+                  {user.role === ROLES.ADMIN && <PanelActionButton onClick={handleDeleteYoung} icon="bin" title="Supprimer" />}
                 </>
               )}
             </div>

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -816,7 +816,6 @@ router.post("/france-connect/user-info", async (req, res) => {
 });
 
 // Delete one user (only admin can delete user)
-// And apparently referent in same geography as well (see canDeleteYoung())
 router.put("/:id/soft-delete", passport.authenticate(["referent"], { session: false, failWithError: true }), async (req, res) => {
   try {
     const { error, value: id } = validateId(req.params.id);
@@ -827,7 +826,7 @@ router.put("/:id/soft-delete", passport.authenticate(["referent"], { session: fa
 
     const young = await YoungObject.findById(id);
     if (!young) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
-    if (!canDeleteYoung(req.user, young)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
+    if (!canDeleteYoung(req.user)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
 
     const fieldToKeep = [
       "_id",

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -104,12 +104,7 @@ function canInviteUser(actorRole, targetRole) {
 
 const canDeleteStructure = (actor, target) => isAdmin(actor) || referentInSameGeography(actor, target);
 
-const canDeleteYoung = (actor, target) => {
-  // un référent peut supprimer un volontaire, mais un volontaire peut se supprimer uniquement si il est HTS
-  if (actor._id.toString() === target._id.toString()) {
-    if (target.source === "CLE") return false;
-    return true;
-  }
+const canDeleteYoung = (actor) => {
   return isAdmin(actor);
 };
 

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -110,7 +110,7 @@ const canDeleteYoung = (actor, target) => {
     if (target.source === "CLE") return false;
     return true;
   }
-  return isAdmin(actor) || referentInSameGeography(actor, target);
+  return isAdmin(actor);
 };
 
 function canEditYoung(actor, young) {


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Enlever-la-possibilit-de-supprimer-un-volontaire-sauf-pour-les-mod-rateurs-ba2162da689044e481126aa203b61144?pvs=4
