### PR TITLE
chore(api): fix CPU is 200% by not fetching the whole young item from ES

### DIFF
--- a/api/src/services/stats.service/engagement.js
+++ b/api/src/services/stats.service/engagement.js
@@ -264,6 +264,7 @@ async function getYoungsWhoStartedOrFinishedMissions(startDate, endDate, user) {
     },
     size: ES_NO_LIMIT,
     track_total_hits: true,
+    _source: false,
   };
 
   if (user.role === ROLES.REFERENT_DEPARTMENT) {


### PR DESCRIPTION
Issue : High cpu usage and very slow ES fetching
Solution : Remove _source from ES fetching