### PR TITLE
fix(admin): 2247 - attestation sur l'honneur disparue

### DIFF
--- a/admin/src/scenes/phase0/components/sections/identite/SectionIdentiteCni.jsx
+++ b/admin/src/scenes/phase0/components/sections/identite/SectionIdentiteCni.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
 
-import { getCohortStartDate, translate, ROLES } from "snu-lib";
+import { translate, ROLES } from "snu-lib";
 
 import api from "@/services/api";
 import dayjs from "@/utils/dayjs.utils";
@@ -88,9 +88,9 @@ export default function SectionIdentiteCni({ young, cohort, globalMode, currentR
 function HonorCertificate({ young, cohort }) {
   let cniExpired = false;
   if (young && young.cohort && young.latestCNIFileExpirationDate) {
-    const cohortDate = getCohortStartDate(young, cohort);
-    if (cohortDate) {
-      cniExpired = dayjs(young.latestCNIFileExpirationDate).toUtc().valueOf() < dayjs(cohortDate).toUtc().valueOf();
+    const cohortStartingDate = cohort?.dateStart;
+    if (cohortStartingDate) {
+      cniExpired = dayjs(young.latestCNIFileExpirationDate).toUtc().valueOf() < dayjs(cohortStartingDate).toUtc().valueOf();
     }
   }
 

--- a/admin/src/scenes/phase0/utils/index.js
+++ b/admin/src/scenes/phase0/utils/index.js
@@ -32,6 +32,9 @@ export function filterDataForYoungSection(data, section) {
       foreignCity: data.foreignCity,
       foreignCountry: data.foreignCountry,
       files: data.files,
+      cohort: data.cohort,
+      parentStatementOfHonorInvalidId: data.parentStatementOfHonorInvalidId,
+      parent1Email: data.parent1Email,
     };
   } else if (section === "parent") {
     bodyYoungSection = {


### PR DESCRIPTION
Fix attestation sur l'honneur disparue côté backoffice :

- Nom de la cohorte n'était plus accessible dans le composant
- La méthode pour obtenir les dates d'une cohorte est dépréciée

https://www.notion.so/jeveuxaider/BUG-Admin-Attestation-sur-l-honneur-disparue-f73867467b074f1bb7a1276ca56909c1?d=2225a08acfe04c5cad7428bdc522b867