### PR TITLE
fix(admin): 2607 - retirer la possibilité aux admin CLE de désister les jeunes

### DIFF
--- a/admin/src/scenes/classe/utils/index.js
+++ b/admin/src/scenes/classe/utils/index.js
@@ -37,6 +37,7 @@ export const statusClassForBadge = (status) => {
 export function getRights(user, classe, cohort) {
   if (!user || !classe || !cohort) return {};
   return {
+    //Attention, le canEdit donne aussi les droit a désister la classe pour les ADMIN CLE !!!
     canEdit:
       // [ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE, ROLES.ADMIN, ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role) &&
       // classe?.status !== STATUS_CLASSE.WITHDRAWN, //à garder car ça va changer

--- a/admin/src/scenes/phase0/components/YoungHeader.jsx
+++ b/admin/src/scenes/phase0/components/YoungHeader.jsx
@@ -260,11 +260,12 @@ export default function YoungHeader({ young, tab, onChange, phase = YOUNG_PHASE.
               )}
             </Title>
             <AttestationDownloadButton young={young} />
-            {[ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE].includes(user.role) && young.status !== YOUNG_STATUS.WITHDRAWN && (
+            {/* temporary disabled (demande DG) */}
+            {/*             {[ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE].includes(user.role) && young.status !== YOUNG_STATUS.WITHDRAWN && (
               <>
                 <DsfrButton title="Désister" onClick={() => onSelectStatus(YOUNG_STATUS.WITHDRAWN)} />
               </>
-            )}
+            )} */}
           </div>
 
           {isStructure ? (

--- a/admin/src/scenes/phase0/components/YoungHeader.jsx
+++ b/admin/src/scenes/phase0/components/YoungHeader.jsx
@@ -350,7 +350,7 @@ export default function YoungHeader({ young, tab, onChange, phase = YOUNG_PHASE.
               </div>
             </div>
             <Field
-              mode="edition"
+              mode={[ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE].includes(user.role) ? "readonly" : "edition"}
               name="status"
               label={translate(phase)}
               value={translateInscriptionStatus(young.status)}


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/CLE-Enlever-la-fonctionnalit-d-sister-pour-les-admin-CLE-chefs-d-tablissement-coordinateurs-487c0a60964e4ba79a4001ba718ea840?pvs=4
