### PR TITLE
feat(github,terraform): 2469 - Crons Healthchecks

### DIFF
--- a/.github/workflows/deploy-production-hotfix.yml
+++ b/.github/workflows/deploy-production-hotfix.yml
@@ -266,7 +266,8 @@ jobs:
           done <<< 'app
           admin
           api
-          antivirus'
+          antivirus
+          crons'
 
           if $failure
           then

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -305,7 +305,8 @@ jobs:
           done <<< 'app
           admin
           api
-          antivirus'
+          antivirus
+          crons'
 
           if $failure
           then

--- a/terraform/environments/production/production.tf
+++ b/terraform/environments/production/production.tf
@@ -263,6 +263,9 @@ output "api_image_tag" {
 output "api_container_status" {
   value = scaleway_container.api.status
 }
+output "crons_container_status" {
+  value = scaleway_container.crons.status
+}
 
 output "app_endpoint" {
   value = "https://${local.app_hostname}"


### PR DESCRIPTION
[2469 - check container status](https://www.notion.so/jeveuxaider/Sprint-tech-W21-23-18e873edd5dd4e18a86fde2336f001fc?p=defd50ecec41453cb614655b6220118b&pm=s)

Check the status of container after deployment.
Exit with failure if one container is not in 'ready' state