### PR TITLE
fix(admin): 2613 -  Créer un centre

### DIFF
--- a/admin/src/scenes/centersV2/components/ModalRattacherCentre.tsx
+++ b/admin/src/scenes/centersV2/components/ModalRattacherCentre.tsx
@@ -51,7 +51,7 @@ export default function ModalRattacherCentre({ isOpen, onSuccess, onCancel, user
 
   const handleChange = (option) => {
     if (option.value === "new") {
-      history.push("/centre/nouveau");
+      history.push(`/centre/nouveau?cohort=${selectedCohort}`);
       return;
     }
     setSelectedCentre(option.center);

--- a/admin/src/scenes/centersV2/components/ModalRattacherCentre.tsx
+++ b/admin/src/scenes/centersV2/components/ModalRattacherCentre.tsx
@@ -36,9 +36,25 @@ export default function ModalRattacherCentre({ isOpen, onSuccess, onCancel, user
 
   const fetchCenters = async (q: string) => {
     const { responses } = await api.post("/elasticsearch/cohesioncenter/not-in-cohort/" + selectedCohort, { filters: { searchbar: [q] } });
-    return responses[0].hits.hits.map((hit) => {
-      return { label: hit._source.name, value: hit._id, center: hit._source };
+    const options = responses[0].hits.hits.map((hit) => ({ label: hit._source.name, value: hit._id, center: hit._source }));
+    options.push({
+      label: (
+        <div className="p-1 border-t-2 text-center">
+          <p className="mt-2 text-center">Le centre n'est pas dans la liste ?</p>
+          <p className="mt-2 text-blue-600">Créer un centre</p>
+        </div>
+      ),
+      value: "new",
     });
+    return options;
+  };
+
+  const handleChange = (option) => {
+    if (option.value === "new") {
+      history.push("/centre/nouveau");
+      return;
+    }
+    setSelectedCentre(option.center);
   };
 
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -103,7 +119,7 @@ export default function ModalRattacherCentre({ isOpen, onSuccess, onCancel, user
               label="Nom du centre"
               placeholder="Nom du centre"
               value={selectedCentre ? { label: selectedCentre.name, value: selectedCentre._id } : null}
-              onChange={(option) => setSelectedCentre(option.center)}
+              onChange={handleChange}
               closeMenuOnSelect
               isAsync
               loadOptions={fetchCenters}


### PR DESCRIPTION
**Description**

Dans [cette PR](https://github.com/betagouv/service-national-universel/pull/3857), la modale de création de session a été mise à jour en fonction de la maquette mais l'option "Créer un centre" est passé à la trappe. Cette PR remet l'option.

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have added the Plausible tags/events
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

[Ticket](https://www.notion.so/jeveuxaider/BUG-Admin-Impossibilit-de-cr-er-un-centre-404938b2378946208b62b357e0fb65d8?pvs=4)

**Testing instructions**

Cliquer sur "Créer un centre" depuis la modale "Rattacher un centre" de la page de centre.