### PR TITLE
chore(api): 2591 - Create crons project on cc

### DIFF
--- a/.github/workflows/cc-deploy-production.yml
+++ b/.github/workflows/cc-deploy-production.yml
@@ -30,6 +30,10 @@ jobs:
           - name: admin
             tag: ${{inputs.admin_image_tag}}
             remote: CLEVER_CLOUD_GIT_REMOTE_ADMIN_DOCKER
+          # crons use the same docker image as api
+          - name: api
+            tag: ${{inputs.api_image_tag}}
+            remote: CLEVER_CLOUD_GIT_REMOTE_CRONS_DOCKER
 
     steps:
       - name: Create SSH key

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -113,11 +113,6 @@
   });
   app.use(loggingMiddleware);
 
-  // WARNING : CleverCloud only
-  if (process.env.RUN_CRONS_CC && ENVIRONMENT === "production" && process.env.CC_DEPLOYMENT_ID && process.env.INSTANCE_NUMBER === "0") {
-    require("./crons");
-  }
-
   app.use(cookieParser());
 
   app.use(express.static(__dirname + "/../public"));

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -8,7 +8,7 @@
     originalConsoleError.apply(console, arguments);
   };
 
-  if (process.env.RUN_CRONS) {
+  if (process.env.RUN_CRONS === "true") {
     const { PORT } = require("./config");
     const { initSentry } = require("./sentry");
     initSentry();


### PR DESCRIPTION
[2591 - CC crons project](https://www.notion.so/jeveuxaider/a0136c3c269c4d3eade64c87fede81b1?v=c4055128404c4daaa5e4541e4a821c26&p=544c4cad5eb340e78c90830e9e5c7e5b&pm=s)

Create a standalone cron project on clever cloud, so we have the same behaviour (env) on each provider

- CLEVER_CLOUD_GIT_REMOTE_CRONS_DOCKER GitHub secret added
- Create CRONS-PROD-DOCKER project in Clevercloud & Copy env var from API-PROD-DOCKER + RUN_CRONS = « true »