### PR TITLE
fix(api): 2286 - add young classeId index

### DIFF
--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -2199,6 +2199,7 @@ Schema.plugin(
 Schema.index({ ligneId: 1 });
 Schema.index({ sessionPhase1Id: 1 });
 Schema.index({ sessionPhase1Id: 1, status: 1 });
+Schema.index({ classeId: -1 });
 
 const OBJ = mongoose.model(MODELNAME, Schema);
 if (ENVIRONMENT === "production") OBJ.syncIndexes();


### PR DESCRIPTION
**Description**

Ajout de l'index dans le model mongo pour qu'il soit réappliqué à chaque déploiement.

lié à https://github.com/betagouv/service-national-universel/pull/3904

**Ticket**

https://www.notion.so/jeveuxaider/TRANSPORT-CLE-Bug-Exports-classes-sch-ma-de-r-partition-pour-les-CLE-da6b90be5f914cc7b735ae5b68baacd4