### PR TITLE
fix(admin): 2442 - affichage du numéro de téléphone sans espaces dans la fiche d'un jeune

### DIFF
--- a/admin/src/scenes/phase0/components/sections/identite/SectionIdentite.jsx
+++ b/admin/src/scenes/phase0/components/sections/identite/SectionIdentite.jsx
@@ -96,7 +96,7 @@ export default function SectionIdentite({ young, cohort, onStartRequest, current
     }
 
     if (!data.phone || !isPhoneNumberWellFormated(data.phone, data.phoneZone)) {
-      errors.phone = PHONE_ZONES[data.phoneZone || "AUTRE"].errorMessage;
+      errors.phone = PHONE_ZONES[data.phoneZone].errorMessage;
       result = false;
     }
 

--- a/admin/src/scenes/phase0/components/sections/identite/SectionIdentite.jsx
+++ b/admin/src/scenes/phase0/components/sections/identite/SectionIdentite.jsx
@@ -90,8 +90,12 @@ export default function SectionIdentite({ young, cohort, onStartRequest, current
       errors.email = "L'email ne semble pas valide";
       result = false;
     }
+    if (!data.phoneZone) {
+      errors.phone = "Veuillez sélectionner une zone";
+      result = false;
+    }
 
-    if (!data.phone || !isPhoneNumberWellFormated(data.phone, data.phoneZone || "AUTRE")) {
+    if (!data.phone || !isPhoneNumberWellFormated(data.phone, data.phoneZone)) {
       errors.phone = PHONE_ZONES[data.phoneZone || "AUTRE"].errorMessage;
       result = false;
     }

--- a/admin/src/scenes/phase0/components/sections/identite/SectionIdentiteContact.jsx
+++ b/admin/src/scenes/phase0/components/sections/identite/SectionIdentiteContact.jsx
@@ -78,7 +78,7 @@ export default function SectionIdentiteContact({ young, globalMode, currentReque
       <PhoneField
         name="phone"
         young={young}
-        value={young.phone}
+        value={young.phone.replace(/\s+/g, "")}
         onChange={(value) => onChange("phone", value)}
         zoneValue={young.phoneZone}
         onChangeZone={(value) => onChange("phoneZone", value)}

--- a/admin/src/scenes/phase0/components/sections/identite/SectionIdentiteContact.jsx
+++ b/admin/src/scenes/phase0/components/sections/identite/SectionIdentiteContact.jsx
@@ -78,7 +78,7 @@ export default function SectionIdentiteContact({ young, globalMode, currentReque
       <PhoneField
         name="phone"
         young={young}
-        value={young.phone.replace(/\s+/g, "")}
+        value={young.phone}
         onChange={(value) => onChange("phone", value)}
         zoneValue={young.phoneZone}
         onChangeZone={(value) => onChange("phoneZone", value)}


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/BUG-Admin-Num-ro-de-t-l-phone-qui-bloque-la-sauvegarde-c9b8534114c74889b0c97b891eafe531?pvs=4

Solution : on pouvait ne pas sélectionner de phoneZone dans le code, et si on faisait cela, on pouvait rentrer n'importe quel numéro de tel sans vérif. On doit mtn choisir une zone. (mais si on choisis : "Autre", on peut rentrer n'importe quel numero aussi). 
Parallelement, un script a tourné pour supprimer tous les espaces des numéros de téléphones en DB