### PR TITLE
fix(api): 2637 - CLE Horaires de retour ne s’affichent pas sur les convocations

### DIFF
--- a/api/src/templates/convocation/cohesion.js
+++ b/api/src/templates/convocation/cohesion.js
@@ -195,9 +195,7 @@ function render(doc, { young, session, cohort, center, service, meetingPoint, li
   doc.font(FONT).text(` est prévu`, { continued: true });
   if (!isLocalTransport(young)) {
     doc.font(FONT_BOLD).text(` le ${dayjs(returnDate).locale("fr").format("dddd DD MMMM YYYY")}`, { continued: true });
-    if (young.source !== "CLE") {
-      doc.font(FONT_BOLD).text(` à ${meetingPoint ? ligneToPoint.returnHour : "11:00"}`, { continued: true });
-    }
+    doc.font(FONT_BOLD).text(` à ${meetingPoint ? ligneToPoint.returnHour : "11:00"}`, { continued: true });
   }
   doc.font(FONT).text(` au même endroit que le jour du départ en centre.`);
 


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/CLE-Juin-Horaires-de-retour-ne-s-affichent-pas-sur-les-convocations-ef6cb701bb7d439f8f5b6fd3033026b2