### PR TITLE
feat(api): 2000 - Flatten error Logs

### DIFF
--- a/api/config/default.js
+++ b/api/config/default.js
@@ -9,6 +9,7 @@ module.exports = {
   IMAGES_ROOTDIR: `${__dirname}/../public/images`,
   FONT_ROOTDIR: `${__dirname}/../src/assets/fonts`,
   ENABLE_SENDINBLUE: true,
+  ENABLE_FLATTEN_ERROR_LOGS: true, // Print error stack without newlines on stderr
   API_URL: "http://localhost:8080",
   APP_URL: "http://localhost:8081",
   ADMIN_URL: "http://localhost:8082",

--- a/api/config/development.js
+++ b/api/config/development.js
@@ -2,4 +2,5 @@ module.exports = {
   ENVIRONMENT: "development",
   SENTRY_PROFILE_SAMPLE_RATE: 1.0,
   SENTRY_TRACING_SAMPLE_RATE: 1.0,
+  ENABLE_FLATTEN_ERROR_LOGS: false,
 };

--- a/api/src/sentry.js
+++ b/api/src/sentry.js
@@ -89,9 +89,18 @@ function initSentryMiddlewares(app) {
   };
 }
 
-function _flatten(stack) {
+function _flattenStack(stack) {
   // Remove new lines and merge spaces to get 1 line log output
   return stack.replace(/\n/g, " | ").replace(/\s+/g, ' ');
+}
+
+function captureError(err, contexte) {
+  if (err.stack && config.ENABLE_FLATTEN_ERROR_LOG) {
+    console.error("capture", _flattenStack(err.stack));
+  } else {
+    console.error("capture", err);
+  }
+  sentryCaptureException(err, contexte);
 }
 
 function capture(err, contexte) {
@@ -103,12 +112,9 @@ function capture(err, contexte) {
   }
 
   if (err instanceof Error) {
-    console.error("capture", err.stack ? _flatten(err.stack) : err);
-    sentryCaptureException(err, contexte);
+    captureError(err, contexte);
   } else if (err.error instanceof Error) {
-    const e = err.error
-    console.error("capture", e.stack ? _flatten(e.stack) : e);
-    sentryCaptureException(e, contexte);
+    captureError(err.error, contexte);
   } else if (err.message) {
     console.error("capture", err.message);
     sentryCaptureMessage(err.message, contexte);
@@ -125,7 +131,7 @@ function captureMessage(mess, contexte) {
   } else {
     const msg = "Message not defined"
     console.error("captureMessage", msg);
-    sentryCaptureMessage("Message not defined");
+    sentryCaptureMessage(msg);
   }
 }
 

--- a/api/src/sentry.js
+++ b/api/src/sentry.js
@@ -89,32 +89,43 @@ function initSentryMiddlewares(app) {
   };
 }
 
+function _flatten(stack) {
+  // Remove new lines and merge spaces to get 1 line log output
+  return stack.replace(/\n/g, " | ").replace(/\s+/g, ' ');
+}
+
 function capture(err, contexte) {
-  console.error("capture", err);
   if (!err) {
-    sentryCaptureMessage("Error not defined");
+    const msg = "Error not defined"
+    console.error("capture", msg);
+    sentryCaptureMessage(msg);
     return;
   }
 
   if (err instanceof Error) {
+    console.error("capture", err.stack ? _flatten(err.stack) : err);
     sentryCaptureException(err, contexte);
   } else if (err.error instanceof Error) {
-    sentryCaptureException(err.error, contexte);
+    const e = err.error
+    console.error("capture", e.stack ? _flatten(e.stack) : e);
+    sentryCaptureException(e, contexte);
   } else if (err.message) {
+    console.error("capture", err.message);
     sentryCaptureMessage(err.message, contexte);
   } else {
-    sentryCaptureMessage("Error not defined well", { extra: { error: err, contexte: contexte } });
+    const msg = "Error not defined well"
+    console.error("capture", msg);
+    sentryCaptureMessage(msg, { extra: { error: err, contexte: contexte } });
   }
 }
 function captureMessage(mess, contexte) {
-  console.error("captureMessage", mess);
-  if (!mess) {
-    sentryCaptureMessage("Message not defined");
-    return;
-  }
-
   if (mess) {
+    console.error("captureMessage", mess);
     sentryCaptureMessage(mess, contexte);
+  } else {
+    const msg = "Message not defined"
+    console.error("captureMessage", msg);
+    sentryCaptureMessage("Message not defined");
   }
 }
 


### PR DESCRIPTION
[2000 - Dashboard Error Logs](https://www.notion.so/jeveuxaider/Sprint-tech-W21-23-18e873edd5dd4e18a86fde2336f001fc?p=dfbc17a4cd4443baa89e402388c8c0ed&pm=s)

Use the ENABLE_FLATTEN_ERROR_LOGS configuration (disabled in development) to remove new lines from error stack, to make easier searching & filtering in stderr logs
