### PR TITLE
chore(api): dot not import sentry profiling when sentry not initialized

### DIFF
--- a/api/src/sentry.js
+++ b/api/src/sentry.js
@@ -8,7 +8,6 @@ const {
   Handlers,
   autoDiscoverNodePerformanceMonitoringIntegrations,
 } = require("@sentry/node");
-const { ProfilingIntegration } = require("@sentry/profiling-node");
 
 const config = require("config");
 
@@ -26,6 +25,7 @@ addGlobalEventProcessor((event) => {
 });
 
 function initSentry() {
+  const { ProfilingIntegration } = require("@sentry/profiling-node");
   init({
     enabled: Boolean(config.SENTRY_URL),
     dsn: config.SENTRY_URL,


### PR DESCRIPTION
**Description**

Corrige le problème de chargement de senty en local

```
api:dev: Unhandled Rejection at: Promise {
api:dev:   <rejected> Error: Cannot find module '/service-national-universel/node_modules/@sentry/profiling-node/lib/sentry_cpu_profiler-darwin-arm64-127.node'
api:dev: } reason: Error: Cannot find module '/service-national-universel/node_modules/@sentry/profiling-node/lib/sentry_cpu_profiler-darwin-arm64-127.node'
api:dev: Require stack:
api:dev: - /service-national-universel/node_modules/@sentry/profiling-node/lib/index.js
api:dev: - /service-national-universel/api/src/sentry.js
```

