### PR TITLE
fix(terraform): 2652 - Fix crons deploy dependency

### DIFF
--- a/terraform/environments/production/production.tf
+++ b/terraform/environments/production/production.tf
@@ -166,11 +166,15 @@ resource "scaleway_container" "crons" {
   protocol       = "http1"
   deploy         = true
 
-  environment_variables = merge(scaleway_container.api.environment_variables, {
-    "RUN_CRONS" = "true"
-  })
+  environment_variables = {
+    "NODE_ENV"       = "production"
+    "RUN_CRONS"      = "true"
+  }
 
-  secret_environment_variables = scaleway_container.api.secret_environment_variables
+  secret_environment_variables = {
+    "SCW_ACCESS_KEY" = local.secrets.SCW_ACCESS_KEY
+    "SCW_SECRET_KEY" = local.secrets.SCW_SECRET_KEY
+  }
 }
 
 output "api_endpoint" {


### PR DESCRIPTION
[2652 - Fix crons deploy dependency](https://www.notion.so/jeveuxaider/Sprint-tech-W21-23-18e873edd5dd4e18a86fde2336f001fc?p=88fde87a681d41f693a50e74c637f964&pm=s)

Do not reuse api environment & secrets for cron in order to remove deploy dependency order