### PR TITLE
chore(api): Throw Error on unhandledRejection

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -29,6 +29,9 @@ console.error = function (message) {
 
 process.on("unhandledRejection", (reason, promise) => {
   console.error("Unhandled Rejection");
+  // Use the process.uncaughtException default handler
+  // that prints the stack trace to stderr and exits with code 1
+  // https://nodejs.org/api/process.html#event-uncaughtexception
   throw reason;
 });
 

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -28,7 +28,8 @@ console.error = function (message) {
 };
 
 process.on("unhandledRejection", (reason, promise) => {
-  console.error("Unhandled Rejection at:", promise, "reason:", reason);
+  console.error("Unhandled Rejection");
+  throw reason;
 });
 
 resolveAsyncConfigs(config).then((config) => {


### PR DESCRIPTION
Throw an error when unhandledRejection occurs, to force app to crash (ex: require error)