### PR TITLE
fix(app): 1881 - Wrong link on Young plateform to BDC

### DIFF
--- a/app/src/scenes/phase1/changeSejour.jsx
+++ b/app/src/scenes/phase1/changeSejour.jsx
@@ -166,7 +166,7 @@ export default function ChangeSejour() {
                         </DropdownMenu>
                       </UncontrolledDropdown>
                       <a
-                        href="https:support.snu.gouv.fr/base-de-connaissance/suis-je-eligible-a-un-sejour-de-cohesion-en-2022-1"
+                        href="https:support.snu.gouv.fr/base-de-connaissance/suis-je-eligible-a-un-sejour-de-cohesion"
                         style={{ color: "#5145cc" }}
                         target="_blank"
                         rel="noreferrer">


### PR DESCRIPTION
en complément de ce ticket : https://www.notion.so/jeveuxaider/Lien-de-redirection-BDC-caduque-pour-les-non-ligibles-17ae5d7195f84f048b548d07c8f319cf

cette erreur Sentry indiquait un lien mort : https://sentry.selego.co/organizations/sentry/issues/44606/?alert_rule_id=164&alert_type=issue&environment=production&notification_uuid=262d2bd9-c378-44a7-b0bf-a387dfd4cd9e&project=143&referrer=slack
