### PR TITLE
feat(api): 2592 - Use synchrone configuration

### DIFF
--- a/api/config/ci.js
+++ b/api/config/ci.js
@@ -6,7 +6,7 @@ if (!secretKey) {
   throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
 }
 
-const REVISION = 13;
+const REVISION = 14;
 const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci", REVISION);
 
 module.exports = {
@@ -16,5 +16,4 @@ module.exports = {
   APP_URL: "https://moncompte.ci.beta-snu.dev",
   ADMIN_URL: "https://admin.ci.beta-snu.dev",
   ...secrets,
-  secret: secrets["SECRET"],
 };

--- a/api/config/ci.js
+++ b/api/config/ci.js
@@ -1,12 +1,20 @@
-const asyncSecretConfig = require("../src/secrets-manager");
+const { getSecrets, CI_PROJECT_ID } = require("../src/secrets-manager");
+
+const secretKey = process.env.SCW_SECRET_KEY;
+
+if (!secretKey) {
+  throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
+}
+
+const REVISION = 13
+const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci", REVISION)
 
 module.exports = {
   ENVIRONMENT: "ci",
-  SECRET_NAME: "snu-ci",
-  SECRET_REVISION: "13",
   RELEASE: process.env.RELEASE,
   API_URL: "https://api.ci.beta-snu.dev",
   APP_URL: "https://moncompte.ci.beta-snu.dev",
   ADMIN_URL: "https://admin.ci.beta-snu.dev",
-  ...asyncSecretConfig(),
+  ...secrets,
+  secret: secrets["SECRET"],
 };

--- a/api/config/ci.js
+++ b/api/config/ci.js
@@ -6,8 +6,8 @@ if (!secretKey) {
   throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
 }
 
-const REVISION = 13
-const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci", REVISION)
+const REVISION = 13;
+const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci", REVISION);
 
 module.exports = {
   ENVIRONMENT: "ci",

--- a/api/config/custom.js
+++ b/api/config/custom.js
@@ -16,5 +16,4 @@ module.exports = {
   APP_URL: process.env.APP_URL,
   ADMIN_URL: process.env.ADMIN_URL,
   ...secrets,
-  secret: secrets["SECRET"],
 };

--- a/api/config/custom.js
+++ b/api/config/custom.js
@@ -7,7 +7,7 @@ if (!secretKey || !secretName) {
   throw new Error("SCW_SECRET_KEY & SECRET_NAME are required to get configuration secrets");
 }
 
-const secrets = getSecrets(secretKey, CI_PROJECT_ID, secretName)
+const secrets = getSecrets(secretKey, CI_PROJECT_ID, secretName);
 
 module.exports = {
   ENVIRONMENT: "custom",

--- a/api/config/custom.js
+++ b/api/config/custom.js
@@ -1,11 +1,20 @@
-const asyncSecretConfig = require("../src/secrets-manager");
+const { getSecrets, CI_PROJECT_ID } = require("../src/secrets-manager");
+
+const secretKey = process.env.SCW_SECRET_KEY;
+const secretName = process.env.SECRET_NAME;
+
+if (!secretKey || !secretName) {
+  throw new Error("SCW_SECRET_KEY & SECRET_NAME are required to get configuration secrets");
+}
+
+const secrets = getSecrets(secretKey, CI_PROJECT_ID, secretName)
 
 module.exports = {
   ENVIRONMENT: "custom",
-  SECRET_NAME: process.env.SECRET_NAME,
   RELEASE: process.env.RELEASE,
   API_URL: process.env.API_URL,
   APP_URL: process.env.APP_URL,
   ADMIN_URL: process.env.ADMIN_URL,
-  ...asyncSecretConfig(),
+  ...secrets,
+  secret: secrets["SECRET"],
 };

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -14,7 +14,7 @@ module.exports = {
   SENTRY_TRACING_SAMPLE_RATE: 0.8,
   SENTRY_PROFILE_SAMPLE_RATE: 0.1,
   MONGO_URL: undefined,
-  secret: "not-so-secret",
+  JWT_SECRET: "not-so-secret",
   SUPPORT_URL: "http://localhost:3000",
   SUPPORT_APIKEY: undefined,
   KNOWLEDGEBASE_URL: "http://localhost:8084",

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -3,8 +3,6 @@ require("dotenv").config({ path: `${__dirname}/../../.env` });
 module.exports = {
   ENVIRONMENT: undefined,
   RELEASE: undefined,
-  SECRET_NAME: undefined,
-  SECRET_REVISION: "latest_enabled",
   PORT: 8080,
   IMAGES_ROOTDIR: `${__dirname}/../public/images`,
   FONT_ROOTDIR: `${__dirname}/../src/assets/fonts`,
@@ -15,8 +13,6 @@ module.exports = {
   ADMIN_URL: "http://localhost:8082",
   SENTRY_TRACING_SAMPLE_RATE: 0.8,
   SENTRY_PROFILE_SAMPLE_RATE: 0.1,
-  SCW_ACCESS_KEY: process.env.SCW_ACCESS_KEY,
-  SCW_SECRET_KEY: process.env.SCW_SECRET_KEY,
   MONGO_URL: undefined,
   secret: "not-so-secret",
   SUPPORT_URL: "http://localhost:3000",

--- a/api/config/local-development.example.js
+++ b/api/config/local-development.example.js
@@ -1,9 +1,16 @@
 // ! Copy to local-development.js & Edit local configuration
+const { getSecrets, CI_PROJECT_ID } = require("../src/secrets-manager");
 
-const asyncSecretConfig = require("../src/secrets-manager");
+const secretKey = process.env.SCW_SECRET_KEY;
+
+if (!secretKey) {
+  throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
+}
+
+const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci")
 
 module.exports = {
-  SECRET_NAME: "snu-ci",
-  ...asyncSecretConfig(),
   ENABLE_SENDINBLUE: false,
+  ...secrets,
+  secret: secrets["SECRET"],
 };

--- a/api/config/local-development.example.js
+++ b/api/config/local-development.example.js
@@ -7,7 +7,7 @@ if (!secretKey) {
   throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
 }
 
-const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci")
+const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci");
 
 module.exports = {
   ENABLE_SENDINBLUE: false,

--- a/api/config/local-development.example.js
+++ b/api/config/local-development.example.js
@@ -12,5 +12,4 @@ const secrets = getSecrets(secretKey, CI_PROJECT_ID, "snu-ci");
 module.exports = {
   ENABLE_SENDINBLUE: false,
   ...secrets,
-  secret: secrets["SECRET"],
 };

--- a/api/config/production.js
+++ b/api/config/production.js
@@ -1,14 +1,22 @@
-const asyncSecretConfig = require("../src/secrets-manager");
+const { getSecrets, PROD_PROJECT_ID } = require("../src/secrets-manager");
+
+const secretKey = process.env.SCW_SECRET_KEY;
+
+if (!secretKey) {
+  throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
+}
+
+const REVISION = "17"
+const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-production", REVISION)
 
 module.exports = {
   ENVIRONMENT: "production",
-  SECRET_NAME: "snu-production",
-  SECRET_REVISION: "17",
   RELEASE: process.env.RELEASE,
   API_URL: "https://api.snu.gouv.fr",
   APP_URL: "https://moncompte.snu.gouv.fr",
   ADMIN_URL: "https://admin.snu.gouv.fr",
   SENTRY_PROFILE_SAMPLE_RATE: 0.2,
   SENTRY_TRACING_SAMPLE_RATE: 0.01,
-  ...asyncSecretConfig(),
+  ...secrets,
+  secret: secrets["SECRET"],
 };

--- a/api/config/production.js
+++ b/api/config/production.js
@@ -6,8 +6,8 @@ if (!secretKey) {
   throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
 }
 
-const REVISION = "17"
-const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-production", REVISION)
+const REVISION = "17";
+const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-production", REVISION);
 
 module.exports = {
   ENVIRONMENT: "production",

--- a/api/config/production.js
+++ b/api/config/production.js
@@ -6,7 +6,7 @@ if (!secretKey) {
   throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
 }
 
-const REVISION = "17";
+const REVISION = "18";
 const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-production", REVISION);
 
 module.exports = {
@@ -18,5 +18,4 @@ module.exports = {
   SENTRY_PROFILE_SAMPLE_RATE: 0.2,
   SENTRY_TRACING_SAMPLE_RATE: 0.01,
   ...secrets,
-  secret: secrets["SECRET"],
 };

--- a/api/config/staging.js
+++ b/api/config/staging.js
@@ -6,8 +6,8 @@ if (!secretKey) {
   throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
 }
 
-const REVISION = 9
-const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-staging", REVISION)
+const REVISION = 9;
+const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-staging", REVISION);
 
 module.exports = {
   ENVIRONMENT: "staging",

--- a/api/config/staging.js
+++ b/api/config/staging.js
@@ -1,14 +1,22 @@
-const asyncSecretConfig = require("../secrets-manager");
+const { getSecrets, PROD_PROJECT_ID } = require("../src/secrets-manager");
+
+const secretKey = process.env.SCW_SECRET_KEY;
+
+if (!secretKey) {
+  throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
+}
+
+const REVISION = 9
+const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-staging", REVISION)
 
 module.exports = {
   ENVIRONMENT: "staging",
-  SECRET_NAME: "snu-staging",
-  SECRET_REVISION: "9",
   RELEASE: process.env.RELEASE,
   API_URL: "https://api.beta-snu.dev",
   APP_URL: "https://moncompte.beta-snu.dev",
   ADMIN_URL: "https://admin.beta-snu.dev",
   SENTRY_PROFILE_SAMPLE_RATE: 0.8,
   SENTRY_TRACING_SAMPLE_RATE: 0.1,
-  ...asyncSecretConfig(),
+  ...secrets,
+  secret: secrets["SECRET"],
 };

--- a/api/config/staging.js
+++ b/api/config/staging.js
@@ -6,7 +6,7 @@ if (!secretKey) {
   throw new Error("SCW_SECRET_KEY is required to get configuration secrets");
 }
 
-const REVISION = 9;
+const REVISION = 10;
 const secrets = getSecrets(secretKey, PROD_PROJECT_ID, "snu-staging", REVISION);
 
 module.exports = {
@@ -18,5 +18,4 @@ module.exports = {
   SENTRY_PROFILE_SAMPLE_RATE: 0.8,
   SENTRY_TRACING_SAMPLE_RATE: 0.1,
   ...secrets,
-  secret: secrets["SECRET"],
 };

--- a/api/package.json
+++ b/api/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@elastic/elasticsearch": "^7.14.0",
     "@godaddy/terminus": "^4.12.1",
-    "@scaleway/sdk": "^1.38.1",
     "@selego/mongoose-elastic": "^1.6.0",
     "@sentry/integrations": "^7.58.1",
     "@sentry/node": "^7.92.0",
@@ -68,6 +67,7 @@
     "sanitize-html": "^2.12.1",
     "sib-api-v3-sdk": "^8.5.0",
     "snu-lib": "*",
+    "sync-request-curl": "^3.0.0",
     "uuid": "^9.0.0",
     "validator": "^13.7.0"
   },

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -171,7 +171,7 @@ class Auth {
         });
       }
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: null, passwordChangedAt: null, emailVerified: "false" }, config.secret, {
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: null, passwordChangedAt: null, emailVerified: "false" }, config.JWT_SECRET, {
         expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
       });
       res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
@@ -308,7 +308,7 @@ class Auth {
         });
       }
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: null, passwordChangedAt: null, emailVerified: "false" }, config.secret, {
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: null, passwordChangedAt: null, emailVerified: "false" }, config.JWT_SECRET, {
         expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
       });
       res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
@@ -363,7 +363,7 @@ class Auth {
 
           let jwtPayload;
           try {
-            jwtPayload = await jwt.verify(trustToken, config.secret);
+            jwtPayload = await jwt.verify(trustToken, config.JWT_SECRET);
           } catch (e) {
             return true;
           }
@@ -402,7 +402,7 @@ class Auth {
       user.set({ lastLoginAt: Date.now(), lastActivityAt: Date.now() });
       await user.save();
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
         expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
       });
       if (isYoung(user)) res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
@@ -455,18 +455,18 @@ class Auth {
       }
       await user.save();
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
         expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
       });
       if (isYoung(user)) {
         if (rememberMe) {
-          const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.secret, { expiresIn: JWT_TRUST_TOKEN_MONCOMPTE_MAX_AGE_SEC });
+          const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.JWT_SECRET, { expiresIn: JWT_TRUST_TOKEN_MONCOMPTE_MAX_AGE_SEC });
           res.cookie(`trust_token-${user._id}`, trustToken, cookieOptions(COOKIE_TRUST_TOKEN_MONCOMPTE_JWT_MAX_AGE_MS));
         }
         res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
       } else if (isReferent(user)) {
         if (rememberMe) {
-          const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.secret, { expiresIn: JWT_TRUST_TOKEN_ADMIN_MAX_AGE_SEC });
+          const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.JWT_SECRET, { expiresIn: JWT_TRUST_TOKEN_ADMIN_MAX_AGE_SEC });
           res.cookie(`trust_token-${user._id}`, trustToken, cookieOptions(COOKIE_TRUST_TOKEN_ADMIN_JWT_MAX_AGE_MS));
         }
         res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
@@ -647,15 +647,15 @@ class Auth {
         },
       });
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
         expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
       });
       if (isYoung(user)) {
-        const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.secret, { expiresIn: JWT_TRUST_TOKEN_MONCOMPTE_MAX_AGE_SEC });
+        const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.JWT_SECRET, { expiresIn: JWT_TRUST_TOKEN_MONCOMPTE_MAX_AGE_SEC });
         res.cookie(`trust_token-${user._id}`, trustToken, cookieOptions(COOKIE_TRUST_TOKEN_MONCOMPTE_JWT_MAX_AGE_MS));
         res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
       } else if (isReferent(user)) {
-        const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.secret, { expiresIn: JWT_TRUST_TOKEN_ADMIN_MAX_AGE_SEC });
+        const trustToken = jwt.sign({ __v: JWT_TRUST_TOKEN_VERSION }, config.JWT_SECRET, { expiresIn: JWT_TRUST_TOKEN_ADMIN_MAX_AGE_SEC });
         res.cookie(`trust_token-${user._id}`, trustToken, cookieOptions(COOKIE_TRUST_TOKEN_ADMIN_JWT_MAX_AGE_MS));
         res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
       }
@@ -755,7 +755,7 @@ class Auth {
       await user.save();
       const data = isYoung(user) ? serializeYoung(user, user) : serializeReferent(user, user);
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
         expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
       });
 
@@ -842,7 +842,7 @@ class Auth {
       user.set({ password: newPassword, passwordChangedAt, loginAttempts: 0 });
       await user.save();
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt }, config.secret, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt }, config.JWT_SECRET, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
       if (isYoung(user)) res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
       else if (isReferent(user)) res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
 

--- a/api/src/controllers/referent.js
+++ b/api/src/controllers/referent.js
@@ -177,7 +177,7 @@ router.post("/signup", async (req, res) => {
     const role = ROLES.RESPONSIBLE; // responsible by default
 
     const user = await ReferentModel.create({ password, email, firstName, lastName, role, acceptCGU, phone, mobile: phone });
-    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: null, passwordChangedAt: null }, config.secret, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
+    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: null, passwordChangedAt: null }, config.JWT_SECRET, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
     res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
 
     //Create structure
@@ -226,7 +226,7 @@ router.post("/signin_as/:type/:id", passport.authenticate("referent", { session:
 
     if (!canSigninAs(req.user, user, type)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
 
-    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
       expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
     });
     if (type === "referent") res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
@@ -251,7 +251,7 @@ router.post("/restore_signin", passport.authenticate("referent", { session: fals
 
     let jwtPayload;
     try {
-      jwtPayload = await jwt.verify(value.jwt, config.secret);
+      jwtPayload = await jwt.verify(value.jwt, config.JWT_SECRET);
     } catch (error) {
       return res.status(401).send({ ok: false, user: { restriction: "public" } });
     }
@@ -259,7 +259,7 @@ router.post("/restore_signin", passport.authenticate("referent", { session: fals
     const user = await ReferentModel.findOne({ _id: jwtPayload._id, role: ROLES.ADMIN });
     if (!user) return res.status(401).send({ ok: false, user: { restriction: "public" } });
 
-    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
       expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
     });
     res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
@@ -395,7 +395,7 @@ router.post("/signup_verify", async (req, res) => {
     const referent = await ReferentModel.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } });
     if (!referent) return res.status(404).send({ ok: false, code: ERRORS.INVITATION_TOKEN_EXPIRED_OR_INVALID });
 
-    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: referent.id, lastLogoutAt: null, passwordChangedAt: null }, config.secret, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
+    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: referent.id, lastLogoutAt: null, passwordChangedAt: null }, config.JWT_SECRET, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
     return res.status(200).send({ ok: true, token, data: serializeReferent(referent, referent) });
   } catch (error) {
     capture(error);
@@ -438,7 +438,7 @@ router.post("/signup_invite", async (req, res) => {
       acceptCGU,
     });
 
-    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: referent.id, lastLogoutAt: null, passwordChangedAt: null }, config.secret, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
+    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: referent.id, lastLogoutAt: null, passwordChangedAt: null }, config.JWT_SECRET, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
     res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
 
     await referent.save({ fromUser: req.user });

--- a/api/src/controllers/signin.js
+++ b/api/src/controllers/signin.js
@@ -41,7 +41,7 @@ router.get("/token", async (req, res) => {
 
     let jwtPayload;
     try {
-      jwtPayload = await jwt.verify(token, config.secret);
+      jwtPayload = await jwt.verify(token, config.JWT_SECRET);
     } catch (error) {
       return res.status(401).send({ ok: false, user: { restriction: "public" } });
     }

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -96,7 +96,7 @@ router.post("/signup_verify", async (req, res) => {
 
     const young = await YoungObject.findOne({ invitationToken: value.invitationToken, invitationExpires: { $gt: Date.now() } });
     if (!young) return res.status(404).send({ ok: false, code: ERRORS.INVITATION_TOKEN_EXPIRED_OR_INVALID });
-    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: young._id, passwordChangedAt: null, lastLogoutAt: null }, config.secret, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
+    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: young._id, passwordChangedAt: null, lastLogoutAt: null }, config.JWT_SECRET, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
     return res.status(200).send({ ok: true, token, data: serializeYoung(young, young) });
   } catch (error) {
     capture(error);
@@ -132,7 +132,7 @@ router.post("/signup_invite", async (req, res) => {
     young.set({ invitationToken: "" });
     young.set({ invitationExpires: null });
 
-    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: young._id, passwordChangedAt: null, lastLogoutAt: null }, config.secret, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
+    const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: young._id, passwordChangedAt: null, lastLogoutAt: null }, config.JWT_SECRET, { expiresIn: JWT_SIGNIN_MAX_AGE_SEC });
     res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
 
     await young.save({ fromUser: req.user });

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,4 +1,3 @@
-const { resolveAsyncConfigs } = require("config/async");
 const config = require("config");
 
 // NODE_ENV environment variable (default "development") is used by :
@@ -6,17 +5,6 @@ const config = require("config");
 // - jest : unit test (NODE_ENV == "test")
 const environment = config.util.getEnv("NODE_ENV");
 console.log("ENVIRONMENT:", environment);
-
-if (!process.env.SCW_ACCESS_KEY || !process.env.SCW_SECRET_KEY) {
-  const message = "SCW_ACCESS_KEY & SCW_SECRET_KEY are required to get configuration secrets";
-  if (environment === "development") {
-    console.warn(message);
-  } else {
-    console.error(message);
-    process.exitCode = 1;
-    return;
-  }
-}
 
 require("events").EventEmitter.defaultMaxListeners = 35; // Fix warning node (Caused by ElasticMongoose-plugin)
 
@@ -35,12 +23,9 @@ process.on("unhandledRejection", (reason, promise) => {
   throw reason;
 });
 
-resolveAsyncConfigs(config).then((config) => {
-  const { runCrons, runAPI } = require("./main");
-
-  if (process.env.RUN_CRONS === "true") {
-    runCrons();
-  } else {
-    runAPI();
-  }
-});
+const { runCrons, runAPI } = require("./main");
+if (process.env.RUN_CRONS === "true") {
+  runCrons();
+} else {
+  runAPI();
+}

--- a/api/src/middlewares/optionalAuth.js
+++ b/api/src/middlewares/optionalAuth.js
@@ -11,7 +11,7 @@ const optionalAuth = async (req, _, next) => {
     const token = getToken(req);
     let user;
     if (token) {
-      const jwtPayload = await jwt.verify(token, config.secret);
+      const jwtPayload = await jwt.verify(token, config.JWT_SECRET);
       const { error, value } = Joi.object({ __v: Joi.string().required(), _id: Joi.string().required(), passwordChangedAt: Joi.string(), lastLogoutAt: Joi.date() }).validate({
         ...jwtPayload,
       });

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -49,7 +49,7 @@ async function validateUser(Model, jwtPayload, done, role) {
 function initPassport() {
   const opts = {};
   opts.jwtFromRequest = getToken;
-  opts.secretOrKey = config.secret;
+  opts.secretOrKey = config.JWT_SECRET;
 
   passport.use("young", new JwtStrategy(opts, (jwtPayload, done) => validateUser(Young, jwtPayload, done)));
   passport.use("referent", new JwtStrategy(opts, (jwtPayload, done) => validateUser(Referent, jwtPayload, done)));

--- a/api/src/secrets-manager.js
+++ b/api/src/secrets-manager.js
@@ -1,76 +1,29 @@
-const { Secret, createClient } = require("@scaleway/sdk");
-const asyncConfig = require("config/async").asyncConfig;
+const request = require("sync-request-curl");
 
-let secrets = null;
+const REGION = "fr-par";
+const PROD_PROJECT_ID = "a0c93450-f68c-4768-8fe8-6e07a1644530"; // snu-production
+const CI_PROJECT_ID = "1b29c5d9-9723-400a-aa8b-0c85ae3567f7"; //snu-ci
 
-function getSecret(key) {
-  return async (config) => {
-    // * L'env est chargé une seule fois
-    if (secrets === null) {
-      const client = createClient({
-        accessKey: config.SCW_ACCESS_KEY,
-        secretKey: config.SCW_SECRET_KEY,
-        defaultRegion: "fr-par",
-        defaultZone: "fr-par-1",
-      });
+function getSecrets(secretKey, projectId, secretName, revision="latest_enabled") {
 
-      const api = new Secret.v1alpha1.API(client);
-
-      const secretName = config.SECRET_NAME;
-      const revision = config.SECRET_REVISION;
-      const secret = await api.accessSecretVersionByName({ secretName, revision });
-      const decodedData = Buffer.from(secret.data, "base64").toString("utf8");
-      secrets = JSON.parse(decodedData);
-    }
-
-    return secrets[key];
+  const url = `https://api.scaleway.com/secret-manager/v1beta1/regions/${REGION}/secrets-by-path/versions/${revision}/access?project_id=${projectId}&secret_name=${secretName}`;
+  const headers = {
+    "X-Auth-Token": secretKey,
   };
+
+  const response = request('GET', url, {headers});
+
+  const body = response.body.toString();
+
+  const jsonBody = JSON.parse(body);
+
+  const decodedData = Buffer.from(jsonBody.data, "base64").toString("utf8");
+
+  return JSON.parse(decodedData);
 }
 
-function asyncSecretConfig() {
-  return {
-    MONGO_URL: asyncConfig(getSecret("MONGO_URL")),
-    secret: asyncConfig(getSecret("SECRET")),
-    SUPPORT_URL: asyncConfig(getSecret("SUPPORT_URL")),
-    SUPPORT_APIKEY: asyncConfig(getSecret("SUPPORT_APIKEY")),
-    KNOWLEDGEBASE_URL: asyncConfig(getSecret("KNOWLEDGEBASE_URL")),
-    API_ANALYTICS_ENDPOINT: asyncConfig(getSecret("API_ANALYTICS_ENDPOINT")),
-    API_ANALYTICS_API_KEY: asyncConfig(getSecret("API_ANALYTICS_API_KEY")),
-    API_ANTIVIRUS_ENDPOINT: asyncConfig(getSecret("API_ANTIVIRUS_ENDPOINT")),
-    API_ANTIVIRUS_TOKEN: asyncConfig(getSecret("API_ANTIVIRUS_TOKEN")),
-    ES_ENDPOINT: asyncConfig(getSecret("ES_ENDPOINT")),
-    SENDINBLUEKEY: asyncConfig(getSecret("SENDINBLUEKEY")),
-    SENTRY_URL: asyncConfig(getSecret("SENTRY_URL")),
-    DIAGORIENTE_URL: asyncConfig(getSecret("DIAGORIENTE_URL")),
-    DIAGORIENTE_TOKEN: asyncConfig(getSecret("DIAGORIENTE_TOKEN")),
-    FRANCE_CONNECT_URL: asyncConfig(getSecret("FRANCE_CONNECT_URL")),
-    FRANCE_CONNECT_CLIENT_ID: asyncConfig(getSecret("FRANCE_CONNECT_CLIENT_ID")),
-    FRANCE_CONNECT_CLIENT_SECRET: asyncConfig(getSecret("FRANCE_CONNECT_CLIENT_SECRET")),
-    CELLAR_ENDPOINT: asyncConfig(getSecret("CELLAR_ENDPOINT")),
-    CELLAR_KEYID: asyncConfig(getSecret("CELLAR_KEYID")),
-    CELLAR_KEYSECRET: asyncConfig(getSecret("CELLAR_KEYSECRET")),
-    BUCKET_NAME: asyncConfig(getSecret("BUCKET_NAME")),
-    PUBLIC_BUCKET_NAME: asyncConfig(getSecret("PUBLIC_BUCKET_NAME")),
-    CELLAR_ENDPOINT_SUPPORT: asyncConfig(getSecret("CELLAR_ENDPOINT_SUPPORT")),
-    CELLAR_KEYID_SUPPORT: asyncConfig(getSecret("CELLAR_KEYID_SUPPORT")),
-    CELLAR_KEYSECRET_SUPPORT: asyncConfig(getSecret("CELLAR_KEYSECRET_SUPPORT")),
-    PUBLIC_BUCKET_NAME_SUPPORT: asyncConfig(getSecret("PUBLIC_BUCKET_NAME_SUPPORT")),
-    FILE_ENCRYPTION_SECRET_SUPPORT: asyncConfig(getSecret("FILE_ENCRYPTION_SECRET_SUPPORT")),
-    FILE_ENCRYPTION_SECRET: asyncConfig(getSecret("FILE_ENCRYPTION_SECRET")),
-    QPV_USERNAME: asyncConfig(getSecret("QPV_USERNAME")),
-    QPV_PASSWORD: asyncConfig(getSecret("QPV_PASSWORD")),
-    API_ENGAGEMENT_URL: asyncConfig(getSecret("API_ENGAGEMENT_URL")),
-    API_ENGAGEMENT_KEY: asyncConfig(getSecret("API_ENGAGEMENT_KEY")),
-    API_ASSOCIATION_ES_ENDPOINT: asyncConfig(getSecret("API_ASSOCIATION_ES_ENDPOINT")),
-    API_ASSOCIATION_CELLAR_ENDPOINT: asyncConfig(getSecret("API_ASSOCIATION_CELLAR_ENDPOINT")),
-    API_ASSOCIATION_CELLAR_KEYID: asyncConfig(getSecret("API_ASSOCIATION_CELLAR_KEYID")),
-    API_ASSOCIATION_CELLAR_KEYSECRET: asyncConfig(getSecret("API_ASSOCIATION_CELLAR_KEYSECRET")),
-    SLACK_BOT_TOKEN: asyncConfig(getSecret("SLACK_BOT_TOKEN")),
-    SLACK_BOT_CHANNEL: asyncConfig(getSecret("SLACK_BOT_CHANNEL")),
-    JVA_TOKEN: asyncConfig(getSecret("JVA_TOKEN")),
-    JVA_API_KEY: asyncConfig(getSecret("JVA_API_KEY")),
-    REDIS_URL: asyncConfig(getSecret("REDIS_URL")),
-  };
-}
-
-module.exports = asyncSecretConfig;
+module.exports = {
+  getSecrets,
+  PROD_PROJECT_ID,
+  CI_PROJECT_ID,
+};

--- a/api/src/secrets-manager.js
+++ b/api/src/secrets-manager.js
@@ -4,14 +4,13 @@ const REGION = "fr-par";
 const PROD_PROJECT_ID = "a0c93450-f68c-4768-8fe8-6e07a1644530"; // snu-production
 const CI_PROJECT_ID = "1b29c5d9-9723-400a-aa8b-0c85ae3567f7"; //snu-ci
 
-function getSecrets(secretKey, projectId, secretName, revision="latest_enabled") {
-
+function getSecrets(secretKey, projectId, secretName, revision = "latest_enabled") {
   const url = `https://api.scaleway.com/secret-manager/v1beta1/regions/${REGION}/secrets-by-path/versions/${revision}/access?project_id=${projectId}&secret_name=${secretName}`;
   const headers = {
     "X-Auth-Token": secretKey,
   };
 
-  const response = request('GET', url, {headers});
+  const response = request("GET", url, { headers });
 
   const body = response.body.toString();
 

--- a/api/src/services/jeveuxaider.js
+++ b/api/src/services/jeveuxaider.js
@@ -29,7 +29,7 @@ router.get("/signin", async (req, res) => {
 
     let jwtPayload;
     try {
-      jwtPayload = await jwt.verify(token_jva, config.secret);
+      jwtPayload = await jwt.verify(token_jva, config.JWT_SECRET);
     } catch (error) {
       return res.status(401).send({ ok: false, code: ERRORS.PASSWORD_TOKEN_EXPIRED_OR_INVALID });
     }
@@ -56,7 +56,7 @@ router.get("/signin", async (req, res) => {
       user.set({ lastLoginAt: Date.now() });
       await user.save();
 
-      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+      const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
         expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
       });
       res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS));
@@ -89,7 +89,7 @@ router.get("/getToken", async (req, res) => {
     // si l'utilisateur n'existe pas, on bloque
     if (!user || user.status === "DELETED") return res.status(401).send({ ok: false, code: ERRORS.EMAIL_OR_API_KEY_INVALID });
 
-    const token_jva = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user._id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.secret, {
+    const token_jva = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user._id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
       expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,6 @@
       "dependencies": {
         "@elastic/elasticsearch": "^7.14.0",
         "@godaddy/terminus": "^4.12.1",
-        "@scaleway/sdk": "^1.38.1",
         "@selego/mongoose-elastic": "^1.6.0",
         "@sentry/integrations": "^7.58.1",
         "@sentry/node": "^7.92.0",
@@ -287,6 +286,7 @@
         "sanitize-html": "^2.12.1",
         "sib-api-v3-sdk": "^8.5.0",
         "snu-lib": "*",
+        "sync-request-curl": "^3.0.0",
         "uuid": "^9.0.0",
         "validator": "^13.7.0"
       },
@@ -2811,6 +2811,95 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "dev": true,
@@ -3733,6 +3822,119 @@
       "version": "0.3.2",
       "license": "MIT"
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -3763,6 +3965,77 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+      "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
+      "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
+      "dependencies": {
+        "agent-base": "^7.1.1",
+        "debug": "^4.3.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@npmcli/fs": {
@@ -3852,6 +4125,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgr/utils": {
@@ -9038,6 +9320,286 @@
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/easy-libcurl": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/easy-libcurl/-/easy-libcurl-2.0.1.tgz",
+      "integrity": "sha512-m+5j8S8C4cCk+UIUA7TobGXoEI+vfBTCKsQ3MTQ+4eWczRF4CtHYgYd0MGuYP3em+ic2DtQ8YEcjwpWqbHP0Gg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "1.0.11",
+        "nan": "^2.18.0",
+        "node-gyp": "10.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/@npmcli/fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/cacache": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.3.tgz",
+      "integrity": "sha512-qXCd4rh6I07cnDqh8V48/94Tc/WSfj+o3Gn6NZ0aZovS255bUx8O13uKxRFd2eWG0xgsco7+YItQNPaa5E85hg==",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/lru-cache": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/make-fetch-happen": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+      "dependencies": {
+        "@npmcli/agent": "^2.0.0",
+        "cacache": "^18.0.0",
+        "http-cache-semantics": "^4.1.1",
+        "is-lambda": "^1.0.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/make-fetch-happen/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/minipass-fetch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+      "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/node-gyp": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.0.1.tgz",
+      "integrity": "sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^13.0.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/ssri": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+      "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/unique-filename": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/unique-slug": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/easy-libcurl/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "license": "Apache-2.0",
@@ -10653,6 +11215,32 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "3.0.1",
       "dev": true,
@@ -12057,6 +12645,23 @@
         "has-symbols": "^1.0.3",
         "reflect.getprototypeof": "^1.0.4",
         "set-function-name": "^2.0.1"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -15883,6 +16488,11 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
+    },
     "node_modules/nano-css": {
       "version": "5.6.1",
       "license": "Unlicense",
@@ -16656,22 +17266,24 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
-      "license": "BlueOak-1.0.0",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "license": "ISC",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -17283,6 +17895,14 @@
       "version": "17.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/proc-log": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+      "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -19206,6 +19826,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.10",
       "dev": true,
@@ -19277,6 +19911,18 @@
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -19586,6 +20232,14 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sync-request-curl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sync-request-curl/-/sync-request-curl-3.0.0.tgz",
+      "integrity": "sha512-d7Frl/Kbwa/qKvJ4CDmJ2m8MoYkyofpcyM2HZ2BR0qEKHW07jilC39O1z2GxMULVUCOSW4GKkX4EN1vvhI3KkQ==",
+      "dependencies": {
+        "easy-libcurl": "^2.0.1"
+      }
     },
     "node_modules/synckit": {
       "version": "0.8.6",
@@ -21562,6 +22216,23 @@
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/terraform/environments/ci/custom/main.tf
+++ b/terraform/environments/ci/custom/main.tf
@@ -110,7 +110,6 @@ resource "scaleway_container" "api" {
   }
 
   secret_environment_variables = {
-    "SCW_ACCESS_KEY" = local.secrets.SCW_ACCESS_KEY
     "SCW_SECRET_KEY" = local.secrets.SCW_SECRET_KEY
   }
 }

--- a/terraform/environments/ci/main.tf
+++ b/terraform/environments/ci/main.tf
@@ -124,11 +124,10 @@ resource "scaleway_container" "api" {
   deploy          = true
 
   environment_variables = {
-    "NODE_ENV"    = "ci"
+    "NODE_ENV"       = "ci"
   }
 
   secret_environment_variables = {
-    "SCW_ACCESS_KEY" = local.secrets.SCW_ACCESS_KEY
     "SCW_SECRET_KEY" = local.secrets.SCW_SECRET_KEY
   }
 }

--- a/terraform/environments/production/production.tf
+++ b/terraform/environments/production/production.tf
@@ -64,7 +64,6 @@ resource "scaleway_container" "api" {
   }
 
   secret_environment_variables = {
-    "SCW_ACCESS_KEY" = local.secrets.SCW_ACCESS_KEY
     "SCW_SECRET_KEY" = local.secrets.SCW_SECRET_KEY
   }
 }
@@ -172,7 +171,6 @@ resource "scaleway_container" "crons" {
   }
 
   secret_environment_variables = {
-    "SCW_ACCESS_KEY" = local.secrets.SCW_ACCESS_KEY
     "SCW_SECRET_KEY" = local.secrets.SCW_SECRET_KEY
   }
 }

--- a/terraform/environments/production/staging/main.tf
+++ b/terraform/environments/production/staging/main.tf
@@ -83,11 +83,10 @@ resource "scaleway_container" "api" {
   deploy          = true
 
   environment_variables = {
-    "NODE_ENV"    = "staging"
+    "NODE_ENV"       = "staging"
   }
 
   secret_environment_variables = {
-    "SCW_ACCESS_KEY" = local.secrets.SCW_ACCESS_KEY
     "SCW_SECRET_KEY" = local.secrets.SCW_SECRET_KEY
   }
 }


### PR DESCRIPTION
[2592 - Use synchrone configuration](https://www.notion.so/jeveuxaider/a0136c3c269c4d3eade64c87fede81b1?v=c4055128404c4daaa5e4541e4a821c26&p=cbe61c8c0e9a478281475705cf7c8b65&pm=s)

Integrate [sync-request-curl](https://www.npmjs.com/package/sync-request-curl?activeTab=readme) to fetch secrets via http synchronously the first time `require('config')` is called