### PR TITLE
fix(api): sentry - download convoc without lineId

### DIFF
--- a/api/src/templates/convocation/cohesion.js
+++ b/api/src/templates/convocation/cohesion.js
@@ -195,7 +195,7 @@ function render(doc, { young, session, cohort, center, service, meetingPoint, li
   doc.font(FONT).text(` est prévu`, { continued: true });
   if (!isLocalTransport(young)) {
     doc.font(FONT_BOLD).text(` le ${dayjs(returnDate).locale("fr").format("dddd DD MMMM YYYY")}`, { continued: true });
-    doc.font(FONT_BOLD).text(` à ${meetingPoint ? ligneToPoint.returnHour : "11:00"}`, { continued: true });
+    doc.font(FONT_BOLD).text(` à ${meetingPoint && ligneToPoint ? ligneToPoint.returnHour : "11:00"}`, { continued: true });
   }
   doc.font(FONT).text(` au même endroit que le jour du départ en centre.`);
 


### PR DESCRIPTION
**Description**

Le téléchargement de la convocation échoue si la ligne de bus n'est pas présente.

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Checklist**

- [ ] **⚠️ My code can have side-effects on other part of the code-base**
- [ ] I have added the Plausible tags/events
- [ ] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

https://sentry.selego.co/organizations/sentry/issues/46475/?environment=api&project=13&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=6

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
