### PR TITLE
fix(github): Sleep before healthchecks

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -150,6 +150,9 @@ jobs:
         shell: bash
         working-directory: ${{ env.ci_directory }}
         run: |
+          # Sleep because status can still be an error if the previous deployement failed
+          sleep 10s
+
           failure=false
           while read name
           do

--- a/.github/workflows/deploy-custom-env.yml
+++ b/.github/workflows/deploy-custom-env.yml
@@ -189,6 +189,9 @@ jobs:
         shell: bash
         working-directory: ${{ env.custom_directory }}
         run: |
+          # Sleep because status can still be an error if the previous deployement failed
+          sleep 10s
+
           failure=false
           while read name
           do

--- a/.github/workflows/deploy-production-hotfix.yml
+++ b/.github/workflows/deploy-production-hotfix.yml
@@ -168,6 +168,9 @@ jobs:
         shell: bash
         working-directory: ${{ env.staging_directory }}
         run: |
+          # Sleep because status can still be an error if the previous deployement failed
+          sleep 10s
+
           failure=false
           while read name
           do
@@ -253,6 +256,9 @@ jobs:
         shell: bash
         working-directory: ${{ env.prod_directory }}
         run: |
+          # Sleep because status can still be an error if the previous deployement failed
+          sleep 10s
+
           failure=false
           while read name
           do

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -207,6 +207,9 @@ jobs:
         shell: bash
         working-directory: ${{ env.staging_directory }}
         run: |
+          # Sleep because status can still be an error if the previous deployement failed
+          sleep 10s
+
           failure=false
           while read name
           do
@@ -292,6 +295,9 @@ jobs:
         shell: bash
         working-directory: ${{ env.prod_directory }}
         run: |
+          # Sleep because status can still be an error if the previous deployement failed
+          sleep 10s
+
           failure=false
           while read name
           do


### PR DESCRIPTION
In certains cases, even if the container deployed successfully, the status can still be in error if the previous deployment failed.

That leads to a failed deployment pipeline even if the container has deployed succesfully. 

Try to add a sleep before healthchecks, to prevent this behaviour