### PR TITLE
fix(api): 2238 - Cron reminderParent wrong CTA

### DIFF
--- a/api/src/crons/reminderImageRightsParent2.js
+++ b/api/src/crons/reminderImageRightsParent2.js
@@ -38,7 +38,7 @@ exports.handler = async () => {
         await sendTemplate(SENDINBLUE_TEMPLATES.parent.PARENT2_IMAGERIGHT_REMINDER, {
           emailTo: [{ name: `${young.parent2FirstName} ${young.parent2LastName}`, email: young.parent2Email }],
           params: {
-            cta: `${config.APP_URL}/representants-legaux/droits-image?token=${young.parent2Inscription2023Token}`,
+            cta: `${config.APP_URL}/representants-legaux/presentation-parent2?token=${young.parent2Inscription2023Token}`,
             youngFirstName: young.firstName,
             youngName: young.lastName,
           },


### PR DESCRIPTION
ticket notion : https://www.notion.so/jeveuxaider/Message-d-erreur-droit-l-image-RL-et-mod-rateurs-53f8552fed3341c5a1ad423db34a33cc

Deux problèmes, les youngs n'avaient pas de parent2token (j'ai passer un script sur les jeunes de 2024 pour ajouter un token)
le CTA pour le reminder image right des parents 2 n'envoyait pas le bon CTA à brevo