### PR TITLE
chore(api): Remove index synchronization at import

### DIFF
--- a/api/src/models/school.js
+++ b/api/src/models/school.js
@@ -22,6 +22,4 @@ const Schema = new mongoose.Schema(
 
 const OBJ = mongoose.model(MODELNAME, Schema);
 
-OBJ.syncIndexes(); // Remove existing index
-
 module.exports = OBJ;

--- a/api/src/models/sessionPhase1.js
+++ b/api/src/models/sessionPhase1.js
@@ -238,6 +238,5 @@ Schema.plugin(mongooseElastic(esClient, { selectiveIndexing: true, ignore: ["tea
 Schema.index({ cohesionCenterId: 1 });
 
 const OBJ = mongoose.model(MODELNAME, Schema);
-if (config.ENVIRONMENT === "production") OBJ.syncIndexes();
 
 module.exports = OBJ;

--- a/api/src/models/young.js
+++ b/api/src/models/young.js
@@ -2202,6 +2202,5 @@ Schema.index({ sessionPhase1Id: 1, status: 1 });
 Schema.index({ classeId: -1 });
 
 const OBJ = mongoose.model(MODELNAME, Schema);
-if (config.ENVIRONMENT === "production") OBJ.syncIndexes();
 
 module.exports = OBJ;


### PR DESCRIPTION
We don't want synchronize mongodb index when importing the module.

Index management are better suited in maintenance scripts