### PR TITLE
fix(api): 2380 - [PDT] add rollback when import failing

### DIFF
--- a/api/src/controllers/planDeTransport/import.js
+++ b/api/src/controllers/planDeTransport/import.js
@@ -22,6 +22,7 @@ const { getMimeFromFile } = require("../../utils/file");
 
 const { validatePdtFile, computeImportSummary } = require("../../pdt/import/pdtImportService");
 const { formatTime } = require("../../pdt/import/pdtImportUtils");
+const { startSession } = require("../../mongo");
 
 // Vérifie un plan de transport importé et l'enregistre dans la collection importplandetransport.
 router.post(
@@ -91,6 +92,7 @@ router.post(
 
 // Importe un plan de transport vérifié et enregistré dans importplandetransport.
 router.post("/:importId/execute", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
+  const tx = await startSession();
   try {
     const { error, value } = Joi.object({
       importId: Joi.string().required(),
@@ -100,180 +102,189 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
     const { importId } = value;
-
-    const importData = await ImportPlanTransportModel.findById(importId);
-    if (!importData) {
-      return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
-    }
-
-    if (!canSendPlanDeTransport(req.user)) {
-      return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
-    }
-
-    const lines = importData.lines;
-    const countPdr = Object.keys(lines[0]).filter((e) => e.startsWith("ID PDR")).length;
-
-    // Vérification des lignes existantes (ne sont modifié que les nouvelles)
-    const newLines = [];
-    const promises = [];
-    for (const line of importData.lines) {
-      promises.push(LigneBusModel.findOne({ cohort: importData.cohort, busId: line["NUMERO DE LIGNE"] }));
-    }
-    const oldLines = await Promise.all(promises);
-    for (let i = 0; i < oldLines.length; i++) {
-      if (!oldLines[i]) {
-        newLines.push(importData.lines[i]);
+    await tx.withTransaction(async () => {
+      const importData = await ImportPlanTransportModel.findById(importId);
+      if (!importData) {
+        return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
       }
-    }
 
-    // import des nouvelles lignes
-    for (const line of newLines) {
-      const pdrIds = [];
-      for (let pdrNumber = 1; pdrNumber <= countPdr; pdrNumber++) {
-        if (line[`ID PDR ${pdrNumber}`] && !["correspondance aller", "correspondance retour", "correspondance"].includes(line[`ID PDR ${pdrNumber}`]?.toLowerCase())) {
-          pdrIds.push(line[`ID PDR ${pdrNumber}`]);
+      if (!canSendPlanDeTransport(req.user)) {
+        return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
+      }
+
+      const lines = importData.lines;
+      const countPdr = Object.keys(lines[0]).filter((e) => e.startsWith("ID PDR")).length;
+
+      // Vérification des lignes existantes (ne sont modifié que les nouvelles)
+      const newLines = [];
+      const promises = [];
+      for (const line of importData.lines) {
+        promises.push(LigneBusModel.findOne({ cohort: importData.cohort, busId: line["NUMERO DE LIGNE"] }));
+      }
+      const oldLines = await Promise.all(promises);
+      for (let i = 0; i < oldLines.length; i++) {
+        if (!oldLines[i]) {
+          newLines.push(importData.lines[i]);
         }
       }
 
-      const session = await SessionPhase1Model.findOne({ cohort: importData.cohort, cohesionCenterId: line["ID CENTRE"] });
-      const busLineData = {
-        cohort: importData.cohort,
-        busId: line["NUMERO DE LIGNE"],
-        departuredDate: parseDate(line["DATE DE TRANSPORT ALLER"], "dd/MM/yyyy", new Date()),
-        returnDate: parseDate(line["DATE DE TRANSPORT RETOUR"], "dd/MM/yyyy", new Date()),
-        centerId: line["ID CENTRE"],
-        centerArrivalTime: formatTime(line["HEURE D'ARRIVEE AU CENTRE"]),
-        centerDepartureTime: formatTime(line["HEURE DE DÉPART DU CENTRE"]),
-        followerCapacity: line["TOTAL ACCOMPAGNATEURS"],
-        youngCapacity: line["CAPACITÉ VOLONTAIRE TOTALE"],
-        totalCapacity: line["CAPACITE TOTALE LIGNE"],
-        youngSeatsTaken: 0,
-        lunchBreak: (line["PAUSE DÉJEUNER ALLER"] || "").toLowerCase() === "oui",
-        lunchBreakReturn: line["PAUSE DÉJEUNER RETOUR" || ""].toLowerCase() === "oui",
-        travelTime: formatTime(line["TEMPS DE ROUTE"]),
-        sessionId: session?._id.toString(),
-        meetingPointsIds: pdrIds,
-        classeId: line["ID CLASSE"] ? line["ID CLASSE"] : undefined,
-        mergedBusIds: line["LIGNES FUSIONNÉES"] ? line["LIGNES FUSIONNÉES"].split(",") : [],
-      };
-      const newBusLine = new LigneBusModel(busLineData);
-      const busLine = await newBusLine.save();
-
-      // Mise à jour des lignes fusionnées existantes
-      for (const mergedBusId of busLineData.mergedBusIds) {
-        const oldMergeLine = await LigneBusModel.findOne({ busId: mergedBusId });
-        if (oldMergeLine) {
-          oldMergeLine.set({ mergedBusIds: busLineData.mergedBusIds });
-          await oldMergeLine.save();
+      // import des nouvelles lignes
+      for (const line of newLines) {
+        const pdrIds = [];
+        for (let pdrNumber = 1; pdrNumber <= countPdr; pdrNumber++) {
+          if (line[`ID PDR ${pdrNumber}`] && !["correspondance aller", "correspondance retour", "correspondance"].includes(line[`ID PDR ${pdrNumber}`]?.toLowerCase())) {
+            pdrIds.push(line[`ID PDR ${pdrNumber}`]);
+          }
         }
-      }
 
-      const lineToPointWithCorrespondance = Array.from({ length: countPdr }, (_, i) => i + 1).reduce((acc, pdrNumber) => {
-        if (pdrNumber > 1 && !line[`ID PDR ${pdrNumber}`]) return acc;
-        if (!["correspondance aller", "correspondance retour", "correspondance"].includes(line[`ID PDR ${pdrNumber}`].toLowerCase())) {
-          acc.push({
-            lineId: busLine._id.toString(),
-            meetingPointId: line[`ID PDR ${pdrNumber}`],
-            transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
-            busArrivalHour: formatTime(line[`HEURE ALLER ARRIVÉE AU PDR ${pdrNumber}`]),
-            departureHour: formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`]),
-            meetingHour: getPDRMeetingHour(formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`])),
-            returnHour: formatTime(line[`HEURE DE RETOUR ARRIVÉE AU PDR ${pdrNumber}`]),
-            stepPoints: [],
-          });
-        } else {
-          if (line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance") {
-            // Special case: when correspondance is not aller or retour
-            // We create 2 step points (aller and retour).
-            acc[acc.length - 1].stepPoints.push({
-              type: "aller",
-              address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`],
+        const session = await SessionPhase1Model.findOne({ cohort: importData.cohort, cohesionCenterId: line["ID CENTRE"] });
+        const busLineData = {
+          cohort: importData.cohort,
+          busId: line["NUMERO DE LIGNE"],
+          departuredDate: parseDate(line["DATE DE TRANSPORT ALLER"], "dd/MM/yyyy", new Date()),
+          returnDate: parseDate(line["DATE DE TRANSPORT RETOUR"], "dd/MM/yyyy", new Date()),
+          centerId: line["ID CENTRE"],
+          centerArrivalTime: formatTime(line["HEURE D'ARRIVEE AU CENTRE"]),
+          centerDepartureTime: formatTime(line["HEURE DE DÉPART DU CENTRE"]),
+          followerCapacity: line["TOTAL ACCOMPAGNATEURS"],
+          youngCapacity: line["CAPACITÉ VOLONTAIRE TOTALE"],
+          totalCapacity: line["CAPACITE TOTALE LIGNE"],
+          youngSeatsTaken: 0,
+          lunchBreak: (line["PAUSE DÉJEUNER ALLER"] || "").toLowerCase() === "oui",
+          lunchBreakReturn: line["PAUSE DÉJEUNER RETOUR" || ""].toLowerCase() === "oui",
+          travelTime: formatTime(line["TEMPS DE ROUTE"]),
+          sessionId: session?._id.toString(),
+          meetingPointsIds: pdrIds,
+          classeId: line["ID CLASSE"] ? line["ID CLASSE"] : undefined,
+          mergedBusIds: line["LIGNES FUSIONNÉES"] ? line["LIGNES FUSIONNÉES"].split(",") : [],
+        };
+        const newBusLine = new LigneBusModel(busLineData);
+        const busLine = await newBusLine.save({ session: tx });
+
+        // Mise à jour des lignes fusionnées existantes
+        for (const mergedBusId of busLineData.mergedBusIds) {
+          const oldMergeLine = await LigneBusModel.findOne({ busId: mergedBusId });
+          if (oldMergeLine) {
+            oldMergeLine.set({ mergedBusIds: busLineData.mergedBusIds });
+            await oldMergeLine.save({ session: tx });
+          }
+        }
+
+        const lineToPointWithCorrespondance = Array.from({ length: countPdr }, (_, i) => i + 1).reduce((acc, pdrNumber) => {
+          if (pdrNumber > 1 && !line[`ID PDR ${pdrNumber}`]) return acc;
+          if (!["correspondance aller", "correspondance retour", "correspondance"].includes(line[`ID PDR ${pdrNumber}`].toLowerCase())) {
+            acc.push({
+              lineId: busLine._id.toString(),
+              meetingPointId: line[`ID PDR ${pdrNumber}`],
+              transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
+              busArrivalHour: formatTime(line[`HEURE ALLER ARRIVÉE AU PDR ${pdrNumber}`]),
               departureHour: formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`]),
-              returnHour: "",
-              transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
-            });
-            acc[acc.length - 1].stepPoints.push({
-              type: "retour",
-              address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`],
-              departureHour: "",
+              meetingHour: getPDRMeetingHour(formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`])),
               returnHour: formatTime(line[`HEURE DE RETOUR ARRIVÉE AU PDR ${pdrNumber}`]),
-              transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
+              stepPoints: [],
             });
           } else {
-            acc[acc.length - 1].stepPoints.push({
-              type: line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance aller" ? "aller" : "retour",
-              address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`],
-              departureHour: line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance aller" ? formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`]) : "",
-              returnHour: line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance aller" ? "" : formatTime(line[`HEURE DE RETOUR ARRIVÉE AU PDR ${pdrNumber}`]),
-              transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
+            if (line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance") {
+              // Special case: when correspondance is not aller or retour
+              // We create 2 step points (aller and retour).
+              acc[acc.length - 1].stepPoints.push({
+                type: "aller",
+                address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`],
+                departureHour: formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`]),
+                returnHour: "",
+                transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
+              });
+              acc[acc.length - 1].stepPoints.push({
+                type: "retour",
+                address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`],
+                departureHour: "",
+                returnHour: formatTime(line[`HEURE DE RETOUR ARRIVÉE AU PDR ${pdrNumber}`]),
+                transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
+              });
+            } else {
+              acc[acc.length - 1].stepPoints.push({
+                type: line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance aller" ? "aller" : "retour",
+                address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`],
+                departureHour: line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance aller" ? formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`]) : "",
+                returnHour: line[`ID PDR ${pdrNumber}`].toLowerCase() === "correspondance aller" ? "" : formatTime(line[`HEURE DE RETOUR ARRIVÉE AU PDR ${pdrNumber}`]),
+                transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`].toLowerCase(),
+              });
+            }
+          }
+          return acc;
+        }, []);
+
+        for (const lineToPoint of lineToPointWithCorrespondance) {
+          const newLineToPoint = new LigneToPointModel(lineToPoint);
+          await newLineToPoint.save({ session: tx });
+        }
+
+        // * Update slave PlanTransport
+        const center = await CohesionCenterModel.findById(busLine.centerId);
+        let pointDeRassemblements = [];
+        for (let i = 0, n = lineToPointWithCorrespondance.length; i < n; ++i) {
+          const ltp = lineToPointWithCorrespondance[i];
+          const pdr = await PdrModel.findById(ltp.meetingPointId);
+          if (pdr) {
+            pointDeRassemblements.push({
+              ...pdr.toObject(),
+              meetingPointId: ltp.meetingPointId,
+              busArrivalHour: ltp.busArrivalHour,
+              meetingHour: ltp.meetingHour,
+              departureHour: ltp.departureHour,
+              returnHour: ltp.returnHour,
+              transportType: ltp.transportType,
             });
           }
         }
-        return acc;
-      }, []);
-
-      for (const lineToPoint of lineToPointWithCorrespondance) {
-        const newLineToPoint = new LigneToPointModel(lineToPoint);
-        await newLineToPoint.save();
-      }
-
-      // * Update slave PlanTransport
-      const center = await CohesionCenterModel.findById(busLine.centerId);
-      let pointDeRassemblements = [];
-      for (let i = 0, n = lineToPointWithCorrespondance.length; i < n; ++i) {
-        const ltp = lineToPointWithCorrespondance[i];
-        const pdr = await PdrModel.findById(ltp.meetingPointId);
-        if (pdr) {
-          pointDeRassemblements.push({
-            ...pdr.toObject(),
-            meetingPointId: ltp.meetingPointId,
-            busArrivalHour: ltp.busArrivalHour,
-            meetingHour: ltp.meetingHour,
-            departureHour: ltp.departureHour,
-            returnHour: ltp.returnHour,
-            transportType: ltp.transportType,
-          });
+        if (busLine.classeId) {
+          const classe = await ClasseModel.findById(busLine.classeId);
+          if (!classe) return res.status(404).send({ ok: false, code: `La classe (ID: ${busLine.classeId}) n'existe pas. Vérifiez les données.` });
+          classe.set({ ligneId: busLine._id });
+          await classe.save();
         }
-      }
-      if (busLine.classeId) {
-        const classe = await ClasseModel.findById(busLine.classeId);
-        if (!classe) return res.status(404).send({ ok: false, code: `La classe (ID: ${busLine.classeId}) n'existe pas. Vérifiez les données.` });
-        classe.set({ ligneId: busLine._id });
-        await classe.save();
+
+        await PlanTransportModel.create(
+          [
+            {
+              _id: busLine._id,
+              cohort: busLine.cohort,
+              busId: busLine.busId,
+              departureString: busLine.departuredDate.toLocaleDateString("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" }),
+              returnString: busLine.returnDate.toLocaleDateString("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" }),
+              youngCapacity: busLine.youngCapacity,
+              totalCapacity: busLine.totalCapacity,
+              lineFillingRate: 0,
+              followerCapacity: busLine.followerCapacity,
+              travelTime: busLine.travelTime,
+              lunchBreak: busLine.lunchBreak,
+              lunchBreakReturn: busLine.lunchBreakReturn,
+              centerId: busLine.centerId,
+              centerRegion: center?.region,
+              centerDepartment: center?.department,
+              centerZip: center?.zip,
+              centerAddress: center?.address,
+              centerName: center?.name,
+              centerCode: center?.code2022,
+              centerArrivalTime: busLine.centerArrivalTime,
+              centerDepartureTime: busLine.centerDepartureTime,
+              pointDeRassemblements,
+              classeId: busLine.classeId ? busLine.classeId : undefined,
+            },
+          ],
+          { session: tx },
+        );
+        // * End update slave PlanTransport
       }
 
-      await PlanTransportModel.create({
-        _id: busLine._id,
-        cohort: busLine.cohort,
-        busId: busLine.busId,
-        departureString: busLine.departuredDate.toLocaleDateString("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" }),
-        returnString: busLine.returnDate.toLocaleDateString("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" }),
-        youngCapacity: busLine.youngCapacity,
-        totalCapacity: busLine.totalCapacity,
-        lineFillingRate: 0,
-        followerCapacity: busLine.followerCapacity,
-        travelTime: busLine.travelTime,
-        lunchBreak: busLine.lunchBreak,
-        lunchBreakReturn: busLine.lunchBreakReturn,
-        centerId: busLine.centerId,
-        centerRegion: center?.region,
-        centerDepartment: center?.department,
-        centerZip: center?.zip,
-        centerAddress: center?.address,
-        centerName: center?.name,
-        centerCode: center?.code2022,
-        centerArrivalTime: busLine.centerArrivalTime,
-        centerDepartureTime: busLine.centerDepartureTime,
-        pointDeRassemblements,
-        classeId: busLine.classeId ? busLine.classeId : undefined,
-      });
-      // * End update slave PlanTransport
-    }
-
-    res.status(200).send({ ok: true, data: lines.length });
+      res.status(200).send({ ok: true, data: lines.length });
+    });
   } catch (error) {
     capture(error);
+
     res.status(500).send({ ok: false, code: ERRORS.SERVER_ERROR });
+  } finally {
+    await tx.endSession();
   }
 });
 

--- a/api/src/controllers/planDeTransport/import.js
+++ b/api/src/controllers/planDeTransport/import.js
@@ -92,7 +92,7 @@ router.post(
 
 // Importe un plan de transport vérifié et enregistré dans importplandetransport.
 router.post("/:importId/execute", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
-  const mongoSession = await startSession();
+  const transaction = await startSession();
   try {
     const { error, value } = Joi.object({
       importId: Joi.string().required(),
@@ -102,7 +102,7 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
     const { importId } = value;
-    await mongoSession.withTransaction(async () => {
+    await transaction.withTransaction(async () => {
       const importData = await ImportPlanTransportModel.findById(importId);
       if (!importData) {
         return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
@@ -159,14 +159,14 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
           mergedBusIds: line["LIGNES FUSIONNÉES"] ? line["LIGNES FUSIONNÉES"].split(",") : [],
         };
         const newBusLine = new LigneBusModel(busLineData);
-        const busLine = await newBusLine.save({ session: mongoSession });
+        const busLine = await newBusLine.save({ session: transaction });
 
         // Mise à jour des lignes fusionnées existantes
         for (const mergedBusId of busLineData.mergedBusIds) {
           const oldMergeLine = await LigneBusModel.findOne({ busId: mergedBusId });
           if (oldMergeLine) {
             oldMergeLine.set({ mergedBusIds: busLineData.mergedBusIds });
-            await oldMergeLine.save({ session: mongoSession });
+            await oldMergeLine.save({ session: transaction });
           }
         }
 
@@ -216,7 +216,7 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
 
         for (const lineToPoint of lineToPointWithCorrespondance) {
           const newLineToPoint = new LigneToPointModel(lineToPoint);
-          await newLineToPoint.save({ session: mongoSession });
+          await newLineToPoint.save({ session: transaction });
         }
 
         // * Update slave PlanTransport
@@ -241,7 +241,7 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
           const classe = await ClasseModel.findById(busLine.classeId);
           if (!classe) return res.status(404).send({ ok: false, code: `La classe (ID: ${busLine.classeId}) n'existe pas. Vérifiez les données.` });
           classe.set({ ligneId: busLine._id });
-          await classe.save({ session: mongoSession });
+          await classe.save({ session: transaction });
         }
 
         await PlanTransportModel.create(
@@ -272,7 +272,7 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
               classeId: busLine.classeId ? busLine.classeId : undefined,
             },
           ],
-          { session: mongoSession },
+          { session: transaction },
         );
         // * End update slave PlanTransport
       }
@@ -284,7 +284,7 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
 
     res.status(500).send({ ok: false, code: ERRORS.SERVER_ERROR });
   } finally {
-    await mongoSession.endSession();
+    await transaction.endSession();
   }
 });
 

--- a/api/src/mongo.js
+++ b/api/src/mongo.js
@@ -58,7 +58,12 @@ async function closeDB() {
   await db.close();
 }
 
+async function startSession() {
+  return await mongoose.startSession();
+}
+
 module.exports = {
   initDB,
   closeDB,
+  startSession,
 };


### PR DESCRIPTION
**Description**

Lorsque que l'import du PDT échoue, il est possible d'arriver dans un état incohérent, c'est à dire d'avoir créé des "lignes de bus" sans créé les `planDeTransport` en base de données.

cette PR a pour but de ne pas sauvegarder partiellement un plan de transport, pour cela on se base sur les transactions mongo qui permettent de rollback les modification en cas d'erreurs.

**Todo**

- [x] mise en place des transactions : https://www.mongodb.com/docs/v5.0/core/transactions/#transactions-and-operations
- [x] gérer la transaction pour les `save` : https://mongoosejs.com/docs/api/model.html#Model.prototype.save()
- [x] gérer la transaction pour les `create` : https://mongoosejs.com/docs/api/model.html#Model.create()
