### PR TITLE
chore(api): add form-data dependency

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -47,6 +47,7 @@
     "express-fileupload": "^1.4.0",
     "file-type": "^16.5.3",
     "forcedomain": "^2.2.11",
+    "form-data": "^4.0.0",
     "helmet": "^4.5.0",
     "joi": "^17.7.0",
     "jsonwebtoken": "^9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,6 +268,7 @@
         "express-fileupload": "^1.4.0",
         "file-type": "^16.5.3",
         "forcedomain": "^2.2.11",
+        "form-data": "^4.0.0",
         "helmet": "^4.5.0",
         "joi": "^17.7.0",
         "jsonwebtoken": "^9.0.1",
@@ -359,6 +360,19 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "api/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "api/node_modules/jest": {


### PR DESCRIPTION
add form-data dependency
La dépendance était présente dans le package-lock, ça ne faisait donc pas échouer les tests (action Github run test-api), mais elle n'était pas dans package.json