### PR TITLE
feat(admin): 2865 - Page centre : préselection pertinente du séjour

### DIFF
--- a/admin/src/scenes/centersV2/components/sessions/SessionList.tsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.tsx
@@ -25,6 +25,7 @@ import SelectCohort from "@/components/cohorts/SelectCohort";
 import { Title } from "../commons";
 import TimeSchedule from "../TimeSchedule";
 import PedagoProject from "../PedagoProject";
+import { getNextSession } from "@/utils/session";
 
 type Props = {
   center: Center;
@@ -41,7 +42,7 @@ export default function SessionList({ center, setCenter, sessions, setSessions }
   const history = useHistory();
   const cohorts = useSelector((state: CohortState) => state.Cohorts);
   const user = useSelector((state: AuthState) => state.Auth.user);
-  const selectedCohort = new URLSearchParams(location.search).get("cohorte") || sessions[0]?.cohort;
+  const selectedCohort = new URLSearchParams(location.search).get("cohorte") || getNextSession(sessions, cohorts)?.cohort || sessions[sessions.length - 1]?.cohort;
   const cohort = cohorts.find((cohort) => cohort.name === selectedCohort) || cohorts[0];
   const session = sessions.find((session) => session.cohort === selectedCohort) || sessions[0];
   const setSession = (newSession: Session) => setSessions(sessions.map((session) => (session._id === newSession._id ? newSession : session)));

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.tsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.tsx
@@ -42,15 +42,18 @@ export default function SessionList({ center, setCenter, sessions, setSessions }
   const history = useHistory();
   const cohorts = useSelector((state: CohortState) => state.Cohorts);
   const user = useSelector((state: AuthState) => state.Auth.user);
-  const selectedCohort = new URLSearchParams(location.search).get("cohorte") || getDefaultSession(sessions, cohorts)?.cohort;
-  const cohort = cohorts.find((cohort) => cohort.name === selectedCohort) || cohorts[0];
-  const session = sessions.find((session) => session.cohort === selectedCohort) || sessions[0];
+
+  const cohortParam = new URLSearchParams(location.search).get("cohorte");
+  const session = cohortParam ? sessions.find((session) => session.cohort === cohortParam) : getDefaultSession(sessions, cohorts);
+  const cohort = cohorts.find((cohort) => cohort.name === session?.cohort);
   const setSession = (newSession: Session) => setSessions(sessions.map((session) => (session._id === newSession._id ? newSession : session)));
 
   const [loading, setLoading] = useState(false);
   const [values, setValues] = useState<Session | null>(null);
   const [errors, setErrors] = useState<Errors>({});
   const [showModalDelete, setShowModalDelete] = useState(false);
+
+  if (!session || !cohort) return <div></div>;
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -137,7 +140,7 @@ export default function SessionList({ center, setCenter, sessions, setSessions }
       <form onSubmit={handleSubmit} id="session-form">
         <div className="flex items-center justify-between mb-3">
           <Title>Par séjour</Title>
-          <SelectCohort cohort={selectedCohort} withBadge filterFn={(c) => Boolean(sessions.find((s) => s.cohort === c.name))} onChange={handleSelect} key="selectCohort" />
+          <SelectCohort cohort={session?.cohort} withBadge filterFn={(c) => Boolean(sessions.find((s) => s.cohort === c.name))} onChange={handleSelect} key="selectCohort" />
         </div>
         <Container
           title="Détails"

--- a/admin/src/scenes/centersV2/components/sessions/SessionList.tsx
+++ b/admin/src/scenes/centersV2/components/sessions/SessionList.tsx
@@ -25,7 +25,7 @@ import SelectCohort from "@/components/cohorts/SelectCohort";
 import { Title } from "../commons";
 import TimeSchedule from "../TimeSchedule";
 import PedagoProject from "../PedagoProject";
-import { getNextSession } from "@/utils/session";
+import { getDefaultSession } from "@/utils/session";
 
 type Props = {
   center: Center;
@@ -42,7 +42,7 @@ export default function SessionList({ center, setCenter, sessions, setSessions }
   const history = useHistory();
   const cohorts = useSelector((state: CohortState) => state.Cohorts);
   const user = useSelector((state: AuthState) => state.Auth.user);
-  const selectedCohort = new URLSearchParams(location.search).get("cohorte") || getNextSession(sessions, cohorts)?.cohort || sessions[sessions.length - 1]?.cohort;
+  const selectedCohort = new URLSearchParams(location.search).get("cohorte") || getDefaultSession(sessions, cohorts)?.cohort;
   const cohort = cohorts.find((cohort) => cohort.name === selectedCohort) || cohorts[0];
   const session = sessions.find((session) => session.cohort === selectedCohort) || sessions[0];
   const setSession = (newSession: Session) => setSessions(sessions.map((session) => (session._id === newSession._id ? newSession : session)));

--- a/admin/src/scenes/volontaires/view/phase1.jsx
+++ b/admin/src/scenes/volontaires/view/phase1.jsx
@@ -165,7 +165,7 @@ export default function Phase1(props) {
                 <div className="mt-4 flex w-full flex-col items-start justify-start self-start">
                   <div className="mb-2 text-xs font-medium text-gray-900">Centre de cohésion</div>
                   <div className="mb-4 flex w-full flex-col gap-4">
-                    <Field title="Code centre" value={cohesionCenter.code2022} externalLink={`${adminURL}/centre/${cohesionCenter?._id}`} />
+                    <Field title="Code centre" value={cohesionCenter.code2022} externalLink={`${adminURL}/centre/${cohesionCenter?._id}?cohorte=${young.cohort}`} />
                     <Field title="Nom" value={cohesionCenter.name} />
                     <Field title="Code postal" value={cohesionCenter.zip} />
                     <Field title="Ville" value={cohesionCenter.city} />

--- a/admin/src/utils/session.ts
+++ b/admin/src/utils/session.ts
@@ -1,0 +1,12 @@
+import { CohortState } from "@/redux/cohorts/reducer";
+import { Session } from "@/types";
+import dayjs from "dayjs";
+
+export function getNextSession(sessions: Session[], cohorts: CohortState["Cohorts"]) {
+  return sessions
+    .map((session) => ({
+      ...session,
+      dateStart: session.dateStart || cohorts.find((cohort) => cohort.name === session.cohort)?.dateStart,
+    }))
+    .filter((session) => dayjs(session.dateStart).isAfter(dayjs()))[0];
+}

--- a/admin/src/utils/session.ts
+++ b/admin/src/utils/session.ts
@@ -2,11 +2,8 @@ import { CohortState } from "@/redux/cohorts/reducer";
 import { Session } from "@/types";
 import dayjs from "dayjs";
 
-export function getNextSession(sessions: Session[], cohorts: CohortState["Cohorts"]) {
-  return sessions
-    .map((session) => ({
-      ...session,
-      dateStart: session.dateStart || cohorts.find((cohort) => cohort.name === session.cohort)?.dateStart,
-    }))
-    .filter((session) => dayjs(session.dateStart).isAfter(dayjs()))[0];
+export function getDefaultSession(sessions: Session[], cohorts: CohortState["Cohorts"]) {
+  const filteredSessions = sessions.filter((session) => dayjs(session.dateStart || cohorts.find((cohort) => cohort.name === session.cohort)?.dateStart).isAfter(dayjs()));
+  if (filteredSessions.length > 0) return filteredSessions[0];
+  return sessions[sessions.length - 1];
 }


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Admin-Centre-Pr-selection-pertinente-du-s-jour-e86e35565e6d49dd8ef623acae9c262c

La session affichée sur la page d'un centre correspond désormais à la règle suivante :
- si paramètre de cohorte dans l'URL : affichage de la session correspondante
- si pas de paramètre : affichage de la prochaine session à venir
- si plus de session à venir : affichage de la dernière session.

De plus, ajout du paramètre de cohorte dans le lien qui mène vers cette page depuis la page phase 1 d'un volontaire.