### PR TITLE
fix(api): migration - remove console and use earlier return

### DIFF
--- a/api/src/migration.js
+++ b/api/src/migration.js
@@ -22,7 +22,7 @@ const runMigrations = async () => {
 
     await doMigrations(db);
   } catch (error) {
-    capture(error, "Migrations");
+    capture(error);
   } finally {
     await unlockChangelogLock(db);
   }


### PR DESCRIPTION
change CHANGHELOG_LOCK_COLLECTION name
remove console.error()
use earlier return