### PR TITLE
fix(github): add environment to subworkflow

### DIFF
--- a/.github/workflows/cc-deploy-production.yml
+++ b/.github/workflows/cc-deploy-production.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   deploy_image:
     runs-on: ubuntu-latest
+    environment: production # Needed for manual approval before deploy
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Add production environment directly to cc-deploy-production workflow