### PR TITLE
feat(api): 2922 - mettre a jour les statusPhase1 des classes de 2023-2034

### DIFF
--- a/api/migrations/20240711094931-2023-2024_classe_statusPhase1.js
+++ b/api/migrations/20240711094931-2023-2024_classe_statusPhase1.js
@@ -1,0 +1,28 @@
+const ClasseModel = require("../src/models/cle/classe");
+const YoungModel = require("../src/models/young");
+const { STATUS_PHASE1_CLASSE, YOUNG_STATUS_PHASE1 } = require("snu-lib");
+
+module.exports = {
+  async up(db, client) {
+    const classes = await ClasseModel.find({ schoolYear: "2023-2024" });
+
+    const classIds = classes.map((classe) => classe._id);
+
+    const youngsDone = await YoungModel.find({ classeId: { $in: classIds }, statusPhase1: YOUNG_STATUS_PHASE1.DONE });
+
+    const doneClassIds = new Set(youngsDone.map((young) => young.classeId));
+
+    await ClasseModel.updateMany(
+      {
+        ligneId: { $exists: true },
+        _id: { $nin: Array.from(doneClassIds) },
+      },
+      { $set: { statusPhase1: STATUS_PHASE1_CLASSE.AFFECTED } },
+    );
+    await ClasseModel.updateMany({ _id: { $in: Array.from(doneClassIds) } }, { $set: { statusPhase1: STATUS_PHASE1_CLASSE.DONE } });
+  },
+
+  async down(db, client) {
+    await ClasseModel.updateMany({ schoolYear: "2023-2024" }, { $set: { statusPhase1: STATUS_PHASE1_CLASSE.WAITING_AFFECTATION } });
+  },
+};


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/CLE-23-24-Gestion-des-classes-et-des-statuts-2065a9bbef964657a5c200e3af7dd547?pvs=4

Rappel des regles métiers : 
- Si au moins un jeune de la classe a validé sa phase1 : classe.statusPhase1 : DONE
- Si la classe possede le champ ligneID mais aucun jeune n'a réalisé sa phase1 : AFFECTED
- Sinon WAITING_AFFECTATION