### PR TITLE
chore(lib): 2976 - Ajout du nom de cohorte Octobre 2024 - Nouvelle-Calédonie

### DIFF
--- a/packages/lib/src/sessions.js
+++ b/packages/lib/src/sessions.js
@@ -34,6 +34,7 @@ const sessions2024CohortNames = [
   "Toussaint 2024",
   "Toussaint 2024 - La Réunion",
   "Toussaint 2024 - Nouvelle-Calédonie",
+  "Octobre 2024 - Nouvelle-Calédonie",
 ];
 
 const getCohortNames = (withNew = true, withToCome = true, withOld = true) => {
@@ -84,6 +85,7 @@ const COHESION_STAY_START = {
   "Toussaint 2024": new Date("10/21/2024"),
   "Toussaint 2024 - La Réunion": new Date("10/14/2024"),
   "Toussaint 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
+  "Octobre 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
 };
 
 // @todo: to be removed @hlecourt
@@ -123,6 +125,7 @@ const START_DATE_SESSION_PHASE1 = {
   "Toussaint 2024": new Date("10/21/2024"),
   "Toussaint 2024 - La Réunion": new Date("10/14/2024"),
   "Toussaint 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
+  "Octobre 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
 };
 
 // @todo: to be removed @hlecourt
@@ -165,6 +168,7 @@ const COHESION_STAY_END = {
   "Toussaint 2024": new Date("10/31/2024"),
   "Toussaint 2024 - La Réunion": new Date("10/26/2024"),
   "Toussaint 2024 - Nouvelle-Calédonie": new Date("10/18/2024"),
+  "Octobre 2024 - Nouvelle-Calédonie": new Date("10/18/2024"),
 };
 
 // @todo: to be removed after adding old cohorts in bd

--- a/packages/lib/src/sessions.js
+++ b/packages/lib/src/sessions.js
@@ -33,7 +33,6 @@ const sessions2024CohortNames = [
   "CLE GE2 2024",
   "Toussaint 2024",
   "Toussaint 2024 - La Réunion",
-  "Toussaint 2024 - Nouvelle-Calédonie",
   "Octobre 2024 - Nouvelle-Calédonie",
 ];
 
@@ -84,7 +83,6 @@ const COHESION_STAY_START = {
   "CLE GE2 2024": new Date("06/17/2024"),
   "Toussaint 2024": new Date("10/21/2024"),
   "Toussaint 2024 - La Réunion": new Date("10/14/2024"),
-  "Toussaint 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
   "Octobre 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
 };
 
@@ -124,7 +122,6 @@ const START_DATE_SESSION_PHASE1 = {
   "CLE GE2 2024": new Date("06/17/2024"),
   "Toussaint 2024": new Date("10/21/2024"),
   "Toussaint 2024 - La Réunion": new Date("10/14/2024"),
-  "Toussaint 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
   "Octobre 2024 - Nouvelle-Calédonie": new Date("10/07/2024"),
 };
 


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Renommer-la-cohorte-HTS-Toussaint-NC-en-Octobre-2024-Nouvelle-Cal-donie-4594e1476daf4890a7f8c3c8178da83b