### PR TITLE
chore(api):  add es integration test

### DIFF
--- a/api/src/__tests__/cle/classe.test.js
+++ b/api/src/__tests__/cle/classe.test.js
@@ -1,5 +1,12 @@
 const request = require("supertest");
+const passport = require("passport");
+const { ObjectId } = require("mongoose").Types;
+const { dbConnect, dbClose } = require("../helpers/db");
+const { mockEsClient } = require("../helpers/es");
 const getAppHelper = require("../helpers/app");
+
+const snuLib = require("snu-lib");
+const { ROLES, SUB_ROLES, STATUS_CLASSE } = require("snu-lib");
 
 //classe
 const { createClasse } = require("../helpers/classe");
@@ -19,14 +26,14 @@ const { createCohortHelper } = require("../helpers/cohort");
 const { getNewReferentFixture } = require("../fixtures/referent");
 const { createReferentHelper } = require("../helpers/referent");
 
-const snuLib = require("snu-lib");
-const { ROLES, SUB_ROLES, STATUS_CLASSE } = require("snu-lib");
-const passport = require("passport");
-const { dbConnect, dbClose } = require("../helpers/db");
-const { ObjectId } = require("mongoose").Types;
-
 beforeAll(dbConnect);
 afterAll(dbClose);
+
+mockEsClient({
+  classe: [{ _id: "classeId", etablissementIds: ["etabId"], referentClasseIds: ["referentId"] }],
+  etablissement: [{ _id: "etabId" }],
+  referent: [{ _id: "referentId" }],
+});
 
 jest.mock("../../emails", () => ({
   emit: jest.fn(),
@@ -512,5 +519,37 @@ describe("GET /:id/notifyRef", () => {
     const res = await request(getAppHelper()).get(`/cle/classe/${validId}/notifyRef`);
 
     expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /elasticsearch/cle/classe/export", () => {
+  it("should return 403 when user is not admin", async () => {
+    passport.user.role = ROLES.RESPONSIBLE;
+    const res = await request(getAppHelper()).post("/elasticsearch/cle/classe/export").send();
+    expect(res.status).toBe(403);
+    passport.user.role = ROLES.ADMIN;
+  });
+  it("should return 200 when export is successful", async () => {
+    const res = await request(getAppHelper())
+      .post("/elasticsearch/cle/classe/export")
+      .send({ filters: {}, exportFields: ["name", "uniqueKeyAndId"] });
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+  });
+});
+
+describe("GET /elasticsearch/cle/etablissement/export", () => {
+  it("should return 403 when user is not admin", async () => {
+    passport.user.role = ROLES.RESPONSIBLE;
+    const res = await request(getAppHelper()).post("/elasticsearch/cle/etablissement/export").send();
+    expect(res.status).toBe(403);
+    passport.user.role = ROLES.ADMIN;
+  });
+  it("should return 200 when export is successful", async () => {
+    const res = await request(getAppHelper())
+      .post("/elasticsearch/cle/etablissement/export")
+      .send({ filters: {}, exportFields: ["name", "uai"] });
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
   });
 });

--- a/api/src/__tests__/cle/classe.test.js
+++ b/api/src/__tests__/cle/classe.test.js
@@ -522,7 +522,7 @@ describe("GET /:id/notifyRef", () => {
   });
 });
 
-describe("GET /elasticsearch/cle/classe/export", () => {
+describe("POST /elasticsearch/cle/classe/export", () => {
   it("should return 403 when user is not admin", async () => {
     passport.user.role = ROLES.RESPONSIBLE;
     const res = await request(getAppHelper()).post("/elasticsearch/cle/classe/export").send();
@@ -538,7 +538,7 @@ describe("GET /elasticsearch/cle/classe/export", () => {
   });
 });
 
-describe("GET /elasticsearch/cle/etablissement/export", () => {
+describe("POST /elasticsearch/cle/etablissement/export", () => {
   it("should return 403 when user is not admin", async () => {
     passport.user.role = ROLES.RESPONSIBLE;
     const res = await request(getAppHelper()).post("/elasticsearch/cle/etablissement/export").send();

--- a/api/src/__tests__/helpers/es.ts
+++ b/api/src/__tests__/helpers/es.ts
@@ -1,0 +1,30 @@
+export const mockEsClient = (results: { [key: string]: [] } = {}) => {
+  const mock = jest.mock("../../es", () => ({
+    search: async (params: { index: string; scroll: "1m"; size: 1000; body: { query: any; _source: "*" } }) => {
+      console.log("mockEsClient - search()", params, results[params.index]?.length || 0);
+      return {
+        body: {
+          hits: {
+            total: { value: results[params.index]?.length || 0, relation: "eq" },
+            hits: results[params.index] || [],
+          },
+          aggregations: {
+            group_by_etablissement: {
+              buckets: [],
+            },
+          },
+        },
+      };
+    },
+    scroll: async () => ({
+      body: {
+        _scroll_id: null,
+        hits: {
+          total: { value: 0 },
+          hits: [], // empty
+        },
+      },
+    }),
+  }));
+  return mock;
+};

--- a/api/src/__tests__/helpers/es.ts
+++ b/api/src/__tests__/helpers/es.ts
@@ -1,4 +1,6 @@
 export const mockEsClient = (results: { [key: string]: [] } = {}) => {
+  jest.mock("@selego/mongoose-elastic", () => () => jest.fn());
+
   const mock = jest.mock("../../es", () => ({
     search: async (params: { index: string; scroll: "1m"; size: 1000; body: { query: any; _source: "*" } }) => {
       console.log("mockEsClient - search()", params, results[params.index]?.length || 0);

--- a/api/src/__tests__/ligne-de-bus.test.js
+++ b/api/src/__tests__/ligne-de-bus.test.js
@@ -173,6 +173,7 @@ describe("Meeting point", () => {
 
     it("should return 500 when there's an error", async () => {
       const passport = require("passport");
+      const previous = passport.user;
       passport.user = null;
       jest.spyOn(LigneBusModel, "find").mockImplementation(() => {
         throw new Error("test error");
@@ -185,6 +186,7 @@ describe("Meeting point", () => {
       expect(res.body.code).toBe("SERVER_ERROR");
 
       jest.spyOn(LigneBusModel, "find").mockRestore();
+      passport.user = previous;
     });
   });
   describe("GET /:id", () => {
@@ -850,11 +852,16 @@ describe("Meeting point", () => {
 
   describe("POST /elasticsearch/lignebus/export", () => {
     it("should return 200 when export is successful", async () => {
+      const user = { _id: "123", role: "admin" };
+      const passport = require("passport");
+      const previous = passport.user;
+      passport.user = user;
       const res = await request(getAppHelper())
         .post("/elasticsearch/lignebus/export")
         .send({ filters: {}, exportFields: ["busId"] });
       expect(res.status).toBe(200);
       expect(res.body.data.length).toBeGreaterThan(0);
+      passport.user = previous;
     });
   });
 });

--- a/api/src/__tests__/ligne-de-bus.test.js
+++ b/api/src/__tests__/ligne-de-bus.test.js
@@ -16,7 +16,7 @@ const getNewYoungFixture = require("./fixtures/young");
 const { createPointDeRassemblementWithBus } = require("./helpers/PlanDeTransport/pointDeRassemblement");
 
 mockEsClient({
-  lignebus: [{ _id: "referentId" }],
+  lignebus: [{ _id: "ligneId" }],
 });
 
 const mockModelMethodWithError = (model, method) => {
@@ -848,7 +848,7 @@ describe("Meeting point", () => {
     });
   });
 
-  describe("GET /elasticsearch/lignebus/export", () => {
+  describe("POST /elasticsearch/lignebus/export", () => {
     it("should return 200 when export is successful", async () => {
       const res = await request(getAppHelper())
         .post("/elasticsearch/lignebus/export")

--- a/api/src/__tests__/session-phase1.test.js
+++ b/api/src/__tests__/session-phase1.test.js
@@ -6,6 +6,7 @@ const { ROLES } = require("snu-lib");
 const { LigneBusModel } = require("../models");
 
 const getAppHelper = require("./helpers/app");
+const { mockEsClient } = require("./helpers/es");
 const { createSessionPhase1, notExistingSessionPhase1Id } = require("./helpers/sessionPhase1");
 const { createSessionWithCohesionCenter } = require("./helpers/cohesionCenter");
 const { dbConnect, dbClose } = require("./helpers/db");
@@ -17,6 +18,10 @@ const { getNewSessionPhase1Fixture } = require("./fixtures/sessionPhase1");
 const { getNewReferentFixture } = require("./fixtures/referent");
 const getNewCohortFixture = require("./fixtures/cohort");
 const getNewLigneBusFixture = require("./fixtures/PlanDeTransport/ligneBus");
+
+mockEsClient({
+  sessionphase1: [{ _id: "sessionId" }],
+});
 
 jest.mock("../sendinblue", () => ({
   ...jest.requireActual("../sendinblue"),
@@ -147,6 +152,16 @@ describe("Session Phase 1", () => {
         .send();
 
       expect(res.status).toBe(403);
+    });
+  });
+
+  describe("POST /elasticsearch/sessionphase1/export", () => {
+    it("should return 200 when export is successful", async () => {
+      const res = await request(getAppHelper())
+        .post("/elasticsearch/sessionphase1/export")
+        .send({ filters: {}, exportFields: ["codeCentre", "cohesionCenterId"] });
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBeGreaterThan(0);
     });
   });
 });

--- a/api/src/controllers/elasticsearch/cle/classe.js
+++ b/api/src/controllers/elasticsearch/cle/classe.js
@@ -152,7 +152,7 @@ const populateWithReferentEtablissementInfo = async (classes, action) => {
     if (action === "search") {
       item._source.referentEtablissement = referentsData?.filter((e) => item._source.etablissement.referentEtablissementIds.includes(e._id.toString()));
     } else {
-      item.referentEtablissement = referentsData?.filter((e) => item.etablissement.referentEtablissementIds.includes(e._id.toString()));
+      item.referentEtablissement = referentsData?.filter((e) => item.etablissement?.referentEtablissementIds.includes(e._id.toString()));
     }
     return item;
   });
@@ -171,7 +171,7 @@ const populateWithReferentInfo = async (classes, action) => {
     if (action === "search") {
       item._source.referentClasse = referentsData?.filter((e) => item._source.referentClasseIds.includes(e._id.toString()));
     } else {
-      item.referentClasse = referentsData?.filter((e) => item.referentClasseIds.includes(e._id.toString()));
+      item.referentClasse = referentsData?.filter((e) => item.referentClasseIds?.includes(e._id.toString()));
     }
     return item;
   });


### PR DESCRIPTION
**Description**

Ajout de tests d'intégration sur les routes ES appelés par la page `/volontaire`

**Todo**

- [x] test /elasticsearch/sessionphase1/export
- [x] test /elasticsearch/lignebus/export
- [x] test /elasticsearch/cle/classe/export
- [x] test /elasticsearch/cle/etablissement/export
