### PR TITLE
fix(admin): Donner la possibilité aux modérateurs d'afficher un bandeau d'informations pour les admin CLE et referent de classe

### DIFF
--- a/admin/src/scenes/alerte/AlerteMessageForm.tsx
+++ b/admin/src/scenes/alerte/AlerteMessageForm.tsx
@@ -39,6 +39,8 @@ export default function AlerteMessageForm({ message, isNew, onIsNewChange, onMes
     { value: ROLES.SUPERVISOR, label: "Superviseurs" },
     { value: ROLES.RESPONSIBLE, label: "Responsables" },
     { value: ROLES.HEAD_CENTER, label: "Chefs de centre" },
+    { value: ROLES.ADMINISTRATEUR_CLE, label: "Administrateurs CLE" },
+    { value: ROLES.REFERENT_CLASSE, label: "Référents de classe" },
   ];
 
   const selectCustomStyles = {

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -790,7 +790,16 @@ function canCreateAlerteMessage(actor) {
 }
 
 function canReadAlerteMessage(actor) {
-  return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT, ROLES.RESPONSIBLE, ROLES.HEAD_CENTER, ROLES.SUPERVISOR].includes(actor.role);
+  return [
+    ROLES.ADMIN,
+    ROLES.REFERENT_REGION,
+    ROLES.REFERENT_DEPARTMENT,
+    ROLES.RESPONSIBLE,
+    ROLES.HEAD_CENTER,
+    ROLES.SUPERVISOR,
+    ROLES.ADMINISTRATEUR_CLE,
+    ROLES.REFERENT_CLASSE,
+  ].includes(actor.role);
 }
 
 function canViewTableDeRepartition(actor) {


### PR DESCRIPTION
L'urgence sur Brevo a révélé que nous ne pouvions pas communiquer rapidement aupres de ce type de référent (CLE) en cas d'urgence. 
Désormais il sera possible de paramétré les messages d'alertes pour qu'ils soient aussi visible par les re cle