### PR TITLE
fix(admin): 2931 - l'affichage des dates dans les params dynamiques avait sauté

### DIFF
--- a/admin/src/components/ui/forms/dateForm/ToggleDate.tsx
+++ b/admin/src/components/ui/forms/dateForm/ToggleDate.tsx
@@ -42,10 +42,10 @@ function ToggleDate({ value, onChange, range, onChangeRange, disabled = false, l
       </div>
       <div className="flex items-center justify-between">
         <p className="text-left text-xs text-gray-500">
-          Début : <strong>{value && range?.from ? dayjs(range?.from).format("DD/MM/YYYY") : ""}</strong>
+          Début : <strong>{range?.from ? dayjs(range?.from).format("DD/MM/YYYY") : ""}</strong>
         </p>
         <p className="text-left text-xs text-gray-500">
-          Fin : <strong>{value && range?.to ? dayjs(range?.to).format("DD/MM/YYYY") : ""}</strong>
+          Fin : <strong>{range?.to ? dayjs(range?.to).format("DD/MM/YYYY") : ""}</strong>
         </p>
         <Popover className="relative">
           {({ open }) => (


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Afficher-les-dates-dans-les-param-tres-dynamiques-CLE-et-HTS-ind-pendamment-de-l-activation-du-bou-6baa5e06793d4035bfb636ef6df1122b?pvs=4