### PR TITLE
chore(api): add mailcatcher for local development

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -153,15 +153,6 @@
       }
     },
     {
-      "label": "Start Pdf",
-      "command": "npm install && npm run dev",
-      "type": "shell",
-      "problemMatcher": [],
-      "options": {
-        "cwd": "./pdf"
-      }
-    },
-    {
       "label": "Open coverage",
       "command": "open coverage/lcov-report/index.html",
       "type": "shell",
@@ -180,13 +171,17 @@
       }
     },
     {
-      "label": "Run local containers",
-      "dependsOn": ["Run local mongo", "Run local ES"],
+      "label": "Run container containers",
+      "dependsOn": [
+        "Run container mongo",
+        "Run container ES",
+        "Run container mailcatcher"
+      ],
       "problemMatcher": []
     },
     {
-      "label": "Run local ES",
-      "command": "docker-compose -f ./docker-compose.dev.yml up -d elasticsearch && docker-compose -f ./docker-compose.dev.yml logs -f elasticsearch",
+      "label": "Run container ES",
+      "command": "docker-compose -f ./docker-compose.dev.yml up -d elasticsearch && docker-compose -f ./docker-compose.dev.yml logs --tail=10 -f elasticsearch",
       "type": "shell",
       "problemMatcher": [],
       "options": {
@@ -194,8 +189,17 @@
       }
     },
     {
-      "label": "Run local mongo",
-      "command": "docker-compose -f ./docker-compose.dev.yml up -d mongo && docker-compose -f ./docker-compose.dev.yml logs -f mongo",
+      "label": "Run container mongo",
+      "command": "docker-compose -f ./docker-compose.dev.yml up -d mongo && docker-compose -f ./docker-compose.dev.yml logs --tail=10 -f mongo",
+      "type": "shell",
+      "problemMatcher": [],
+      "options": {
+        "cwd": "./api"
+      }
+    },
+    {
+      "label": "Run container mailcatcher",
+      "command": "docker-compose -f ./docker-compose.dev.yml up -d mailcatcher && docker-compose -f ./docker-compose.dev.yml logs --tail=10 -f mailcatcher",
       "type": "shell",
       "problemMatcher": [],
       "options": {

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -9,6 +9,8 @@ module.exports = {
   RUN_CRONS: false,
   ENABLE_SENDINBLUE: true, // TODO: default false
   ENABLE_SENDINBLUE_SIMULATE_TEMPLATE: false,
+  MAILCATCHER_HOST: undefined,
+  MAILCATCHER_PORT: undefined,
   ENABLE_ANTIVIRUS: true,
   ENABLE_FLATTEN_ERROR_LOGS: true, // Print error stack without newlines on stderr
   API_URL: "http://localhost:8080",

--- a/api/docker-compose.dev.yml
+++ b/api/docker-compose.dev.yml
@@ -13,6 +13,11 @@ services:
       - "9200:9200"
     volumes:
       - elasticsearch_data:/data/elastic
+  mailcatcher:
+    image: schickling/mailcatcher
+    ports:
+      - "1025:1025"
+      - "1080:1080"
 
 volumes:
   mongodb_data:

--- a/api/package.json
+++ b/api/package.json
@@ -70,6 +70,7 @@
     "netmask": "^2.0.2",
     "node-cron": "^3.0.2",
     "node-fetch": "^2.6.1",
+    "nodemailer": "^6.9.14",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",
     "password-validator": "^5.3.0",

--- a/api/src/mailcatcher.ts
+++ b/api/src/mailcatcher.ts
@@ -1,0 +1,25 @@
+import nodemailer, { SendMailOptions } from "nodemailer";
+import config from "config";
+
+import type { SendMailParameters } from "./brevo";
+
+export async function sendMailCatcher(subject, html, { emailTo, cc, bcc, attachment }: SendMailParameters) {
+  return await sendMail({
+    to: emailTo!.map(({ email }) => email).join(", "),
+    cc: cc?.map(({ email }) => email).join(", "),
+    bcc: bcc?.map(({ email }) => email).join(", "),
+    subject,
+    html,
+    attachments: attachment?.map((file) => ({ filename: file.name, content: file.content, encoding: "base64" })) || [],
+  });
+}
+
+const sendMail = async (mailOptions: SendMailOptions) => {
+  const transporter = nodemailer.createTransport({
+    host: config.MAILCATCHER_HOST,
+    port: Number(config.MAILCATCHER_PORT),
+    secure: false,
+  });
+
+  await transporter.sendMail(mailOptions);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -515,6 +515,7 @@
         "netmask": "^2.0.2",
         "node-cron": "^3.0.2",
         "node-fetch": "^2.6.1",
+        "nodemailer": "^6.9.14",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.0",
         "password-validator": "^5.3.0",
@@ -18656,6 +18657,14 @@
     "node_modules/node-releases": {
       "version": "2.0.14",
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.14",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.14.tgz",
+      "integrity": "sha512-Dobp/ebDKBvz91sbtRKhcznLThrKxKt97GI2FAlAyy+fk19j73Uz3sBXolVtmcXjaorivqsbbbjDY+Jkt4/bQA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.0",


### PR DESCRIPTION
**Description**

Ajout du mailcatcher en local uniquement !

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/fd6055db-9c89-4395-b976-370c66611104">

**Todo**

- [x] Ajout des variables `MAILCATCHER_HOST` et `MAILCATCHER_PORT`
- [x] Envoi du message en SMTP avec pièce si disponible
- [x] Ajout du container mailcatcher dans le docker-compose local (accès à la console web http://localhost:1080/)
```bash
cd api
docker-compose -f ./docker-compose.dev.yml up -d mailcatcher
```

**Ticket / Issue**

<!-- If you have a Notion Ticket / GitHub Issue -->
<!-- Fixes [Notion ticket #123](https://notion.so/abc) -->

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
