### PR TITLE
feat(api): 3049 - migrate - add cohorts and add cohortId to collections

### DIFF
--- a/api/migrations/20240806105049-create-non-existing-cohort.js
+++ b/api/migrations/20240806105049-create-non-existing-cohort.js
@@ -1,0 +1,31 @@
+const { CohortModel } = require("../src/models");
+const cohortsNames = ["2019", "2020", "2021", "2022", "Juin 2022", "Février 2022", "Juin 2022", "Juillet 2022", "à venir"];
+module.exports = {
+  async up() {
+    for (const cohortName of cohortsNames) {
+      const cohort = new CohortModel({
+        snuId: cohortName,
+        name: cohortName,
+        dateStart: new Date("2022-01-01"),
+        dateEnd: new Date("2022-12-31"),
+        eligibility: {
+          zones: ["A"],
+          schoolLevels: ["3eme"],
+          bornAfter: new Date("2000-01-01"),
+          bornBefore: new Date("2005-12-31"),
+        },
+        inscriptionStartDate: new Date("2022-02-01"),
+        inscriptionEndDate: new Date("2022-03-31"),
+        instructionEndDate: new Date("2022-04-30"),
+        buffer: 1,
+        event: "Event Name",
+      });
+      await cohort.save({ fromUser: { firstName: "create-non-existing-cohort" } });
+    }
+  },
+
+  async down() {
+    const deletedCohorts = await CohortModel.deleteMany({ name: { $in: cohortsNames } });
+    console.log("Deleted Cohort:", deletedCohorts.deletedCount);
+  },
+};

--- a/api/migrations/20240806125049-add-cohortId-into-collections.js
+++ b/api/migrations/20240806125049-add-cohortId-into-collections.js
@@ -1,0 +1,75 @@
+const { CohortModel } = require("../src/models");
+const collectionsWithCohortIdToAdd = [
+  "youngs",
+  "importplandetransports",
+  "lignebuses",
+  "modificationbuses",
+  "plandetransports",
+  "pointderassemblements",
+  "schemaderepartitions",
+  "tablederepartitions",
+  "applications",
+  "buses",
+  "classes",
+  "departmentservices",
+  "inscriptiongoals",
+  "stats-young-centers",
+  "meetingpoints",
+  "sessionphase1",
+];
+
+module.exports = {
+  async up(db) {
+    const cohorts = await CohortModel.find({}, { name: 1 }).lean();
+    const cohortsMap = new Map();
+    for (const cohort of cohorts) {
+      cohortsMap.set(cohort.name, cohort._id?.toString());
+    }
+    let updatedDocumentsCount = 0;
+    let updatedDocumentsForOriginalCohortCount = 0;
+
+    const addCohortIdToCollection = async (collectionName, cohort) => {
+      let updatedDocuments = await db.collection(collectionName).updateMany({ cohort: cohort[0] }, { $set: { cohortId: cohort[1] } });
+
+      updatedDocumentsCount += updatedDocuments.modifiedCount;
+      console.log(
+        `Collection ${collectionName} - Added cohortId: ${cohort[1]} for cohort: ${cohort[0]} - Matched: ${updatedDocuments.matchedCount}, Added property cohortId : ${updatedDocuments.modifiedCount}`,
+      );
+    };
+
+    const addOriginalCohortIdToCollection = async (collectionName, cohort) => {
+      let updatedDocuments = await db.collection(collectionName).updateMany({ originalCohort: cohort[0] }, { $set: { originalCohortId: cohort[1] } });
+
+      updatedDocumentsForOriginalCohortCount += updatedDocuments.modifiedCount;
+      console.log(
+        `Collection ${collectionName} - Added originalCohortId: ${cohort[1]} for originalCohort: ${cohort[0]} - Matched: ${updatedDocuments.matchedCount}, Added property originalCohortId : ${updatedDocuments.modifiedCount}`,
+      );
+    };
+
+    // For every collection declared above
+    for (const collectionName of collectionsWithCohortIdToAdd) {
+      updatedDocumentsCount = 0;
+      for (const cohort of cohortsMap) {
+        await addCohortIdToCollection(collectionName, cohort);
+      }
+      console.log(`Total documents updated: ${updatedDocumentsCount} on ${collectionName}`);
+    }
+
+    // Collections with originalCohort field : youngs
+    for (const cohort of cohortsMap) {
+      await addOriginalCohortIdToCollection("youngs", cohort);
+    }
+    console.log(`Total documents updated for originalCohortId: ${updatedDocumentsForOriginalCohortCount}`);
+  },
+
+  async down(db) {
+    for (const collectionName of collectionsWithCohortIdToAdd) {
+      const updatedDocuments = await db.collection(collectionName).updateMany({ cohortId: { $exists: true } }, { $unset: { cohortId: 1 } });
+      console.log(`Collection ${collectionName} - Matched: ${updatedDocuments.matchedCount} Removed property cohortId on : ${updatedDocuments.modifiedCount}`);
+    }
+    const updatedDocumentsForOriginalCohort = await db.collection("youngs").updateMany({ originalCohortId: { $exists: true } }, { $unset: { originalCohortId: 1 } });
+    console.log(
+      `Collection youngs - Matched: ${updatedDocumentsForOriginalCohort.matchedCount} Removed property originalCohortId on : ${updatedDocumentsForOriginalCohort.modifiedCount}`,
+    );
+  },
+};

--- a/api/package.json
+++ b/api/package.json
@@ -26,7 +26,8 @@
     "build": "tsc -b ./build.tsconfig.json",
     "migrate-status": "migrate-mongo status",
     "migrate-create": "migrate-mongo create",
-    "migrate-down": "tsx node_modules/.bin/migrate-mongo down"
+    "migrate-down": "tsx --max-old-space-size=4096 node_modules/.bin/migrate-mongo down",
+    "migrate-up": "tsx --max-old-space-size=4096 node_modules/.bin/migrate-mongo up"
   },
   "author": "SELEGO",
   "license": "MIT",

--- a/api/src/__tests__/fixtures/application.ts
+++ b/api/src/__tests__/fixtures/application.ts
@@ -24,6 +24,7 @@ function getNewApplicationFixture(): Partial<ApplicationType> {
     tutorName: faker.person.firstName(),
     priority: "1",
     status: "WAITING_VALIDATION",
+    cohortId: "1",
   };
 }
 

--- a/api/src/__tests__/fixtures/bus.ts
+++ b/api/src/__tests__/fixtures/bus.ts
@@ -6,6 +6,7 @@ function getNewBusFixture(): Partial<BusType> {
     idExcel: faker.lorem.words(),
     capacity: faker.number.int({ min: 11, max: 20 }),
     placesLeft: faker.number.int({ min: 1, max: 10 }),
+    cohortId: "1",
   };
 }
 

--- a/api/src/__tests__/fixtures/classe.ts
+++ b/api/src/__tests__/fixtures/classe.ts
@@ -23,6 +23,7 @@ export function createFixtureClasse(fields: Partial<ClasseType> = {}): Partial<C
     type: "FULL",
     estimatedSeats: 20,
     trimester: "T1",
+    cohortId: "1",
     ...fields,
   };
   return classe;

--- a/api/src/__tests__/fixtures/inscriptionGoal.ts
+++ b/api/src/__tests__/fixtures/inscriptionGoal.ts
@@ -6,5 +6,6 @@ export default function getNewInscriptionGoalFixture(): Partial<InscriptionGoalT
     region: faker.lorem.words(),
     department: faker.number.int({ min: 11, max: 123 }).toString(),
     max: faker.number.int({ min: 11, max: 123 }),
+    cohortId: "1",
   };
 }

--- a/api/src/__tests__/fixtures/meetingPoint.ts
+++ b/api/src/__tests__/fixtures/meetingPoint.ts
@@ -18,6 +18,7 @@ function getNewMeetingPointFixture(): Partial<MeetingPointType> {
     departureAtString: faker.lorem.words(),
     returnAt: faker.date.past(),
     returnAtString: faker.lorem.words(),
+    cohortId: "1",
   };
 }
 

--- a/api/src/__tests__/fixtures/sessionPhase1.ts
+++ b/api/src/__tests__/fixtures/sessionPhase1.ts
@@ -8,6 +8,7 @@ function getNewSessionPhase1Fixture(object: Partial<SessionPhase1Type> = {}): Pa
     placesTotal: placesLeft,
     placesLeft: placesLeft,
     status: "VALIDATED",
+    cohortId: "1",
     ...object,
   };
 }

--- a/api/src/__tests__/fixtures/young.ts
+++ b/api/src/__tests__/fixtures/young.ts
@@ -205,6 +205,8 @@ export default function getNewYoungFixture(fields: Partial<YoungType> = {}): Par
     sportInterest: faker.lorem.sentences(),
     environmentInterest: faker.lorem.sentences(),
     citizenshipInterest: faker.lorem.sentences(),
+    cohortId: "1",
+    originalCohortId: "1",
     ...fields,
   };
 }

--- a/api/src/models/PlanDeTransport/importPlanTransport.ts
+++ b/api/src/models/PlanDeTransport/importPlanTransport.ts
@@ -15,6 +15,12 @@ const schema = new Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   lines: {
     type: [Object],
     documentation: {

--- a/api/src/models/PlanDeTransport/ligneBus.ts
+++ b/api/src/models/PlanDeTransport/ligneBus.ts
@@ -77,6 +77,12 @@ const schema = new Schema({
       description: "Cohorte de la ligne de bus",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
 
   busId: {
     type: String,

--- a/api/src/models/PlanDeTransport/modificationBus.ts
+++ b/api/src/models/PlanDeTransport/modificationBus.ts
@@ -19,6 +19,12 @@ export const schema = new Schema({
       description: "Cohorte de la ligne de bus",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   //Informations de la ligne de bus
   lineId: {
     type: String,

--- a/api/src/models/PlanDeTransport/planTransport.ts
+++ b/api/src/models/PlanDeTransport/planTransport.ts
@@ -70,7 +70,12 @@ const schema = new Schema({
       description: "Cohorte de la ligne de bus",
     },
   },
-
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   busId: {
     type: String,
     required: true,

--- a/api/src/models/PlanDeTransport/pointDeRassemblement.ts
+++ b/api/src/models/PlanDeTransport/pointDeRassemblement.ts
@@ -55,6 +55,12 @@ const schema = new Schema({
             description: "Cohorte du complément d'adresse",
           },
         },
+        cohortId: {
+          type: String,
+          documentation: {
+            description: "Id de la cohorte",
+          },
+        },
         complement: {
           type: String,
           documentation: {

--- a/api/src/models/PlanDeTransport/schemaDeRepartition.ts
+++ b/api/src/models/PlanDeTransport/schemaDeRepartition.ts
@@ -16,6 +16,12 @@ const schema = new Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   intradepartmental: {
     type: String,
     enum: ["true", "false"],

--- a/api/src/models/PlanDeTransport/tableDeRepartition.ts
+++ b/api/src/models/PlanDeTransport/tableDeRepartition.ts
@@ -17,6 +17,12 @@ const schema = new Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   fromDepartment: {
     type: String,
     documentation: {

--- a/api/src/models/application.ts
+++ b/api/src/models/application.ts
@@ -69,6 +69,12 @@ const schema = new Schema({
       description: "Cohorte du volontaire",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
 
   missionId: {
     type: String,

--- a/api/src/models/bus.ts
+++ b/api/src/models/bus.ts
@@ -11,6 +11,12 @@ const schema = new Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   idExcel: {
     type: String,
   },

--- a/api/src/models/cle/classe.ts
+++ b/api/src/models/cle/classe.ts
@@ -54,6 +54,12 @@ const schema = new Schema({
       description: "Cohorte de la classe",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
 
   uniqueKey: {
     type: String,

--- a/api/src/models/departmentService.ts
+++ b/api/src/models/departmentService.ts
@@ -17,6 +17,12 @@ const schema = new Schema({
           type: String,
           documentation: "cohorte concerné par le service",
         },
+        cohortId: {
+          type: String,
+          documentation: {
+            description: "Id de la cohorte",
+          },
+        },
         contactName: {
           type: String,
           documentation: {

--- a/api/src/models/inscriptionGoal.ts
+++ b/api/src/models/inscriptionGoal.ts
@@ -42,6 +42,12 @@ const schema = new Schema({
       description: "Cohorte des jeunes",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   fillingRate: {
     type: Number,
     documentation: {

--- a/api/src/models/legacy/stats-young-center.js
+++ b/api/src/models/legacy/stats-young-center.js
@@ -63,6 +63,12 @@ const Schema = new mongoose.Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   young_phase: {
     type: String,
     default: "INSCRIPTION",

--- a/api/src/models/meetingPoint.ts
+++ b/api/src/models/meetingPoint.ts
@@ -21,6 +21,12 @@ const schema = new Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   busId: {
     type: String,
     documentation: {

--- a/api/src/models/sessionPhase1.ts
+++ b/api/src/models/sessionPhase1.ts
@@ -33,6 +33,12 @@ const schema = new Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   department: {
     type: String,
     documentation: {

--- a/api/src/models/young.ts
+++ b/api/src/models/young.ts
@@ -38,6 +38,12 @@ const CorrectionRequest = new Schema({
       description: "Cohorte du jeune au moment de la dernière action sur cette demande de correction",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   field: {
     type: String,
     required: true,
@@ -221,10 +227,22 @@ const schema = new Schema({
       description: "Cohorte",
     },
   },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
   originalCohort: {
     type: String,
     documentation: {
       description: "Cohorte d'origine du volontaire, dans le cas ou il a changé de cohorte après sa validation",
+    },
+  },
+  originalCohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte d'origine",
     },
   },
   cohortChangeReason: {


### PR DESCRIPTION

- [x] Ajout en bdd des précédentes cohortes
- [x] Lien entre cohortId et les collections  :
  - [x] "youngs",
  - [x] "importplandetransports",
  - [x]   "lignebuses",
  - [x]   "modificationbuses",
  - [x]   "plandetransports",
  - [x]   "pointderassemblements",
  - [x]   "schemaderepartitions",
  - [x]   "tablederepartitions",
  - [x]   "applications",
  - [x]   "buses",
  - [x]   "classes",
  - [x]   "departmentservices",
  - [x]   "inscriptiongoals",
  - [x]   "stats-young-centers",
  - [x]   "meetingpoints",
  - [x]   "sessionphase1",

**Après déploiement:**
- [ ] Indexation ES

https://www.notion.so/jeveuxaider/CLE-24-25-g-rer-les-cohortes-via-un-ID-et-non-le-nom-d673b2e5ac884915905a5533b366f447