### PR TITLE
fix(api): 2907 - reset affectation informations when a young is switched to LC

### DIFF
--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -98,6 +98,7 @@ import { getFilteredSessions, getAllSessions } from "../utils/cohort";
 import scanFile from "../utils/virusScanner";
 import { getMimeFromBuffer, getMimeFromFile } from "../utils/file";
 import { UserRequest } from "../controllers/request";
+import { shouldSwitchYoungByIdToLC, switchYoungByIdToLC } from "../young/youngService";
 
 const router = express.Router();
 const ReferentAuth = new AuthObject(ReferentModel);
@@ -589,6 +590,10 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
     if (young.ligneId) {
       const bus = await LigneBusModel.findById(young.ligneId);
       if (bus) await updateSeatsTakenInBusLine(bus);
+    }
+
+    if (await shouldSwitchYoungByIdToLC(id, value.status)) {
+      await switchYoungByIdToLC(id);
     }
 
     res.status(200).send({ ok: true, data: young });

--- a/api/src/young/youngService.test.ts
+++ b/api/src/young/youngService.test.ts
@@ -1,6 +1,8 @@
 import * as youngService from "./youngService";
-// import * as documentService from "../document/document.service";
+import { findYoungByIdOrThrow, shouldSwitchYoungByIdToLC, switchYoungByIdToLC } from "./youngService";
 import { generatePdfIntoBuffer } from "../utils/pdf-renderer";
+import { YoungDocument, YoungModel } from "../models";
+import { ERRORS, YOUNG_PHASE, YOUNG_STATUS } from "snu-lib";
 
 const mockBuffer = Buffer.from("pdf");
 
@@ -23,6 +25,91 @@ describe("YoungService", () => {
 
     expect(youngsPdfCreated).toEqual(mockBuffer);
     expect(generatePdfIntoBuffer).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("YoungService.findYoungByIdOrThrow", () => {
+  it("should return a young object when found", async () => {
+    const mockYoung = {
+      _id: "1",
+      name: "John Doe",
+      status: YOUNG_STATUS.VALIDATED,
+    };
+    YoungModel.findById = jest.fn().mockResolvedValue(mockYoung);
+
+    const result = await findYoungByIdOrThrow("1");
+    expect(result).toBe(mockYoung);
+    expect(YoungModel.findById).toHaveBeenCalledWith("1");
+  });
+
+  it("should throw an error when young is not found", async () => {
+    YoungModel.findById = jest.fn().mockResolvedValue(null);
+
+    await expect(findYoungByIdOrThrow("2")).rejects.toThrow(ERRORS.YOUNG_NOT_FOUND);
+    expect(YoungModel.findById).toHaveBeenCalledWith("2");
+  });
+});
+
+describe("YoungService.switchYoungByIdToLC()", () => {
+  it("should update the young's properties and save successfully", async () => {
+    const mockYoung = {
+      set: jest.fn(),
+      save: jest.fn().mockResolvedValue("mocked saved young"),
+    };
+    jest.spyOn(youngService, "findYoungByIdOrThrow").mockResolvedValue(mockYoung as unknown as YoungDocument);
+
+    const result = await switchYoungByIdToLC("123");
+
+    expect(mockYoung.set).toHaveBeenCalledWith({
+      cohesionCenterId: undefined,
+      sessionPhase1Id: undefined,
+      meetingPointId: undefined,
+      ligneId: undefined,
+      deplacementPhase1Autonomous: undefined,
+      transportInfoGivenByLocal: undefined,
+      cohesionStayPresence: undefined,
+      presenceJDM: undefined,
+      departInform: undefined,
+      departSejourAt: undefined,
+      departSejourMotif: undefined,
+      departSejourMotifComment: undefined,
+      youngPhase1Agreement: "false",
+      hasMeetingInformation: undefined,
+      cohesionStayMedicalFileReceived: undefined,
+    });
+    expect(mockYoung.save).toHaveBeenCalledTimes(1);
+    expect(result).toBe("mocked saved young");
+  });
+});
+
+describe("shouldSwitchYoungByIdToLC", () => {
+  const mockYoung = {
+    status: YOUNG_STATUS.VALIDATED,
+    phase: YOUNG_PHASE.INSCRIPTION,
+  };
+
+  it("returns true if conditions are met for switching to LC", async () => {
+    jest.spyOn(youngService, "findYoungByIdOrThrow").mockResolvedValue(mockYoung as any);
+    const result = await shouldSwitchYoungByIdToLC("youngId", YOUNG_STATUS.WAITING_LIST);
+    expect(result).toBe(true);
+  });
+
+  it("returns false if the status is not VALIDATED", async () => {
+    jest.spyOn(youngService, "findYoungByIdOrThrow").mockResolvedValue({ ...mockYoung, status: YOUNG_STATUS.ABANDONED } as any);
+    const result = await shouldSwitchYoungByIdToLC("youngId", YOUNG_STATUS.WAITING_LIST);
+    expect(result).toBe(false);
+  });
+
+  it("returns false if the phase is not INSCRIPTION", async () => {
+    jest.spyOn(youngService, "findYoungByIdOrThrow").mockResolvedValue({ ...mockYoung, phase: YOUNG_PHASE.COHESION_STAY } as any);
+    const result = await shouldSwitchYoungByIdToLC("youngId", YOUNG_STATUS.WAITING_LIST);
+    expect(result).toBe(false);
+  });
+
+  it("returns false if the new status is not WAITING_LIST", async () => {
+    jest.spyOn(youngService, "findYoungByIdOrThrow").mockResolvedValue(mockYoung as any);
+    const result = await shouldSwitchYoungByIdToLC("youngId", YOUNG_STATUS.VALIDATED);
+    expect(result).toBe(false);
   });
 });
 

--- a/api/src/young/youngService.ts
+++ b/api/src/young/youngService.ts
@@ -1,6 +1,6 @@
 import { YOUNG_DOCUMENT, YOUNG_DOCUMENT_PHASE_TEMPLATE } from "./youngDocument";
-import { YoungModel } from "../models";
-import { YoungDto } from "snu-lib";
+import { YoungDocument, YoungModel, YoungType } from "../models";
+import { ERRORS, YOUNG_PHASE, YOUNG_STATUS, YOUNG_STATUS_PHASE1, YoungDto } from "snu-lib";
 import { generatePdfIntoBuffer } from "../utils/pdf-renderer";
 
 export const generateConvocationsForMultipleYoungs = async (youngs: YoungDto[]): Promise<Buffer> => {
@@ -13,4 +13,39 @@ export const generateConvocationsForMultipleYoungs = async (youngs: YoungDto[]):
 
 export const findYoungsByClasseId = async (classeId: string): Promise<YoungDto[]> => {
   return YoungModel.find({ classeId });
+};
+
+export const shouldSwitchYoungByIdToLC = async (youngId: string, newYoungStatus: keyof typeof YOUNG_STATUS): Promise<boolean> => {
+  const young = await findYoungByIdOrThrow(youngId);
+  return young.status === YOUNG_STATUS.VALIDATED && young.phase === YOUNG_PHASE.INSCRIPTION && newYoungStatus === YOUNG_STATUS.WAITING_LIST;
+};
+
+export const findYoungByIdOrThrow = async (youngId: string): Promise<YoungDocument> => {
+  const young = await YoungModel.findById(youngId);
+  if (!young) {
+    throw new Error(ERRORS.YOUNG_NOT_FOUND);
+  }
+  return young;
+};
+
+export const switchYoungByIdToLC = async (youngId: string): Promise<YoungType> => {
+  const young = await findYoungByIdOrThrow(youngId);
+  young.set({
+    cohesionCenterId: undefined,
+    sessionPhase1Id: undefined,
+    meetingPointId: undefined,
+    ligneId: undefined,
+    deplacementPhase1Autonomous: undefined,
+    transportInfoGivenByLocal: undefined,
+    cohesionStayPresence: undefined,
+    presenceJDM: undefined,
+    departInform: undefined,
+    departSejourAt: undefined,
+    departSejourMotif: undefined,
+    departSejourMotifComment: undefined,
+    youngPhase1Agreement: "false",
+    hasMeetingInformation: undefined,
+    cohesionStayMedicalFileReceived: undefined,
+  });
+  return await young.save();
 };


### PR DESCRIPTION
Reset les infos d'affectation quand un jeune passe de LP à LC

https://www.notion.so/jeveuxaider/Sprint-Admin-15-S32-S33-df9d21c982734b4790a7ecce3c7afbad?p=cf724c60a25442bdb5b52db2f3a6846b&pm=s