### PR TITLE
fix(api): 3156 - add isFirstInvitationPending when create a new referent

### DIFF
--- a/api/migrations/20240828123437-add-isFirstInvitationPending-when-create-referent-classe.js
+++ b/api/migrations/20240828123437-add-isFirstInvitationPending-when-create-referent-classe.js
@@ -1,0 +1,11 @@
+const { ReferentModel } = require("../src/models");
+const { ReferentCreatedBy } = require("snu-lib");
+module.exports = {
+  async up() {
+    await ReferentModel.updateMany({ "metadata.createdBy": ReferentCreatedBy.UPDATE_REFERENT_2024_2025 }, { $set: { "metadata.isFirstInvitationPending": true } });
+  },
+
+  async down() {
+    await ReferentModel.updateMany({ "metadata.createdBy": ReferentCreatedBy.UPDATE_REFERENT_2024_2025 }, { $unset: { "metadata.isFirstInvitationPending": 1 } });
+  },
+};

--- a/api/package.json
+++ b/api/package.json
@@ -24,8 +24,8 @@
     "doc": "node ./src/utils/generate-models-documentation.js",
     "clean": "rm -fr node_modules .turbo",
     "build": "tsc -b ./build.tsconfig.json",
-    "migrate-status": "migrate-mongo status",
-    "migrate-create": "migrate-mongo create",
+    "migrate-status": "tsx node_modules/.bin/migrate-mongo status",
+    "migrate-create": "tsx node_modules/.bin/migrate-mongo create",
     "migrate-down": "tsx --max-old-space-size=4096 node_modules/.bin/migrate-mongo down",
     "migrate-up": "tsx --max-old-space-size=4096 node_modules/.bin/migrate-mongo up"
   },

--- a/api/src/__tests__/cle/classe.test.ts
+++ b/api/src/__tests__/cle/classe.test.ts
@@ -792,6 +792,7 @@ describe("PUT /cle/classe/:id/referent", () => {
     expect(updatedReferent.firstName).toBe(newReferentDetails.firstName);
     expect(updatedReferent.lastName).toBe(newReferentDetails.lastName);
     expect(updatedReferent.email).toBe(newReferentDetails.email);
+    expect(updatedReferent.metadata.isFirstInvitationPending).toBe(true);
     expect(res.status).toBe(200);
   });
 

--- a/api/src/cle/classe/classeService.ts
+++ b/api/src/cle/classe/classeService.ts
@@ -96,7 +96,7 @@ export const updateReferent = async (classeId: string, newReferent: Pick<Referen
   }
   const newReferentClasse = {
     role: ROLES.REFERENT_CLASSE,
-    metadata: { invitationType: InvitationType.INSCRIPTION, createdBy: ReferentCreatedBy.UPDATE_REFERENT_2024_2025 },
+    metadata: { invitationType: InvitationType.INSCRIPTION, createdBy: ReferentCreatedBy.UPDATE_REFERENT_2024_2025, isFirstInvitationPending: true },
     firstName: newReferent.firstName,
     lastName: newReferent.lastName,
     email: newReferent.email,


### PR DESCRIPTION
Ajout de isFirstInvitationPending si un référent de classe inexistant sur la plateforme est lié à une classe.

https://www.notion.so/jeveuxaider/CLE-Permettre-de-modifier-les-informations-du-r-f-rent-de-classe-lorsque-le-statut-de-la-classe-es-431c45b0352a493dbbc4e83f7cd672a8?pvs=4