### PR TITLE
fix(api): 3174 - referent deprtment cannot verify classe

### DIFF
--- a/api/src/__tests__/cle/classe.test.ts
+++ b/api/src/__tests__/cle/classe.test.ts
@@ -502,9 +502,9 @@ describe("PUT /cle/classe/:id/verify", () => {
     // @ts-ignore
     passport.user.role = ROLES.REFERENT_DEPARTMENT;
     // @ts-ignore
-    const previous = passport.user.departement;
+    const previous = passport.user.department;
     // @ts-ignore
-    passport.user.departement = "Loire";
+    passport.user.department = ["Loire"];
     const res = await request(getAppHelper())
       .put(`/cle/classe/${validId}/verify`)
       .send({
@@ -514,7 +514,7 @@ describe("PUT /cle/classe/:id/verify", () => {
     // @ts-ignore
     passport.user.role = ROLES.ADMIN;
     // @ts-ignore
-    passport.user.departement = previous;
+    passport.user.department = previous;
   });
 
   it("should return 403 when REFERENT_REGION tries to verify a class they don't manage", async () => {
@@ -598,7 +598,7 @@ describe("GET /:id/notifyRef", () => {
     // @ts-ignore
     passport.user.role = ROLES.REFERENT_DEPARTMENT;
     // @ts-ignore
-    passport.user.departement = "Loire";
+    passport.user.department = ["Loire"];
     const res = await request(getAppHelper()).get(`/cle/classe/${validId}/notifyRef`);
     expect(res.status).toBe(403);
     // @ts-ignore

--- a/api/src/cle/classe/classeController.ts
+++ b/api/src/cle/classe/classeController.ts
@@ -115,7 +115,7 @@ router.post("/export", passport.authenticate("referent", { session: false, failW
 
     const queryParams = req.query.type === "schema-de-repartition" ? { cohort: req.body.cohort, status: { $in: [STATUS_CLASSE.OPEN, STATUS_CLASSE.CLOSED] } } : {};
     if (req.user.role === ROLES.REFERENT_REGION) queryParams["region"] = req.user.region;
-    if (req.user.role === ROLES.REFERENT_DEPARTMENT) queryParams["department"] = req.user.departement;
+    if (req.user.role === ROLES.REFERENT_DEPARTMENT) queryParams["department"] = req.user.department;
 
     const classes: ClasseDocument<{
       cohesionCenter?: CohesionCenterDocument;
@@ -539,7 +539,7 @@ router.get("/:id/notifyRef", passport.authenticate("referent", { session: false,
     if (req.user.role === ROLES.REFERENT_REGION && classe.etablissement.region !== req.user.region) {
       return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     }
-    if (req.user.role === ROLES.REFERENT_DEPARTMENT && classe.etablissement.department !== req.user.departement) {
+    if (req.user.role === ROLES.REFERENT_DEPARTMENT && !req.user.department?.includes(classe.etablissement.department)) {
       return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     }
 
@@ -579,7 +579,7 @@ router.put("/:id/verify", passport.authenticate("referent", { session: false, fa
       }
     }
     if (req.user.role === ROLES.REFERENT_DEPARTMENT) {
-      if (classe.department !== req.user.departement) {
+      if (!req.user.department?.includes(classe.department)) {
         return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
       }
     }

--- a/packages/lib/src/dto/userDto.ts
+++ b/packages/lib/src/dto/userDto.ts
@@ -8,6 +8,6 @@ export type UserDto = {
   lastName: string;
   structureId: string;
   region: string;
-  departement: string;
+  department: string[];
   subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES_LIST | keyof typeof VISITOR_SUB_ROLES_LIST;
 };


### PR DESCRIPTION
Le DTO de user était faux : 
`departement: string`  remplacé par:
`department: string[]`

https://www.notion.so/jeveuxaider/BUG-Admin-CLE-D-clarer-une-classe-v-rifi-e-par-un-R-f-rent-6c8ff56ab59047c090837f43b09465ee?pvs=4