### PR TITLE
fix(api): 3181 - referent hide deletedat

### DIFF
--- a/api/src/controllers/elasticsearch/referent.js
+++ b/api/src/controllers/elasticsearch/referent.js
@@ -202,6 +202,7 @@ router.post("/:action(search|export)", passport.authenticate(["referent"], { ses
     // Context filters
     const contextFilters = [
       ...referentContextFilters,
+      { bool: { must_not: { exists: { field: "deletedAt" } } } },
       query.cohort
         ? {
             bool: {


### PR DESCRIPTION
**Description**

Les utilisateurs supprimés logiquement (champ deletedAt) ne doivent pas apparaitre dans la la liste.

**Ticket / Issue**

https://www.notion.so/jeveuxaider/BUG-Admin-CLE-Doublon-comptes-tablissements-1a43f5f63ed54fb2baa8f91c095904c1
