### PR TITLE
fix(app): 3197 - Réparer les pages Consentements (volontaires HTS) et Représentants légaux (HTS et CLE)

### DIFF
--- a/api/src/cohort/cohortController.ts
+++ b/api/src/cohort/cohortController.ts
@@ -135,6 +135,46 @@ router.get("/:cohort", passport.authenticate(["referent", "young"], { session: f
   }
 });
 
+router.get("/:cohortId/public", async (req: UserRequest, res: Response) => {
+  try {
+    const { error, value } = Joi.object({
+      cohortId: Joi.string().required(),
+    })
+      .unknown()
+      .validate(req.params, { stripUnknown: true });
+    if (error) {
+      capture(error);
+      return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
+    }
+    const cohort = await CohortModel.findById(value.cohortId);
+
+    if (!cohort) {
+      return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+    }
+
+    const data = {
+      _id: cohort._id,
+      name: cohort.name,
+      type: cohort.type,
+      dateStart: cohort.dateStart,
+      dateEnd: cohort.dateEnd,
+      isAssignmentAnnouncementsOpenForYoung: cohort.isAssignmentAnnouncementsOpenForYoung,
+      inscriptionStartDate: cohort.inscriptionStartDate,
+      inscriptionEndDate: cohort.inscriptionEndDate,
+      instructionEndDate: cohort.instructionEndDate,
+      inscriptionModificationEndDate: cohort.inscriptionModificationEndDate,
+      reInscriptionStartDate: cohort.reInscriptionStartDate,
+      reInscriptionEndDate: cohort.reInscriptionEndDate,
+      pdrChoiceLimitDate: cohort.pdrChoiceLimitDate,
+    };
+
+    return res.status(200).send({ ok: true, data });
+  } catch (error) {
+    capture(error);
+    return res.status(500).send({ ok: false, code: ERRORS.SERVER_ERROR, error });
+  }
+});
+
 router.get("/bysession/:sessionId", passport.authenticate(["referent"], { session: false, failWithError: true }), async (req: UserRequest, res: Response) => {
   try {
     const { error, value } = Joi.object({

--- a/app/src/context/RepresentantsLegauxContextProvider.jsx
+++ b/app/src/context/RepresentantsLegauxContextProvider.jsx
@@ -24,7 +24,6 @@ const RepresentantsLegauxContextProvider = ({ children, parentId }) => {
         if (!token || !parentId) setError(true);
         const { ok, data } = await api.get(`/representants-legaux/young?token=${token}&parent=${parentId}`);
         if (!ok) return setError(true);
-        console.log("🚀 ~ getYoungFromToken ~ data:", data);
         setYoung(data);
 
         if (data.cohortId) {
@@ -33,7 +32,7 @@ const RepresentantsLegauxContextProvider = ({ children, parentId }) => {
         }
 
         if (data.classeId) {
-          const { ok, data: classe } = await fetchClass(data.classeId);
+          const classe = await fetchClass(data.classeId);
           if (ok) setClasse(classe);
         }
       } catch (e) {

--- a/app/src/context/RepresentantsLegauxContextProvider.jsx
+++ b/app/src/context/RepresentantsLegauxContextProvider.jsx
@@ -3,14 +3,20 @@ import { Redirect } from "react-router-dom";
 import queryString from "query-string";
 import api from "../services/api";
 import { capture } from "../sentry";
+import Loader from "@/components/Loader";
+import { fetchClass } from "@/services/classe.service";
+import { fetchCohort } from "@/utils/cohorts";
 
 export const RepresentantsLegauxContext = createContext();
 
 const RepresentantsLegauxContextProvider = ({ children, parentId }) => {
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const params = queryString.parse(location.search);
   const { token } = params;
   const [young, setYoung] = useState(null);
+  const [classe, setClasse] = useState(null);
+  const [cohort, setCohort] = useState(null);
 
   useEffect(() => {
     async function getYoungFromToken() {
@@ -18,17 +24,30 @@ const RepresentantsLegauxContextProvider = ({ children, parentId }) => {
         if (!token || !parentId) setError(true);
         const { ok, data } = await api.get(`/representants-legaux/young?token=${token}&parent=${parentId}`);
         if (!ok) return setError(true);
+        console.log("🚀 ~ getYoungFromToken ~ data:", data);
         setYoung(data);
+
+        if (data.cohortId) {
+          const { ok, data: cohort } = await fetchCohort(data.cohortId);
+          if (ok) setCohort(cohort);
+        }
+
+        if (data.classeId) {
+          const { ok, data: classe } = await fetchClass(data.classeId);
+          if (ok) setClasse(classe);
+        }
       } catch (e) {
         if (e.code === "INVALID_BODY" || e.code === "OPERATION_UNAUTHORIZED") setError(true);
         capture(e);
       }
+      setLoading(false);
     }
     getYoungFromToken();
   }, [token, parentId]);
 
+  if (loading) return <Loader />;
   if (error) return <Redirect to="/representants-legaux/token-invalide" />;
-  return <RepresentantsLegauxContext.Provider value={{ young, token }}>{children}</RepresentantsLegauxContext.Provider>;
+  return <RepresentantsLegauxContext.Provider value={{ young, token, classe, cohort }}>{children}</RepresentantsLegauxContext.Provider>;
 };
 
 export default RepresentantsLegauxContextProvider;

--- a/app/src/scenes/inscription2023/steps/stepConsentements.jsx
+++ b/app/src/scenes/inscription2023/steps/stepConsentements.jsx
@@ -29,7 +29,7 @@ export default function StepConsentements() {
     consentment2: young?.acceptCGU === "true",
   });
 
-  const { data: classe, isPending } = useQuery({
+  const { data: classe, isLoading } = useQuery({
     queryKey: ["class", young?.classeId],
     queryFn: () => fetchClass(young?.classeId),
     enabled: isCLE && validateId(young?.classeId),
@@ -64,7 +64,7 @@ export default function StepConsentements() {
     else setDisabled(true);
   }, [data]);
 
-  if (isPending) return <Loader />;
+  if (isLoading) return <Loader />;
 
   const cohortYear = isCLE ? classe?.schoolYear : getCohortYear(getCohort(young.cohort));
 

--- a/app/src/scenes/representants-legaux/mobile/consentement.jsx
+++ b/app/src/scenes/representants-legaux/mobile/consentement.jsx
@@ -246,7 +246,7 @@ function ConsentementForm({ young, token, step, parentId }) {
 
   if (isLoading) return <Loader />;
 
-  const cohortYear = young.source === YOUNG_SOURCE.CLE ? classe?.schoolYear : getCohortYear(young.cohort);
+  const cohortYear = young.source === YOUNG_SOURCE.CLE ? classe?.schoolYear : young?.cohort.includes("2024") ? "2024" : "2025";
 
   return (
     <>

--- a/app/src/scenes/representants-legaux/mobile/consentement.jsx
+++ b/app/src/scenes/representants-legaux/mobile/consentement.jsx
@@ -8,7 +8,7 @@ import Input from "../../inscription2023/components/Input";
 import ResponsiveRadioButton from "../../../components/dsfr/ui/buttons/RadioButton";
 // TODO: mettre le Toggle dans les components génériques
 import Toggle from "../../../components/dsfr/forms/toggle";
-import { translate, getCohortYear, PHONE_ZONES, isPhoneNumberWellFormated, YOUNG_SOURCE } from "snu-lib";
+import { translate, PHONE_ZONES, isPhoneNumberWellFormated, YOUNG_SOURCE } from "snu-lib";
 import Check from "../components/Check";
 import { FRANCE, ABROAD, translateError, API_CONSENT, isReturningParent, CDN_BASE_URL } from "../commons";
 import AddressForm from "@/components/dsfr/forms/AddressForm";
@@ -21,32 +21,23 @@ import AuthorizeBlock from "../components/AuthorizeBlock";
 import { getAddress, getDataForConsentStep } from "../utils";
 import PhoneField from "../../../components/dsfr/forms/PhoneField";
 import { SignupButtons } from "@snu/ds/dsfr";
-import { useQuery } from "@tanstack/react-query";
-import { fetchClass } from "@/services/classe.service";
-import { validateId } from "@/utils";
 
 export default function Consentement({ step, parentId }) {
-  const { young, token } = useContext(RepresentantsLegauxContext);
+  const { young, token, classe, cohort } = useContext(RepresentantsLegauxContext);
   if (!young) return <Loader />;
   if (isReturningParent(young, parentId)) {
     const route = parentId === 2 ? "done-parent2" : "done";
     return <Redirect to={`/representants-legaux/${route}?token=${token}`} />;
   }
-  return <ConsentementForm young={young} token={token} step={step} parentId={parentId} />;
+  return <ConsentementForm young={young} token={token} step={step} parentId={parentId} cohort={cohort} classe={classe} />;
 }
 
-function ConsentementForm({ young, token, step, parentId }) {
+function ConsentementForm({ young, token, step, parentId, cohort, classe }) {
   const history = useHistory();
   const [errors, setErrors] = useState({});
   const [saving, setSaving] = React.useState(false);
   const [imageRightsExplanationShown, setImageRightsExplanationShown] = useState(false);
   const [data, setData] = useState(getDataForConsentStep(young, parentId));
-
-  const { data: classe, isLoading } = useQuery({
-    queryKey: ["class", young?.classeId],
-    queryFn: () => fetchClass(young?.classeId),
-    enabled: young?.source === YOUNG_SOURCE.CLE && validateId(young?.classeId),
-  });
 
   // --- young
   const youngFullname = young.firstName + " " + young.lastName;
@@ -244,9 +235,7 @@ function ConsentementForm({ young, token, step, parentId }) {
     }
   }
 
-  if (isLoading) return <Loader />;
-
-  const cohortYear = young.source === YOUNG_SOURCE.CLE ? classe?.schoolYear : young?.cohort.includes("2024") ? "2024" : "2025";
+  const cohortYear = young.source === YOUNG_SOURCE.CLE ? classe?.schoolYear : new Date(cohort.dateStart).getFullYear();
 
   return (
     <>

--- a/app/src/scenes/representants-legaux/mobile/consentement.jsx
+++ b/app/src/scenes/representants-legaux/mobile/consentement.jsx
@@ -42,7 +42,7 @@ function ConsentementForm({ young, token, step, parentId }) {
   const [imageRightsExplanationShown, setImageRightsExplanationShown] = useState(false);
   const [data, setData] = useState(getDataForConsentStep(young, parentId));
 
-  const { data: classe, isPending } = useQuery({
+  const { data: classe, isLoading } = useQuery({
     queryKey: ["class", young?.classeId],
     queryFn: () => fetchClass(young?.classeId),
     enabled: young?.source === YOUNG_SOURCE.CLE && validateId(young?.classeId),
@@ -244,7 +244,7 @@ function ConsentementForm({ young, token, step, parentId }) {
     }
   }
 
-  if (isPending) return <Loader />;
+  if (isLoading) return <Loader />;
 
   const cohortYear = young.source === YOUNG_SOURCE.CLE ? classe?.schoolYear : getCohortYear(young.cohort);
 

--- a/app/src/scenes/representants-legaux/mobile/presentation.jsx
+++ b/app/src/scenes/representants-legaux/mobile/presentation.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { Redirect, useHistory } from "react-router-dom";
-import { getCohortPeriod } from "snu-lib";
 import CalendarBig from "../../../assets/icons/CalendarBig";
 import CheckCircleStroke from "../../../assets/icons/CheckCircleStroke";
 import LinkTo from "../../../assets/icons/LinkTo";
@@ -15,7 +14,7 @@ import { SignupButtons } from "@snu/ds/dsfr";
 
 export default function Presentation({ step, parentId }) {
   const history = useHistory();
-  const { young, token } = useContext(RepresentantsLegauxContext);
+  const { young, token, cohort } = useContext(RepresentantsLegauxContext);
 
   if (!young) return <Loader />;
 
@@ -30,8 +29,6 @@ export default function Presentation({ step, parentId }) {
     if (status === "REFUSED") return "est refusé";
   };
 
-  // const isCLE = young?.cohort.name.includes("CLE");
-  const sejourDate = getCohortPeriod(young.cohort);
   const title = parentId === 2 ? `${young.firstName} s'est inscrit(e) au SNU !` : `${young.firstName} souhaite s'inscrire au SNU !`;
 
   function onSubmit() {
@@ -95,7 +92,10 @@ export default function Presentation({ step, parentId }) {
               </div>
               <p className="font-400 mt-3 text-center text-[15px] leading-[19px]">
                 {young.firstName} a choisi le séjour <br />
-                <strong>{sejourDate}</strong>.
+                <strong>
+                  du {new Date(cohort.dateStart).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })} au{" "}
+                  {new Date(cohort.dateEnd).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}.
+                </strong>
               </p>
             </div>
           </div>

--- a/app/src/scenes/representants-legaux/mobile/verification.jsx
+++ b/app/src/scenes/representants-legaux/mobile/verification.jsx
@@ -2,8 +2,7 @@ import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 import { RepresentantsLegauxContext } from "../../../context/RepresentantsLegauxContextProvider";
 import "dayjs/locale/fr";
-import { getDepartmentByZip, translate, translateGrade, getCohortPeriod, YOUNG_SOURCE } from "snu-lib";
-import { getCohort } from "@/utils/cohorts";
+import { getDepartmentByZip, translate, translateGrade, YOUNG_SOURCE } from "snu-lib";
 import api from "../../../services/api";
 import { API_VERIFICATION, isReturningParent } from "../commons";
 import { concatPhoneNumberWithZone } from "snu-lib";
@@ -17,7 +16,7 @@ import { SignupButtons } from "@snu/ds/dsfr";
 
 export default function Verification({ step, parentId }) {
   const history = useHistory();
-  const { young, token } = useContext(RepresentantsLegauxContext);
+  const { young, token, cohort } = useContext(RepresentantsLegauxContext);
   const [certified, setCertified] = React.useState(young?.parent1DataVerified);
   const [error, setError] = React.useState(null);
   const [saving, setSaving] = React.useState(false);
@@ -102,7 +101,7 @@ export default function Verification({ step, parentId }) {
           )}
         </div>
 
-        <ProfileDetails young={young} isCLE={isCLE} hasHandicap={hasHandicap} />
+        <ProfileDetails young={young} isCLE={isCLE} hasHandicap={hasHandicap} cohort={cohort} />
 
         {parentId === 1 && (
           <>
@@ -126,7 +125,7 @@ export default function Verification({ step, parentId }) {
   );
 }
 
-const ProfileDetails = ({ young, isCLE, hasHandicap }) => {
+const ProfileDetails = ({ young, isCLE, hasHandicap, cohort }) => {
   return (
     <>
       <hr className="mt-4" />
@@ -142,8 +141,10 @@ const ProfileDetails = ({ young, isCLE, hasHandicap }) => {
         <hr className="mt-4" />
         <div className="flex flex-col gap-1">
           <h1 className="mt-2 text-lg font-bold text-[#161616]">Séjour de cohésion :</h1>
-          {/* <div className="text-lg font-normal text-[#161616]">{capitalizeFirstLetter(getCohortPeriod(getCohort(young?.cohort)))}</div> */}
-          <div className="text-lg font-normal text-[#161616]">{young?.cohort}</div>
+          <div className="font-normal text-[#161616]">
+            Du {new Date(cohort.dateStart).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })} au{" "}
+            {new Date(cohort.dateEnd).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}.
+          </div>
         </div>
         <hr className="mt-4" />
         <div className="flex items-center justify-between">
@@ -222,7 +223,3 @@ const Details = ({ title, value }) => {
     </div>
   );
 };
-
-function capitalizeFirstLetter(string) {
-  if (string) return string.charAt(0).toUpperCase() + string.slice(1);
-}

--- a/app/src/scenes/representants-legaux/mobile/verification.jsx
+++ b/app/src/scenes/representants-legaux/mobile/verification.jsx
@@ -142,7 +142,8 @@ const ProfileDetails = ({ young, isCLE, hasHandicap }) => {
         <hr className="mt-4" />
         <div className="flex flex-col gap-1">
           <h1 className="mt-2 text-lg font-bold text-[#161616]">Séjour de cohésion :</h1>
-          <div className="text-lg font-normal text-[#161616]">{capitalizeFirstLetter(getCohortPeriod(getCohort(young?.cohort)))}</div>
+          {/* <div className="text-lg font-normal text-[#161616]">{capitalizeFirstLetter(getCohortPeriod(getCohort(young?.cohort)))}</div> */}
+          <div className="text-lg font-normal text-[#161616]">{young?.cohort}</div>
         </div>
         <hr className="mt-4" />
         <div className="flex items-center justify-between">

--- a/app/src/utils/cohorts.js
+++ b/app/src/utils/cohorts.js
@@ -3,6 +3,8 @@ import { YOUNG_STATUS, YOUNG_STATUS_PHASE1 } from "snu-lib";
 import api from "@/services/api";
 import { capture } from "../sentry";
 import dayjs from "dayjs";
+import { apiURL } from "@/config";
+
 let cohorts = null;
 let cohortsCachedAt = null;
 
@@ -94,3 +96,11 @@ export const canYoungResumePhase1 = (y) => {
     ![YOUNG_STATUS_PHASE1.DONE, YOUNG_STATUS_PHASE1.EXEMPTED, YOUNG_STATUS_PHASE1.NOT_DONE].includes(y.statusPhase1)
   );
 };
+
+export async function fetchCohort(cohortId) {
+  const res = await fetch(`${apiURL}/cohort/${cohortId}/public`);
+  if (!res.ok) {
+    throw new Error("Unable to fetch cohort");
+  }
+  return res.json();
+}


### PR DESCRIPTION
- API : ajout d’une route publique pour obtenir les données de la cohorte (pour être accessible aux RL)
- Parcours des RL : la cohorte et la classe sont désormais dans le contexte => on peut notamment accéder aux dates et les formater comme on veut. Remplacement des fonctions très buggy getCohort et getCohortPeriod par les données du contexte.
- Correction d'un bug de chargement infini pour les HTS sur l'étape de consentement du volontaire.