### PR TITLE
fix(admin,api): 3272 - Fix de bug a la création ou la modification des classes qui n'updatait pas le bon status, ce qui empechait les classes d'ouvrir

### DIFF
--- a/admin/src/scenes/classe/components/GeneralInfos.tsx
+++ b/admin/src/scenes/classe/components/GeneralInfos.tsx
@@ -121,7 +121,8 @@ export default function GeneralInfos({ classe, setClasse, edit, setEdit, errors,
                 closeMenuOnSelect={true}
                 value={classe?.cohort ? { value: classe?.cohort, label: classe?.cohort } : null}
                 onChange={(options) => {
-                  setClasse({ ...classe, cohort: options.value });
+                  const cohortId = cohorts?.find((c) => c.name === options.value)?._id;
+                  setClasse({ ...classe, cohortId });
                 }}
                 error={errors.cohort}
               />

--- a/admin/src/scenes/classe/create.tsx
+++ b/admin/src/scenes/classe/create.tsx
@@ -5,8 +5,8 @@ import { Link, useHistory } from "react-router-dom";
 import { toastr } from "react-redux-toastr";
 import validator from "validator";
 
-import { translate, canCreateClasse, ERRORS, FeatureFlagName, translateGrade, COHORT_TYPE, canUpdateCohort } from "snu-lib";
-import { ClasseDto, ReferentDto } from "snu-lib/src/dto";
+import { translate, canCreateClasse, ERRORS, FeatureFlagName, translateGrade, COHORT_TYPE, canUpdateCohort, ClasseType } from "snu-lib";
+import { ReferentDto } from "snu-lib/src/dto";
 import { ProfilePic } from "@snu/ds";
 import { Page, Header, Container, Button, Label, InputText, ModalConfirmation, Select, InputNumber } from "@snu/ds/admin";
 
@@ -37,7 +37,7 @@ export default function Create() {
   const user = useSelector((state: AuthState) => state.Auth.user);
   const cohorts = useSelector((state: CohortState) => state.Cohorts).filter((cohort) => cohort.type === COHORT_TYPE.CLE && canUpdateCohort(cohort, user));
 
-  const [classe, setClasse] = useState<Partial<ClasseDto & { referent?: Partial<ReferentDto> }>>({});
+  const [classe, setClasse] = useState<Partial<ClasseType & { referent?: Partial<ReferentDto> }>>({});
   const [errors, setErrors] = useState<FormError>({});
   const [referentClasse, setReferentClasse] = useState<Partial<ReferentDto>>({
     firstName: "",
@@ -63,7 +63,7 @@ export default function Create() {
       if (!ok) {
         return toastr.error("Oups, une erreur est survenue lors de la récupération de l'établissement", translate(code));
       }
-      setClasse({ ...classe, uniqueKey: response.uniqueKey + "-XXXXXX", etablissementId: response._id, etablissement: response });
+      setClasse({ ...classe, uniqueKey: response.uniqueKey + "-XXXXXX", etablissementId: response._id });
       loadReferents({
         etablissementId: response._id,
         coordinateurs: response.coordinateurs.map((referent) => ({ ...referent, value: referent._id, label: `${referent.firstName} ${referent.lastName}` })),
@@ -193,7 +193,8 @@ export default function Create() {
                   closeMenuOnSelect={true}
                   value={classe?.cohort ? { value: classe?.cohort, label: classe?.cohort } : null}
                   onChange={(options) => {
-                    setClasse({ ...classe, cohort: options.value });
+                    const cohortId = cohorts.find((c) => c.name === options.value)?._id;
+                    setClasse({ ...classe, cohortId });
                   }}
                   error={errors.cohort}
                 />

--- a/admin/src/scenes/utilisateur/edit/details.jsx
+++ b/admin/src/scenes/utilisateur/edit/details.jsx
@@ -340,8 +340,6 @@ export default function Details({ user, setUser, currentUser }) {
     ? MODE_EDITION
     : MODE_DEFAULT;
 
-  console.log(data);
-
   return (
     <>
       <ConfirmationModal

--- a/admin/src/scenes/utilisateur/edit/details.jsx
+++ b/admin/src/scenes/utilisateur/edit/details.jsx
@@ -340,6 +340,8 @@ export default function Details({ user, setUser, currentUser }) {
     ? MODE_EDITION
     : MODE_DEFAULT;
 
+  console.log(data);
+
   return (
     <>
       <ConfirmationModal

--- a/api/migrations/20240913104014-fix-status-classe.js
+++ b/api/migrations/20240913104014-fix-status-classe.js
@@ -1,0 +1,29 @@
+const { ClasseModel } = require("../src/models");
+
+module.exports = {
+  async up(db, client) {
+    const classeIds = [
+      "66e1ac89d2e47db1985c904b",
+      "668ea2c7c269e600463e42a8",
+      "668ea2c6c269e600463e429e",
+      "668ea382c269e600463e8aea",
+      "668ea312c269e600463e607f",
+      "66913ed90f15fe00460d0985",
+      "668ea2e7c269e600463e4f12",
+      "668ea2c6c269e600463e428b",
+      "668ea326c269e600463e67a1",
+      "668ea342c269e600463e738d",
+      "668ea2d9c269e600463e4a5f",
+      "66e1a7d1d2e47db1985b55f2",
+    ];
+
+    await ClasseModel.updateMany(
+      {
+        _id: { $in: classeIds },
+      },
+      {
+        $set: { status: "OPEN" },
+      },
+    );
+  },
+};

--- a/api/src/__tests__/cle/classe.test.ts
+++ b/api/src/__tests__/cle/classe.test.ts
@@ -934,7 +934,9 @@ describe("PUT /cle/classe/:id/referent", () => {
   it("should create a new referent if classe is not CREATED for super admin", async () => {
     const referent = await createReferentHelper(getNewReferentFixture({ email: "a@a.com", role: ROLES.REFERENT_CLASSE }));
     const classe = await createClasse(createFixtureClasse({ status: STATUS_CLASSE.CREATED, referentClasseIds: [referent?._id] }));
+    // @ts-ignore
     passport.user.role = ROLES.ADMIN;
+    // @ts-ignore
     passport.user.subrole = "god";
     const newReferentDetails = {
       firstName: "John",
@@ -951,6 +953,7 @@ describe("PUT /cle/classe/:id/referent", () => {
     expect(updatedReferent.email).toBe(newReferentDetails.email);
     expect(updatedReferent.metadata.isFirstInvitationPending).toBe(true);
     expect(res.status).toBe(200);
+    // @ts-ignore
     passport.user.subrole = "";
   });
 
@@ -975,6 +978,7 @@ describe("PUT /cle/classe/:id/referent", () => {
   it("should return 403 if the user is not authorized to update the referent classe", async () => {
     const referent = await createReferentHelper(getNewReferentFixture({ email: "a@a.com", role: ROLES.REFERENT_CLASSE }));
     const classe = await createClasse(createFixtureClasse({ status: STATUS_CLASSE.CREATED, referentClasseIds: [referent?._id] }));
+    // @ts-ignore
     passport.user.role = ROLES.REFERENT_CLASSE; // Assuming this role is not authorized to update the referent classe
     const newReferentDetails = {
       firstName: "John",
@@ -985,6 +989,7 @@ describe("PUT /cle/classe/:id/referent", () => {
     expect(res.ok).toBe(false);
     expect(res.text).toContain(ERRORS.OPERATION_UNAUTHORIZED);
     expect(res.status).toBe(403);
+    // @ts-ignore
     passport.user.role = ROLES.ADMIN; // Resetting the role for other tests
   });
 });

--- a/api/src/__tests__/cle/classe.test.ts
+++ b/api/src/__tests__/cle/classe.test.ts
@@ -314,11 +314,12 @@ describe("PUT /cle/classe/:id", () => {
   it("should return 404 when user try to change cohort that doesn't exist", async () => {
     const classe = createFixtureClasse();
     const validId = (await createClasse(classe))._id;
+    const cohortId = new ObjectId().toString();
     const res = await request(getAppHelper())
       .put(`/cle/classe/${validId}`)
       .send({
         ...classe,
-        cohort: "New Cohort",
+        cohortId: cohortId,
       });
     expect(res.status).toBe(404);
   });
@@ -337,7 +338,7 @@ describe("PUT /cle/classe/:id", () => {
       .put(`/cle/classe/${validId}`)
       .send({
         ...classe,
-        cohort: cohort.name,
+        cohortId: cohort._id,
       });
     expect(res.status).toBe(403);
     // @ts-ignore
@@ -355,7 +356,7 @@ describe("PUT /cle/classe/:id", () => {
       .put(`/cle/classe/${validId}`)
       .send({
         ...classe,
-        cohort: cohort.name,
+        cohortId: cohort._id,
       });
 
     expect(res.status).toBe(403);
@@ -451,7 +452,7 @@ describe("PUT /cle/classe/:id", () => {
       .put(`/cle/classe/${validId}`)
       .send({
         ...classe,
-        cohort: cohort.name,
+        cohortId: cohort._id,
       });
 
     expect(res.status).toBe(403);
@@ -476,14 +477,14 @@ describe("PUT /cle/classe/:id", () => {
     const cohort = await createCohortHelper(getNewCohortFixture({ name: "CLE juin 2024" }));
     const classe = createFixtureClasse({});
     const validId = (await createClasse(classe))._id;
-    const young = getNewYoungFixture({ classeId: validId, cohort: "CLE mai 2024" });
+    const young = getNewYoungFixture({ classeId: validId, cohortId: cohort._id });
     await createYoungHelper(young);
 
     const res = await request(getAppHelper())
       .put(`/cle/classe/${validId}`)
       .send({
         ...classe,
-        cohort: cohort.name,
+        cohortId: cohort._id,
       });
     expect(res.status).toBe(200);
     expect(res.body.data.name).toBe(classe.name);
@@ -777,9 +778,10 @@ describe("POST /cle/classe", () => {
   it("should return 404 if the cohort is not found", async () => {
     jest.spyOn(featureService, "isFeatureAvailable").mockResolvedValueOnce(true);
     const etablissement = await createEtablissement(createFixtureEtablissement());
+    const cohortId = new ObjectId().toString();
     const response = await request(getAppHelper({ role: ROLES.ADMIN }))
       .post("/cle/classe")
-      .send({ ...validBody, cohort: "invalidCohort", etablissementId: etablissement._id.toString() });
+      .send({ ...validBody, cohortId: cohortId, etablissementId: etablissement._id.toString() });
 
     expect(response.status).toBe(404);
     expect(response.body.message).toBe("Cohort not found.");
@@ -790,7 +792,7 @@ describe("POST /cle/classe", () => {
     const cohort = await createCohortHelper(getNewCohortFixture());
     const response = await request(getAppHelper({ role: ROLES.ADMIN }))
       .post("/cle/classe")
-      .send({ ...validBody, cohort: cohort.name, etablissementId: etablissement._id.toString() });
+      .send({ ...validBody, cohortId: cohort._id, etablissementId: etablissement._id.toString() });
 
     expect(response.status).toBe(400);
   });
@@ -801,7 +803,7 @@ describe("POST /cle/classe", () => {
     const cohort = await createCohortHelper(getNewCohortFixture());
     const response = await request(getAppHelper({ role: ROLES.ADMIN }))
       .post("/cle/classe")
-      .send({ ...validBody, cohort: cohort.name, etablissementId: etablissement._id.toString() });
+      .send({ ...validBody, cohortId: cohort._id, etablissementId: etablissement._id.toString() });
 
     expect(response.status).toBe(200);
     const classe = await ClasseModel.findById(response.body.data._id).lean();

--- a/api/src/cle/classe/classeController.ts
+++ b/api/src/cle/classe/classeController.ts
@@ -78,7 +78,6 @@ import {
 } from "./export/classeExportService";
 import ClasseStateManager from "./stateManager";
 import { isCohortInscriptionOpen } from "../../cohort/cohortService";
-import { is } from "date-fns/locale";
 
 const router = express.Router();
 router.post(
@@ -249,7 +248,12 @@ router.post(
       if (!referent) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND, message: "Referent not found/created." });
       if (referent === ERRORS.USER_ALREADY_REGISTERED) return res.status(409).send({ ok: false, code: ERRORS.USER_ALREADY_REGISTERED });
 
-      const classeStatus = isCleClasseCohortEnabled ? (isInscriptionOpen ? STATUS_CLASSE.OPEN : STATUS_CLASSE.ASSIGNED) : STATUS_CLASSE.CREATED;
+      let classeStatus;
+      if (isCleClasseCohortEnabled) {
+        classeStatus = isInscriptionOpen ? STATUS_CLASSE.OPEN : STATUS_CLASSE.ASSIGNED;
+      } else {
+        classeStatus = STATUS_CLASSE.CREATED;
+      }
 
       const classe = await ClasseModel.create({
         ...payload,

--- a/api/src/cle/classe/classeController.ts
+++ b/api/src/cle/classe/classeController.ts
@@ -359,7 +359,7 @@ router.put(
           return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
         }
         if (oldCohortId !== payload.cohortId && !classe.ligneId) {
-          const cohort = await CohortModel.findById({ name: payload.cohortId });
+          const cohort = await CohortModel.findById({ _id: payload.cohortId });
           const classeStatus = isCohortInscriptionOpen(cohort as CohortType) ? STATUS_CLASSE.OPEN : STATUS_CLASSE.ASSIGNED;
 
           const youngs = await YoungModel.find({ classeId: classe._id });

--- a/api/src/cle/classe/classeValidator.ts
+++ b/api/src/cle/classe/classeValidator.ts
@@ -12,7 +12,7 @@ const CreateClasseRouteSchema = {
   payload: Joi.object<ClassesRoutes["Create"]["payload"]>({
     // Classe
     name: Joi.string().required(),
-    cohort: Joi.string().allow("").allow(null).optional(),
+    cohortId: Joi.string().allow("").allow(null).optional(),
     estimatedSeats: Joi.number().min(1).required(),
     coloration: Joi.string()
       .valid(...CLE_COLORATION_LIST)
@@ -38,7 +38,7 @@ const UpdateClasseRouteSchema = {
     name: Joi.string().required(),
     estimatedSeats: Joi.number().required(),
     totalSeats: Joi.number().required(),
-    cohort: Joi.string().optional(),
+    cohortId: Joi.string().optional(),
     coloration: Joi.string()
       .valid(...CLE_COLORATION_LIST)
       .required(),

--- a/api/src/cle/etablissement/etablissementController.ts
+++ b/api/src/cle/etablissement/etablissementController.ts
@@ -41,7 +41,7 @@ router.get("/from-user", passport.authenticate("referent", { session: false, fai
     let valueField: any = { $in: [req.user._id] };
     if (req.user.role === ROLES.REFERENT_CLASSE) {
       const classes: ClasseType[] = await ClasseModel.find({ referentClasseIds: { $in: req.user._id } });
-      if (!classes) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+      if (!classes || classes.length === 0) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
       const lastClasse = classes.find((classe) => classe.schoolYear === ClasseSchoolYear.YEAR_2024_2025) || classes[0];
       valueField = lastClasse.etablissementId;
     }

--- a/api/src/cle/etablissement/etablissementController.ts
+++ b/api/src/cle/etablissement/etablissementController.ts
@@ -14,6 +14,8 @@ import {
   isChefEtablissement,
   isReferentOrAdmin,
   SENDINBLUE_TEMPLATES,
+  ClasseType,
+  ClasseSchoolYear,
 } from "snu-lib";
 import { ReferentDto } from "snu-lib";
 import { capture } from "../../sentry";
@@ -38,9 +40,10 @@ router.get("/from-user", passport.authenticate("referent", { session: false, fai
     const query = {};
     let valueField: any = { $in: [req.user._id] };
     if (req.user.role === ROLES.REFERENT_CLASSE) {
-      const classe = await ClasseModel.findOne({ referentClasseIds: { $in: req.user._id } });
+      const classe: ClasseType[] = await ClasseModel.find({ referentClasseIds: { $in: req.user._id } });
       if (!classe) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
-      valueField = classe.etablissementId;
+      const lastClasse = classe.find((classe) => classe.schoolYear === ClasseSchoolYear.YEAR_2024_2025) || classe[0];
+      valueField = lastClasse.etablissementId;
     }
     query[searchField] = valueField;
     const etablissement = await EtablissementModel.findOne(query)?.lean();

--- a/api/src/cle/etablissement/etablissementController.ts
+++ b/api/src/cle/etablissement/etablissementController.ts
@@ -40,9 +40,9 @@ router.get("/from-user", passport.authenticate("referent", { session: false, fai
     const query = {};
     let valueField: any = { $in: [req.user._id] };
     if (req.user.role === ROLES.REFERENT_CLASSE) {
-      const classe: ClasseType[] = await ClasseModel.find({ referentClasseIds: { $in: req.user._id } });
-      if (!classe) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
-      const lastClasse = classe.find((classe) => classe.schoolYear === ClasseSchoolYear.YEAR_2024_2025) || classe[0];
+      const classes: ClasseType[] = await ClasseModel.find({ referentClasseIds: { $in: req.user._id } });
+      if (!classes) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
+      const lastClasse = classes.find((classe) => classe.schoolYear === ClasseSchoolYear.YEAR_2024_2025) || classes[0];
       valueField = lastClasse.etablissementId;
     }
     query[searchField] = valueField;

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -96,6 +96,7 @@ import {
   CLE_FILIERE,
   canValidateMultipleYoungsInClass,
   canValidateYoungInClass,
+  ClasseSchoolYear,
 } from "snu-lib";
 import { getFilteredSessions, getAllSessions } from "../utils/cohort";
 import scanFile from "../utils/virusScanner";
@@ -1270,7 +1271,8 @@ async function populateReferent(ref) {
     if (!classes) throw new Error(ERRORS.NOT_FOUND);
     ref.classe = classes;
 
-    const etablissement = await EtablissementModel.findById(classes[0].etablissementId).lean();
+    const lastClasse = classes.find((classe) => classe.schoolYear === ClasseSchoolYear.YEAR_2024_2025) || classes[0];
+    const etablissement = await EtablissementModel.findById(lastClasse.etablissementId).lean();
     if (!etablissement) throw new Error(ERRORS.NOT_FOUND);
     ref.etablissement = etablissement;
   }
@@ -1287,7 +1289,7 @@ router.get("/:id", passport.authenticate("referent", { session: false, failWithE
     let referent = await ReferentModel.findById(checkedId);
     if (!referent) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
     if (!canViewReferent(req.user, referent)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
-    referent = serializeReferent(referent, req.user);
+    referent = serializeReferent(referent);
 
     await populateReferent(referent);
 

--- a/packages/lib/src/routes/cle/classe/create.ts
+++ b/packages/lib/src/routes/cle/classe/create.ts
@@ -5,7 +5,7 @@ import { BasicRoute, RouteResponseBody } from "../..";
 export interface CreateClasseRoute extends BasicRoute {
   method: "POST";
   path: "/cle/classe";
-  payload: Pick<ClasseType, "name" | "cohort" | "estimatedSeats" | "coloration" | "filiere" | "grades" | "type" | "etablissementId"> & {
+  payload: Pick<ClasseType, "name" | "cohortId" | "estimatedSeats" | "coloration" | "filiere" | "grades" | "type" | "etablissementId"> & {
     referent: Pick<ReferentDto, "_id" | "firstName" | "lastName" | "email">;
   };
   response: RouteResponseBody<ClasseType>;

--- a/packages/lib/src/routes/cle/classe/update.ts
+++ b/packages/lib/src/routes/cle/classe/update.ts
@@ -11,7 +11,7 @@ export interface UpdateClasseRoute extends BasicRoute {
     ClasseType,
     | "name"
     | "totalSeats"
-    | "cohort"
+    | "cohortId"
     | "estimatedSeats"
     | "coloration"
     | "filiere"


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Bug-des-classes-v-rifi-es-sur-la-cohortes-CLE-novembre-alors-que-les-inscriptions-sont-ouvertes-fc03127eef5b49cfbc41faaa66b3b4f6?pvs=4

 - changement du type du payload pour les route post/classe et put/classe/id pour mettre la cohortId plutot que le nom de cohort
 - modif du controller post/classe pour mettre la classe dans le bon statut
 - modif du controller put/classe/id pour mettre la classe dans le bon statut lors d'un changement de cohorte
 - modif du controller get/etablissement/from-user pour prendre le dernier etablissement d'un référent de classe (cas d'un référent muté depuis l'année derniere et qui voit encore son ancien etablissement)
 - modif du controller get/referent/id pour la meme raison
