### PR TITLE
chore(api, lib): move session-phase1 schema to lib

### DIFF
--- a/api/src/__tests__/fixtures/sessionPhase1.ts
+++ b/api/src/__tests__/fixtures/sessionPhase1.ts
@@ -1,4 +1,4 @@
-import { SessionPhase1Type } from "../../models";
+import { SessionPhase1Type } from "snu-lib";
 
 function getNewSessionPhase1Fixture(object: Partial<SessionPhase1Type> = {}): Partial<SessionPhase1Type> {
   const placesLeft = 15;

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -18,7 +18,7 @@ export { ProgramModel, ProgramDocument, ProgramType } from "./program";
 export { ReferentModel, ReferentDocument } from "./referent";
 export { SchoolModel, SchoolDocument, SchoolType } from "./school";
 export { SchoolRAMSESModel, SchoolRAMSESDocument, SchoolRAMSESType } from "./schoolRAMSES";
-export { SessionPhase1Model, SessionPhase1Document, SessionPhase1Type } from "./sessionPhase1";
+export { SessionPhase1Model, SessionPhase1Document } from "./sessionPhase1";
 export { SessionPhase1TokenModel } from "./sessionPhase1Token";
 export { StructureModel, StructureDocument, StructureType } from "./structure";
 export { TagsModel, TagsDocument, TagsType } from "./tags";

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -27,6 +27,8 @@ import {
   EtablissementDocument,
   ClasseDocument,
   CohortModel,
+  SessionPhase1Document,
+  CohesionCenterDocument,
 } from "../models";
 
 import emailsEmitter from "../emails";
@@ -1511,12 +1513,11 @@ router.get("/:id/session-phase1", passport.authenticate("referent", { session: f
       return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     }
 
-    let sessions = await SessionPhase1Model.find({ headCenterId: checkedId });
+    let sessions: SessionPhase1Document<{ cohesionCenter?: CohesionCenterDocument }>[] = await SessionPhase1Model.find({ headCenterId: checkedId });
     const cohesionCenters = await CohesionCenterModel.find({ _id: { $in: sessions.map((s) => s.cohesionCenterId?.toString()) } });
     if (JoiQueryWithCohesionCenter.value === "true") {
       sessions = sessions.map((s) => {
-        // @ts-expect-error FIXME: populate cohesionCenter does not exist in SessionPhase1Type
-        s._doc.cohesionCenter = cohesionCenters.find((c) => c._id.toString() === s.cohesionCenterId?.toString());
+        s._doc!.cohesionCenter = cohesionCenters.find((c) => c._id.toString() === s.cohesionCenterId?.toString());
         return s;
       });
     }

--- a/api/src/templates/certificate/phase1.ts
+++ b/api/src/templates/certificate/phase1.ts
@@ -117,4 +117,4 @@ function generateBatchCertifPhase1(outStream, youngs, session, cohort, cohesionC
   timer.done({ message: "RENDERING", level: "debug" });
 }
 
-module.exports = { generateCertifPhase1, generateBatchCertifPhase1 };
+export { generateCertifPhase1, generateBatchCertifPhase1 };

--- a/api/src/templates/droitImage/droitImage.ts
+++ b/api/src/templates/droitImage/droitImage.ts
@@ -153,4 +153,4 @@ function generateBatchDroitImage(outStream, youngs) {
   timer.done({ message: "RENDERING", level: "debug" });
 }
 
-module.exports = { generateDroitImage, generateBatchDroitImage };
+export { generateDroitImage, generateBatchDroitImage };

--- a/packages/lib/src/dto/userDto.ts
+++ b/packages/lib/src/dto/userDto.ts
@@ -10,4 +10,5 @@ export type UserDto = {
   region: string;
   department: string[];
   subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES_LIST | keyof typeof VISITOR_SUB_ROLES_LIST | "god";
+  sessionPhase1Id?: string;
 };

--- a/packages/lib/src/mongoSchema/index.ts
+++ b/packages/lib/src/mongoSchema/index.ts
@@ -6,4 +6,5 @@ export * from "./cohesionCenter";
 export * from "./cohort";
 export * from "./pointDeRassemblement";
 export * from "./referent";
+export * from "./sessionPhase1";
 export * from "./young";

--- a/packages/lib/src/mongoSchema/sessionPhase1.ts
+++ b/packages/lib/src/mongoSchema/sessionPhase1.ts
@@ -1,0 +1,198 @@
+import { Schema, InferSchemaType } from "mongoose";
+import { InterfaceExtended } from "..";
+
+export const SessionPhase1FileSchema = {
+  _id: String,
+  name: String,
+  uploadedAt: Date,
+  size: Number,
+  mimetype: String,
+};
+
+export const SessionPhase1Schema = {
+  cohesionCenterId: {
+    type: String,
+    documentation: {
+      description: "Id du centre de cohésion",
+    },
+  },
+  cohort: {
+    type: String,
+    documentation: {
+      description: "Cohorte",
+    },
+  },
+  cohortId: {
+    type: String,
+    documentation: {
+      description: "Id de la cohorte",
+    },
+  },
+  department: {
+    type: String,
+    documentation: {
+      description: "Département du centre",
+    },
+  },
+  region: {
+    type: String,
+    documentation: {
+      description: "Région du centre",
+    },
+  },
+  codeCentre: {
+    type: String,
+    documentation: {
+      description: "Code du centre",
+    },
+  },
+  nameCentre: {
+    type: String,
+    documentation: {
+      description: "Nom du centre",
+    },
+  },
+  zipCentre: {
+    type: String,
+    documentation: {
+      description: "Zip du centre",
+    },
+  },
+  cityCentre: {
+    type: String,
+    documentation: {
+      description: "Ville du centre",
+    },
+  },
+  headCenterId: {
+    type: String,
+    documentation: {
+      description: "Id de l'utilisateur responsable, le chef de centre",
+    },
+  },
+  team: {
+    type: [
+      {
+        firstName: {
+          type: String,
+          description: "prénom du membre de l'équipe",
+        },
+        lastName: {
+          type: String,
+          description: "nom du membre de l'équipe",
+        },
+        role: {
+          type: String,
+          description: "role du membre de l'équipe",
+        },
+        email: {
+          type: String,
+          description: "email du membre de l'équipe",
+        },
+        phone: {
+          type: String,
+          description: "téléphone du membre de l'équipe",
+        },
+      },
+    ],
+    documentation: {
+      description: "equipe d'encadrement pour le séjour",
+    },
+  },
+  waitingList: {
+    type: [String],
+    documentation: {
+      description: "Liste  des jeunes en liste d'attente sur ce séjour de cohésion",
+    },
+  },
+
+  placesTotal: {
+    type: Number,
+    documentation: {
+      description: "Nombre de places au total",
+    },
+  },
+  placesLeft: {
+    type: Number,
+    documentation: {
+      description: "Nombre de places disponibles",
+    },
+  },
+
+  timeScheduleFiles: {
+    type: [SessionPhase1FileSchema],
+    documentation: {
+      description: "Fichiers d'emploi du temps",
+    },
+  },
+  hasTimeSchedule: {
+    type: String,
+    enum: ["true", "false"],
+    default: "false",
+    documentation: {
+      description: "La session possède au moins 1 fichier d'emploi du temps.",
+    },
+  },
+  pedagoProjectFiles: {
+    type: [SessionPhase1FileSchema],
+    documentation: {
+      description: "Fichiers du projet pédagogique",
+    },
+  },
+  hasPedagoProject: {
+    type: String,
+    enum: ["true", "false"],
+    default: "false",
+    documentation: {
+      description: "La session possède au moins 1 fichier de projet pédagogique.",
+    },
+  },
+
+  dateStart: {
+    type: Date,
+    documentation: {
+      description: "Date spécifique de début du séjour",
+    },
+  },
+  dateEnd: {
+    type: Date,
+    documentation: {
+      description: "Date spécifique de fin du séjour",
+    },
+  },
+
+  // TODO: remove this field
+  status: {
+    type: String,
+    default: "WAITING_VALIDATION",
+    enum: ["VALIDATED", "WAITING_VALIDATION"],
+    documentation: {
+      description: "Statut",
+    },
+  },
+
+  sanitaryContactEmail: {
+    type: String,
+    documentation: {
+      description: "email nécessaire pour envoyer la fiche sanitaire au centre de la sessions",
+    },
+  },
+
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+};
+
+// le schéma doit être défini ici pour l'inferage, mais dupliqué dans l'api pour une bonne interpretation du model
+const schema = new Schema({
+  ...SessionPhase1Schema,
+  timeScheduleFiles: {
+    ...SessionPhase1Schema.timeScheduleFiles,
+    type: [new Schema(SessionPhase1FileSchema)],
+  },
+  pedagoProjectFiles: {
+    ...SessionPhase1Schema.pedagoProjectFiles,
+    type: [new Schema(SessionPhase1FileSchema)],
+  },
+});
+
+export type SessionPhase1Type = InterfaceExtended<InferSchemaType<typeof schema>>;

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -2,7 +2,7 @@ import { ReferentDto, UserDto } from "./dto";
 import { region2department } from "./region-and-departments";
 import { isNowBetweenDates } from "./utils/date";
 import { LIMIT_DATE_ESTIMATED_SEATS, LIMIT_DATE_TOTAL_SEATS, STATUS_CLASSE } from "./constants/constants";
-import { ClasseType } from "./mongoSchema";
+import { ClasseType, SessionPhase1Type } from "./mongoSchema";
 
 const DURATION_BEFORE_EXPIRATION_2FA_MONCOMPTE_MS = 1000 * 60 * 15; // 15 minutes
 const DURATION_BEFORE_EXPIRATION_2FA_ADMIN_MS = 1000 * 60 * 10; // 10 minutes
@@ -348,7 +348,7 @@ function canCreateOrUpdateCohesionCenter(actor) {
 function canCreateEvent(actor) {
   return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT].includes(actor.role);
 }
-function canCreateOrUpdateSessionPhase1(actor, target) {
+function canCreateOrUpdateSessionPhase1(actor: UserDto, target?: SessionPhase1Type | null) {
   const isAdmin = actor.role === ROLES.ADMIN;
   const isReferent = [ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(actor.role);
   const isHeadCenter = actor.role === ROLES.HEAD_CENTER && target && actor._id.toString() === target.headCenterId;
@@ -542,7 +542,7 @@ function canSearchAssociation(actor) {
   return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT].includes(actor.role);
 }
 
-function canViewCohesionCenter(actor) {
+function canViewCohesionCenter(actor: UserDto) {
   return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT, ROLES.HEAD_CENTER, ROLES.TRANSPORTER, ROLES.REFERENT_CLASSE, ROLES.ADMINISTRATEUR_CLE].includes(
     actor.role,
   );

--- a/packages/lib/src/routes/cle/classe/getOne.ts
+++ b/packages/lib/src/routes/cle/classe/getOne.ts
@@ -1,5 +1,4 @@
-import { ClasseType, CohesionCenterType, CohortType, EtablissementType, ReferentType, PointDeRassemblementType } from "../../../mongoSchema";
-import { ClasseDto } from "../../../dto";
+import { ClasseType, CohesionCenterType, CohortType, EtablissementType, ReferentType, PointDeRassemblementType, SessionPhase1Type } from "../../../mongoSchema";
 import { BasicRoute, RouteResponseBody } from "../..";
 
 export interface GetOneClasseRoute extends BasicRoute {
@@ -14,7 +13,7 @@ export interface GetOneClasseRoute extends BasicRoute {
       etablissement?: Omit<EtablissementType, "referentEtablissementIds" | "coordinateurIds" | "createdAt" | "updatedAt">;
       referents?: Pick<ReferentType, "_id" | "firstName" | "lastName" | "role" | "email">[];
       cohesionCenter?: Pick<CohesionCenterType, "_id" | "name" | "address" | "zip" | "city" | "department" | "region">;
-      session?: Pick<ClasseDto["session"], "_id">;
+      session?: Pick<SessionPhase1Type, "_id">;
       pointDeRassemblement?: Pick<PointDeRassemblementType, "_id" | "name" | "address" | "zip" | "city" | "department" | "region">;
       cohortDetails?: Pick<CohortType, "_id" | "dateStart" | "dateEnd">;
     }


### PR DESCRIPTION
**Description**

Déplacement du schéma "SessionPhase#" dans la snu-lib, pour l'inferage automatique des types utilisable dans les routes.

⚠️ les sous objects ne sont plus des Schéma dans la snu-lib, seule l'object parent est un schéma. cela change la génération auto d'id pour les sous type

**TODO**

- [x] Déplacer le schéma
- [x] Vérifier le comportement des sous types ( timeScheduleFiles, pedagoProjectFiles)

**Ticket / Issue**

<!-- If you have a Notion Ticket / GitHub Issue -->
<!-- Fixes [Notion ticket #123](https://notion.so/abc) -->

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
