### PR TITLE
feat(api): 3240 - migrate - create CLE 2025 cohort and add verified classes

### DIFF
--- a/admin/src/scenes/classe/components/GeneralInfos.tsx
+++ b/admin/src/scenes/classe/components/GeneralInfos.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { HiOutlinePencil } from "react-icons/hi";
 
-import { translate, ROLES, translateGrade, formatDateFRTimezoneUTC, CohortDto, ClassesRoutes } from "snu-lib";
+import { translate, ROLES, translateGrade, formatDateFRTimezoneUTC, CohortDto, ClassesRoutes, shouldDisplayDateByCohortName } from "snu-lib";
 import { Container, Button, Label, InputText, Select } from "@snu/ds/admin";
 import { User } from "@/types";
 import { Rights } from "./types";
@@ -136,17 +136,19 @@ export default function GeneralInfos({ classe, setClasse, edit, setEdit, errors,
                 }}
                 error={errors.cohort}
               />
-              <div className="flex flex-col gap-2 rounded-lg bg-gray-100 px-3 py-2 mb-3">
-                <p className="text-left text-sm  text-gray-800">Dates</p>
-                <div className="flex items-center">
-                  <p className="text-left text-xs text-gray-500 flex-1">
-                    Début : <strong>{formatDateFRTimezoneUTC(classe.cohortDetails?.dateStart)}</strong>
-                  </p>
-                  <p className="text-left text-xs text-gray-500 flex-1">
-                    Fin : <strong>{formatDateFRTimezoneUTC(classe.cohortDetails?.dateEnd)}</strong>
-                  </p>
+              {shouldDisplayDateByCohortName(cohorts?.find((c) => c.name === classe?.cohort)?.name || "") ? (
+                <div className="flex flex-col gap-2 rounded-lg bg-gray-100 px-3 py-2 mb-3">
+                  <p className="text-left text-sm  text-gray-800">Dates</p>
+                  <div className="flex items-center">
+                    <p className="text-left text-xs text-gray-500 flex-1">
+                      Début : <strong>{formatDateFRTimezoneUTC(classe.cohortDetails?.dateStart)}</strong>
+                    </p>
+                    <p className="text-left text-xs text-gray-500 flex-1">
+                      Fin : <strong>{formatDateFRTimezoneUTC(classe.cohortDetails?.dateEnd)}</strong>
+                    </p>
+                  </div>
                 </div>
-              </div>
+              ) : null}
             </>
           )}
           <Label title="Type de groupe" name="type" />

--- a/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
+++ b/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
@@ -1,0 +1,55 @@
+const { STATUS_CLASSE } = require("snu-lib");
+const { CohortModel, ClasseModel } = require("../src/models");
+const { logger } = require("../src/logger");
+
+const cohortName = "CLE 2025";
+
+module.exports = {
+  async up() {
+    try {
+      const classesVerifiedAndNoCohort = await ClasseModel.find({ $or: [{ cohortId: { $exists: false } }, { cohortId: null }], status: STATUS_CLASSE.VERIFIED });
+      const cohort = new CohortModel({
+        snuId: cohortName,
+        name: cohortName,
+        eligibility: {
+          zones: ["A", "B", "C"],
+          schoolLevels: ["4eme", "3eme", "2ndePro", "2ndeGT", "1erePro", "1ereGT", "TermPro", "TermGT", "CAP", "1ereCAP", "2ndeCAP", "Autre", "NOT_SCOLARISE"],
+          bornAfter: new Date("2010-01-01"),
+          bornBefore: new Date("2007-12-31"),
+        },
+        inscriptionStartDate: new Date("2024-09-18"),
+        inscriptionEndDate: new Date("2024-11-30"),
+        instructionEndDate: new Date("2024-11-30"),
+        buffer: 1,
+        event: "Event Name",
+      });
+
+      const cohortCle2025Saved = await cohort.save();
+      logger.info(`Cohorte ${cohortName} is created with success (id: ${cohortCle2025Saved._id})`);
+
+      const updateResult = await ClasseModel.updateMany({ _id: { $in: classesVerifiedAndNoCohort.map((classe) => classe._id) } }, { $set: { cohortId: cohortCle2025Saved._id } });
+      logger.info(`${updateResult.modifiedCount} classes added to cohort ${cohortName}`);
+    } catch (error) {
+      logger.error(`Error while migration up: ${error.message}`);
+      throw error;
+    }
+  },
+
+  async down() {
+    try {
+      const cohortCle2025ToDelete = await CohortModel.findOne({ name: cohortName });
+
+      if (cohortCle2025ToDelete === null) {
+        logger.info(`Cohorte ${cohortName} not found`);
+        return;
+      }
+
+      const updateResult = await ClasseModel.updateMany({ cohortId: cohortCle2025ToDelete._id }, { $set: { cohortId: null } });
+      logger.info(`${updateResult.modifiedCount} Classes removed from cohort ${cohortName}`);
+      await CohortModel.deleteOne({ name: cohortName });
+      logger.info(`Cohorte ${cohortName} is deleted with success`);
+    } catch (error) {
+      logger.error(`Error while migration down: ${error.message}`);
+    }
+  },
+};

--- a/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
+++ b/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
@@ -1,8 +1,8 @@
-const { STATUS_CLASSE, COHORT_TYPE } = require("snu-lib");
+const { STATUS_CLASSE, COHORT_TYPE, COHORTS } = require("snu-lib");
 const { CohortModel, ClasseModel } = require("../src/models");
 const { logger } = require("../src/logger");
 
-const cohortName = "2025 CLE Globale";
+const cohortName = COHORTS.CLEGLOBALE2025;
 
 module.exports = {
   async up() {

--- a/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
+++ b/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
@@ -23,6 +23,7 @@ module.exports = {
         inscriptionStartDate: new Date("2024-09-18"),
         inscriptionEndDate: new Date("2024-11-30"),
         instructionEndDate: new Date("2024-11-30"),
+        inscriptionModificationEndDate: new Date("2024-11-30"),
         buffer: 1,
         event: "Event Name",
       });

--- a/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
+++ b/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
@@ -1,8 +1,8 @@
-const { STATUS_CLASSE } = require("snu-lib");
+const { STATUS_CLASSE, COHORT_TYPE } = require("snu-lib");
 const { CohortModel, ClasseModel } = require("../src/models");
 const { logger } = require("../src/logger");
 
-const cohortName = "CLE 2025";
+const cohortName = "2025 CLE Globale";
 
 module.exports = {
   async up() {
@@ -13,6 +13,7 @@ module.exports = {
         name: cohortName,
         dateStart: new Date("2024-01-01"),
         dateEnd: new Date("2024-12-31"),
+        type: COHORT_TYPE.CLE,
         eligibility: {
           zones: ["A", "B", "C"],
           schoolLevels: ["4eme", "3eme", "2ndePro", "2ndeGT", "1erePro", "1ereGT", "TermPro", "TermGT", "CAP", "1ereCAP", "2ndeCAP", "Autre", "NOT_SCOLARISE"],
@@ -29,7 +30,10 @@ module.exports = {
       const cohortCle2025Saved = await cohort.save();
       logger.info(`Cohorte ${cohortName} is created with success (id: ${cohortCle2025Saved._id})`);
 
-      const updateResult = await ClasseModel.updateMany({ _id: { $in: classesVerifiedAndNoCohort.map((classe) => classe._id) } }, { $set: { cohortId: cohortCle2025Saved._id } });
+      const updateResult = await ClasseModel.updateMany(
+        { _id: { $in: classesVerifiedAndNoCohort.map((classe) => classe._id) } },
+        { $set: { cohortId: cohortCle2025Saved._id, cohort: cohortCle2025Saved.name } },
+      );
       logger.info(`${updateResult.modifiedCount} classes added to cohort ${cohortName}`);
     } catch (error) {
       logger.error(`Error while migration up: ${error.message}`);
@@ -46,7 +50,7 @@ module.exports = {
         return;
       }
 
-      const updateResult = await ClasseModel.updateMany({ cohortId: cohortCle2025ToDelete._id }, { $set: { cohortId: null } });
+      const updateResult = await ClasseModel.updateMany({ cohortId: cohortCle2025ToDelete._id }, { $set: { cohortId: null, cohort: null } });
       logger.info(`${updateResult.modifiedCount} Classes removed from cohort ${cohortName}`);
       await CohortModel.deleteOne({ name: cohortName });
       logger.info(`Cohorte ${cohortName} is deleted with success`);

--- a/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
+++ b/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
@@ -11,8 +11,8 @@ module.exports = {
       const cohort = new CohortModel({
         snuId: cohortName,
         name: cohortName,
-        dateStart: new Date("2024-01-01"),
-        dateEnd: new Date("2024-12-31"),
+        dateStart: new Date("2025-01-01"),
+        dateEnd: new Date("2024-06-30"),
         type: COHORT_TYPE.CLE,
         eligibility: {
           zones: ["A", "B", "C"],

--- a/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
+++ b/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
@@ -11,6 +11,8 @@ module.exports = {
       const cohort = new CohortModel({
         snuId: cohortName,
         name: cohortName,
+        dateStart: new Date("2024-01-01"),
+        dateEnd: new Date("2024-12-31"),
         eligibility: {
           zones: ["A", "B", "C"],
           schoolLevels: ["4eme", "3eme", "2ndePro", "2ndeGT", "1erePro", "1ereGT", "TermPro", "TermGT", "CAP", "1ereCAP", "2ndeCAP", "Autre", "NOT_SCOLARISE"],

--- a/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
+++ b/api/migrations/20240913131927-create-cohorte-cle-2025-globale.js
@@ -32,7 +32,7 @@ module.exports = {
 
       const updateResult = await ClasseModel.updateMany(
         { _id: { $in: classesVerifiedAndNoCohort.map((classe) => classe._id) } },
-        { $set: { cohortId: cohortCle2025Saved._id, cohort: cohortCle2025Saved.name } },
+        { $set: { cohortId: cohortCle2025Saved._id, cohort: cohortCle2025Saved.name, status: STATUS_CLASSE.ASSIGNED } },
       );
       logger.info(`${updateResult.modifiedCount} classes added to cohort ${cohortName}`);
     } catch (error) {

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -527,7 +527,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
     let { __v, ...newYoung } = value;
 
     // Vérification des objectifs à la validation d'un jeune
-    if (value.status === "VALIDATED" && young.status !== "VALIDATED" && (!canUpdateInscriptionGoals(req.user) || !req.query.forceGoal)) {
+    if (young.source !== YOUNG_SOURCE.CLE && value.status === "VALIDATED" && young.status !== "VALIDATED" && (!canUpdateInscriptionGoals(req.user) || !req.query.forceGoal)) {
       const fillingRate = await getFillingRate(young.department, young.cohort);
       if (fillingRate >= FILLING_RATE_LIMIT) {
         return res.status(400).send({ ok: false, code: FUNCTIONAL_ERRORS.INSCRIPTION_GOAL_REACHED, fillingRate });

--- a/app/src/scenes/representants-legaux/mobile/presentation.jsx
+++ b/app/src/scenes/representants-legaux/mobile/presentation.jsx
@@ -9,6 +9,7 @@ import Navbar from "../components/Navbar";
 import DSFRContainer from "@/components/dsfr/layout/DSFRContainer";
 import plausibleEvent from "@/services/plausible";
 import { SignupButtons } from "@snu/ds/dsfr";
+import { shouldDisplayDateByCohortName } from "snu-lib";
 
 export default function Presentation({ step, parentId }) {
   const history = useHistory();
@@ -92,8 +93,14 @@ export default function Presentation({ step, parentId }) {
               <p className="font-400 mt-3 text-center text-[15px] leading-[19px]">
                 {young.firstName} a choisi le séjour <br />
                 <strong>
-                  du {new Date(cohort.dateStart).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })} au{" "}
-                  {new Date(cohort.dateEnd).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}.
+                  {shouldDisplayDateByCohortName(cohort.name) ? (
+                    <>
+                      du {new Date(cohort.dateStart).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })} au{" "}
+                      {new Date(cohort.dateEnd).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}.
+                    </>
+                  ) : (
+                    "à venir"
+                  )}
                 </strong>
               </p>
             </div>

--- a/app/src/scenes/representants-legaux/mobile/verification.jsx
+++ b/app/src/scenes/representants-legaux/mobile/verification.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 import { RepresentantsLegauxContext } from "../../../context/RepresentantsLegauxContextProvider";
 import "dayjs/locale/fr";
-import { getDepartmentByZip, translate, translateGrade, YOUNG_SOURCE } from "snu-lib";
+import { getDepartmentByZip, translate, translateGrade, YOUNG_SOURCE, shouldDisplayDateByCohortName } from "snu-lib";
 import api from "../../../services/api";
 import { API_VERIFICATION, isReturningParent } from "../commons";
 import { concatPhoneNumberWithZone } from "snu-lib";
@@ -142,8 +142,14 @@ const ProfileDetails = ({ young, isCLE, hasHandicap, cohort }) => {
         <div className="flex flex-col gap-1">
           <h1 className="mt-2 text-lg font-bold text-[#161616]">Séjour de cohésion :</h1>
           <div className="font-normal text-[#161616]">
-            Du {new Date(cohort.dateStart).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })} au{" "}
-            {new Date(cohort.dateEnd).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}.
+            {shouldDisplayDateByCohortName(cohort.name) ? (
+              <>
+                Du {new Date(cohort.dateStart).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })} au{" "}
+                {new Date(cohort.dateEnd).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}.
+              </>
+            ) : (
+              "à venir"
+            )}
           </div>
         </div>
         <hr className="mt-4" />

--- a/packages/lib/src/constants/cohort.ts
+++ b/packages/lib/src/constants/cohort.ts
@@ -1,3 +1,4 @@
 export enum COHORTS {
   AVENIR = "à venir",
+  CLEGLOBALE2025 = "2025 CLE Globale",
 }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -28,5 +28,6 @@ export * from "./transport-info";
 export * from "./utils/date";
 export * from "./utils/file";
 export * from "./utils/request";
+export * from "./utils/cohortUtils";
 export * from "./young";
 export * from "./mongoSchema";

--- a/packages/lib/src/sessions.ts
+++ b/packages/lib/src/sessions.ts
@@ -5,6 +5,7 @@ import { getZonedDate } from "./utils/date";
 import { EtablissementDto } from "./dto";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
+import { shouldDisplayDateByCohortName } from "./utils/cohortUtils";
 
 const COHORTS_WITH_JDM_COUNT = ["2019", "2020", "2021", "2022", "Février 2022", "Juin 2022", "Juillet 2022", "Février 2023 - C", "Avril 2023 - B", "Avril 2023 - A", "Juin 2023"];
 
@@ -25,7 +26,10 @@ const getCohortYear = (cohort) => cohort?.dateStart?.slice(0, 4);
 
 const getCohortPeriod = (cohort, withBold = false) => {
   if (!cohort.dateStart || !cohort.dateEnd) return cohort.name || cohort;
-  if (cohort.name === "à venir") return "à venir";
+
+  if(!shouldDisplayDateByCohortName(cohort.name)) {
+    return "à venir";
+  }
 
   // Fonction pour formater les dates avec la localisation française
   const formatDate = (dateString, dateFormat) => {
@@ -43,11 +47,11 @@ const getCohortPeriod = (cohort, withBold = false) => {
   // Si même mois et même année
   if (startMonthYear === endMonthYear) {
     formattedPeriod = `du ${formatDate(cohort.dateStart, "d")} au ${formatDate(cohort.dateEnd, "d MMMM yyyy")}`;
-  } 
+  }
   // Si même année mais mois différents
   else if (startYear === endYear) {
     formattedPeriod = `du ${formatDate(cohort.dateStart, "d MMMM")} au ${formatDate(cohort.dateEnd, "d MMMM yyyy")}`;
-  } 
+  }
   // Si mois et années différents
   else {
     formattedPeriod = `du ${formatDate(cohort.dateStart, "d MMMM yyyy")} au ${formatDate(cohort.dateEnd, "d MMMM yyyy")}`;

--- a/packages/lib/src/utils/cohortUtils.ts
+++ b/packages/lib/src/utils/cohortUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * List of cohorts for which the date should not be displayed.
+ * Any cohort name that appears in this array will be excluded from date display.
+ */
+const excludedCohortsForDateDisplay: string[] = ["à venir", "CLE 2025"];
+
+/**
+ * Determines whether the date should be displayed based on the cohort name.
+ * If the cohort name is included in the `excludedCohortsForDateDisplay` list,
+ * the function will return `false`, meaning the date should not be displayed.
+ *
+ * @param {string} cohortName - The name of the cohort for which to check the display rule.
+ * @returns {boolean} - Returns `true` if the date should be displayed, otherwise `false`.
+ */
+const shouldDisplayDateByCohortName = (cohortName: string): boolean => {
+  return !excludedCohortsForDateDisplay.includes(cohortName);
+};
+
+export { excludedCohortsForDateDisplay, shouldDisplayDateByCohortName };

--- a/packages/lib/src/utils/cohortUtils.ts
+++ b/packages/lib/src/utils/cohortUtils.ts
@@ -1,8 +1,10 @@
+import { COHORTS } from "src/constants/cohort";
+
 /**
  * List of cohorts for which the date should not be displayed.
  * Any cohort name that appears in this array will be excluded from date display.
  */
-const excludedCohortsForDateDisplay: string[] = ["à venir", "2025 CLE Globale"];
+const excludedCohortsForDateDisplay: string[] = [COHORTS.AVENIR, COHORTS.CLEGLOBALE2025];
 
 /**
  * Determines whether the date should be displayed based on the cohort name.

--- a/packages/lib/src/utils/cohortUtils.ts
+++ b/packages/lib/src/utils/cohortUtils.ts
@@ -2,7 +2,7 @@
  * List of cohorts for which the date should not be displayed.
  * Any cohort name that appears in this array will be excluded from date display.
  */
-const excludedCohortsForDateDisplay: string[] = ["à venir", "CLE 2025"];
+const excludedCohortsForDateDisplay: string[] = ["à venir", "2025 CLE Globale"];
 
 /**
  * Determines whether the date should be displayed based on the cohort name.

--- a/packages/lib/src/utils/cohortUtils.ts
+++ b/packages/lib/src/utils/cohortUtils.ts
@@ -1,4 +1,4 @@
-import { COHORTS } from "src/constants/cohort";
+import { COHORTS } from "../constants/cohort";
 
 /**
  * List of cohorts for which the date should not be displayed.


### PR DESCRIPTION
Script migration - create CLE 2025 cohort and add verified classes without cohort.

**Description**

1. Créer une cohorte globale “2025 CLE”
    1. inscription start date : 18/09
    2. inscription end date : 30/11
    3. instruction end date : 30/11
2. Ne pas afficher de date, de la même façon que pour la cohorte “à venir”
3. Affecter les classes au statut “vérifiée” et sans cohorte à la cohorte “CLE 2025”

**Todo**

- [x] Créer une cohorte globale “2025 CLE” les dates spécifiées dans la description
- [x] Récupérer les classes sans cohorte dont le statut est vérifié
- [x] Ajouter les loggers + "gestion des erreurs"
- [x] Faire le script down
- [x] Ajouter les conditions dans le FO (admin + moncompte) de la même manière que la cohorte "à venir"

**Ticket / Issue**

[Notion ticket #3240](https://www.notion.so/jeveuxaider/Ajouter-une-cohorte-CLE-2025-globale-f7d99ab7da9d4232914fcc063e0a036b)
