### PR TITLE
fix(app, api): 3291 - Modifier le numéro de téléphone sur le profil du jeune

### DIFF
--- a/api/src/controllers/young/account.js
+++ b/api/src/controllers/young/account.js
@@ -20,7 +20,7 @@ router.put("/profile", passport.authenticate("young", { session: false, failWith
       gender: Joi.string().valid("male", "female").required(),
       phone: Joi.string().required(),
       phoneZone: Joi.string().required(),
-      psc1Info: Joi.string().valid("true", "false"),
+      psc1Info: Joi.string().valid("true", "false").allow(null),
     }).validate(req.body, { stripUnknown: true });
 
     if (error) return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });

--- a/app/src/scenes/account/scenes/general/index.jsx
+++ b/app/src/scenes/account/scenes/general/index.jsx
@@ -31,7 +31,7 @@ const getInitialFormValues = (young) => ({
     phoneNumber: young.phone || "",
     phoneZone: young.phoneZone || "",
   },
-  psc1Info: young.psc1Info || "",
+  psc1Info: young.psc1Info || null,
 });
 
 const AccountGeneralPage = () => {


### PR DESCRIPTION
Ticket notion : https://www.notion.so/jeveuxaider/BUG-Mon-Compte-les-jeunes-ne-peuvent-pas-modifier-leur-num-ro-de-t-l-phone-depuis-leur-compte-b7f1d51341674b6f835b5fa74ad9599d