### PR TITLE
fix(app, admin): Filtrer les fichiers modifiés avant de provoquer un rechargement des apps

### DIFF
--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -14,7 +14,9 @@ export const VitePluginWatchPackages = async (config) => {
       });
     },
     async handleHotUpdate({ file, server }) {
-      server.ws.send({ type: "full-reload" });
+      if (externalFiles.includes(file)) {
+        server.ws.send({ type: "full-reload" });
+      }
     },
   };
 };

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -14,7 +14,9 @@ export const VitePluginWatchPackages = async (config) => {
       });
     },
     async handleHotUpdate({ file, server }) {
-      server.ws.send({ type: "full-reload" });
+      if (externalFiles.includes(file)) {
+        server.ws.send({ type: "full-reload" });
+      }
     },
   };
 };
@@ -49,7 +51,7 @@ export default defineConfig(({ mode }) => {
     );
   } else {
     // autp-reload when changes detected in snu-lib
-    plugins.push(VitePluginWatchPackages());
+    // plugins.push(VitePluginWatchPackages());
   }
   return {
     server: {
@@ -77,7 +79,7 @@ export default defineConfig(({ mode }) => {
     },
     optimizeDeps: {
       include: ["snu-lib", "@snu/ds"],
-      force: true,
+      // force: true,
     },
     resolve: {
       alias: [{ find: "@", replacement: path.resolve(__dirname, "src") }],

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -51,7 +51,7 @@ export default defineConfig(({ mode }) => {
     );
   } else {
     // autp-reload when changes detected in snu-lib
-    // plugins.push(VitePluginWatchPackages());
+    plugins.push(VitePluginWatchPackages());
   }
   return {
     server: {
@@ -79,7 +79,7 @@ export default defineConfig(({ mode }) => {
     },
     optimizeDeps: {
       include: ["snu-lib", "@snu/ds"],
-      // force: true,
+      force: true,
     },
     resolve: {
       alias: [{ find: "@", replacement: path.resolve(__dirname, "src") }],


### PR DESCRIPTION
**Description**

Problème : tous les changements de fichiers provoquent un rechargement complet de l'app, et pas seulement les changements dans le package lib.

Cause : la fonction handleHotUpdate réagit par défaut à l'édition de tous les fichiers du projet, pas seulement les fichiers externes ajoutés à la watchlist (merci chat gpt).

Solution : vérifier si les fichiers modifiés font partie de la lib avant de déclencher le rechargement.

**Todo**

- [x] app
- [x] admin

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Testing instructions**

En local, observer si il y a reload dans les cas suivants :
- [ ] Editer un fichier dans l'app => non
- [ ] Editer un ficher dans admin => non
- [ ] Editer un fichier dans la lib => oui (si projet lancé avec turbo ou npm run dev dans lib)
