### PR TITLE
fix(api): 3322 - les refs de classe et admin_cle ne pouvaient plus valider un jeune dans une classe depuis l'onglet "volontaire"

### DIFF
--- a/admin/src/scenes/phase0/view.tsx
+++ b/admin/src/scenes/phase0/view.tsx
@@ -200,7 +200,11 @@ export default function VolontairePhase0View({ young, onChange, globalMode }) {
         }
       }
 
-      await api.put(`/referent/young/${young._id}`, body);
+      const { ok, code } = await api.put(`/referent/young/${young._id}`, body);
+      if (!ok) {
+        toastr.error("Oups, une erreur est survenue", translate(code));
+        return;
+      }
 
       //Notify young
       // TODO: move notification logic to referent controller
@@ -223,8 +227,9 @@ export default function VolontairePhase0View({ young, onChange, globalMode }) {
     } catch (err) {
       console.error(err);
       toastr.error("Erreur !", translate(err.code));
+    } finally {
+      setProcessing(false);
     }
-    setProcessing(false);
   }
 
   return (

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -1035,7 +1035,7 @@ function canValidateMultipleYoungsInClass(actor: UserDto, classe: ClasseType) {
 }
 function canValidateYoungInClass(actor: UserDto, classe: ClasseType) {
   if (isAdmin(actor)) return true;
-  return [ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(actor.role) && classe.status === STATUS_CLASSE.OPEN;
+  return [ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION, ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_CLASSE].includes(actor.role) && classe.status === STATUS_CLASSE.OPEN;
 }
 
 export {


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/BUG-CLE-Les-r-f-rents-de-classe-ne-peuvent-pas-valider-les-dossiers-de-leurs-l-ves-10672a322d508087a77dd75f473faa57?pvs=4
