### PR TITLE
fix(github): Update branch name in mirroring.yml

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -2,7 +2,7 @@ name: Mirroring
 
 on:
   push:
-    branches: [main]
+    branches: [production_state]
 
 jobs:
   mirror:


### PR DESCRIPTION
This pull request fixes an issue with the branch name in the mirroring.yml file. The branch name has been updated from "main" to "production_state".