### PR TITLE
fix(api): Ajouter l'authentification pour la création de documents

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -2,7 +2,7 @@ name: Mirroring
 
 on:
   push:
-    branches: [production_state]
+    branches: [main]
 
 jobs:
   mirror:

--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -2,7 +2,7 @@ name: Mirroring
 
 on:
   push:
-    branches: [main]
+    branches: [production_state]
 
 jobs:
   mirror:

--- a/api/src/controllers/young/documents.js
+++ b/api/src/controllers/young/documents.js
@@ -17,7 +17,7 @@ const { generatePdfIntoStream } = require("../../utils/pdf-renderer");
 const { getMimeFromFile } = require("../../utils/file");
 const { sendDocumentEmailTask } = require("../../queues/sendMailQueue");
 
-router.post("/:type/:template", async (req, res) => {
+router.post("/:type/:template", passport.authenticate(["young", "referent"], { session: false, failWithError: true }), async (req, res) => {
   try {
     const { error, value } = Joi.object({ id: Joi.string().required(), type: Joi.string().required(), template: Joi.string().required() })
       .unknown()


### PR DESCRIPTION
This pull request includes a fix for the authentication process when creating documents. Previously, the authentication was missing, but now it has been added to the route. This ensures that only authenticated users (young and referent) can create documents.