### PR TITLE
feat(app,admin): 3402 - les jeunes CLE statut "en cours" peuvent continuer de modifier leur profil apres inscriptionEndDate et avant inscriptionModificationEndDate

### DIFF
--- a/admin/src/scenes/settings/index.jsx
+++ b/admin/src/scenes/settings/index.jsx
@@ -355,10 +355,10 @@ export default function Settings() {
                         tooltipRadius="6">
                         <ul className=" text-left text-gray-600 text-xs w-[275px] !px-2 !py-1.5 list-outside">
                           <li>
-                            Fermeture de la possibilité de modifier ou corriger son dossier d’inscription (pour les dossiers “en attente de validation” et “en attente de
-                            correction”).
+                            Fermeture de la possibilité de modifier ou corriger son dossier d’inscription (pour les dossiers {data.type === COHORT_TYPE.CLE && "“en cours”"}, “en
+                            attente de validation” et “en attente de correction”).
                           </li>
-                          <li>Le bouton d’accès au dossier est masqué sur le compte volontaire et l’URL d’accès au formulaire bloquée.</li>
+                          {data.type !== COHORT_TYPE.CLE && <li>Le bouton d’accès au dossier est masqué sur le compte volontaire et l’URL d’accès au formulaire bloquée.</li>}
                         </ul>
                       </ReactTooltip>
                     </div>

--- a/app/src/scenes/inscription2023/index.jsx
+++ b/app/src/scenes/inscription2023/index.jsx
@@ -130,7 +130,7 @@ export default function Index() {
     return <Redirect to={{ pathname: "/" }} />;
   }
 
-  if (!inscriptionCreationOpenForYoungs(cohort) && [YOUNG_STATUS.IN_PROGRESS].includes(young.status)) {
+  if (!inscriptionCreationOpenForYoungs(cohort) && !isCLE && [YOUNG_STATUS.IN_PROGRESS].includes(young.status)) {
     return <InscriptionClosed young={young} isCLE={isCLE} />;
   }
 


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/CLE-Quand-les-inscriptions-sont-ferm-es-permettre-aux-jeunes-dont-le-statut-d-inscription-est-en-10d72a322d5080eca82cd12b0aa7320c