### PR TITLE
fix(api): 3424 - les sessions de certains centres ne s’affichent pas

### DIFF
--- a/api/migrations/20241001090255-denormalize-cohort-in-session.js
+++ b/api/migrations/20241001090255-denormalize-cohort-in-session.js
@@ -1,0 +1,22 @@
+const { SessionPhase1Model, CohortModel } = require("../src/models");
+const { logger } = require("../src/logger");
+
+module.exports = {
+  async up() {
+    const sessionPhase1WithoutCohortName = await SessionPhase1Model.find({
+      cohort: { $exists: false },
+    });
+
+    for (const session of sessionPhase1WithoutCohortName) {
+      const cohort = await CohortModel.findById(session.cohortId);
+      if (cohort) {
+        session.set({ cohort: cohort.name });
+        logger.info(`Updated session ${session._id} with cohort name ${cohort.name}`);
+        await session.save({ fromUser: { firstName: "DENORMALIZE_COHORT_NAME_IN_SESSION" } });
+      }
+    }
+    logger.info(`Updated sessionIds: ${sessionPhase1WithoutCohortName?.map((session) => session?._id)}`);
+  },
+
+  async down() {},
+};

--- a/api/src/sessionPhase1/import/sessionPhase1ImportService.ts
+++ b/api/src/sessionPhase1/import/sessionPhase1ImportService.ts
@@ -93,6 +93,7 @@ const createSession = async (
   const sessionPhase1: Partial<SessionPhase1Type> = {
     cohesionCenterId: foundCenter._id,
     cohortId: foundCohort._id,
+    cohort: foundCohort.name,
     placesTotal: sessionCenter.sessionPlaces,
     department: foundCenter.department,
     region: foundCenter.region,


### PR DESCRIPTION
les sessions de certains centres ne s’affichent pas.

Les sessions n'ont pas le nom de la cohorte, correctif : 
- [x] Ajout des noms de cohortes dans les sessions via Migration
- [x] Modification de l'import pour ajouter le nom

https://www.notion.so/jeveuxaider/BUG-les-sessions-de-certains-centres-ne-s-affichent-pas-11272a322d50805aa56ee79517d4e364?pvs=4