### PR TITLE
fix(api): 3434 - script de rattrapage des jeunes CLE avec une cohort différente de celle de leur classe

### DIFF
--- a/api/migrations/20241002091833-rattrappage-youngsInClasse-wrongCohort.js
+++ b/api/migrations/20241002091833-rattrappage-youngsInClasse-wrongCohort.js
@@ -1,0 +1,23 @@
+const { ClasseModel, YoungModel } = require("../src/models");
+const { logger } = require("../src/logger");
+
+module.exports = {
+  async up(db, client) {
+    const youngUpdated = [];
+    const classes = await ClasseModel.find({ schoolYear: "2024-2025" });
+    logger.info(`Found ${classes.length} classes for schoolYear 2024-2025`);
+    for (const classe of classes) {
+      const youngs = await YoungModel.find({ classeId: classe._id });
+      for (const young of youngs) {
+        if (young.cohortId !== classe.cohortId) {
+          young.set({ cohortId: classe.cohortId, cohort: classe.cohort });
+          await young.save({ fromUser: { firstName: "Rattrappage CLE des young avec une cohorte différente de sa classe" } });
+          youngUpdated.push(young._id);
+          logger.info(`Young ${young._id} updated with cohortId ${classe.cohortId} and cohort ${classe.cohort}`);
+        }
+      }
+    }
+    logger.info(`Updated cohort of youngs: ${youngUpdated}`);
+    logger.info(`${youngUpdated.length} youngs updated`);
+  },
+};

--- a/api/migrations/20241002091833-rattrappage-youngsInClasse-wrongCohort.js
+++ b/api/migrations/20241002091833-rattrappage-youngsInClasse-wrongCohort.js
@@ -10,7 +10,15 @@ module.exports = {
       const youngs = await YoungModel.find({ classeId: classe._id });
       for (const young of youngs) {
         if (young.cohortId !== classe.cohortId) {
-          young.set({ cohortId: classe.cohortId, cohort: classe.cohort });
+          const originalCohortId = young.cohortId;
+          const originalCohortName = young.cohort;
+          young.set({
+            cohortId: classe.cohortId,
+            cohort: classe.cohort,
+            originalCohort: originalCohortName,
+            originalCohortId: originalCohortId,
+            cohortChangeReason: `Import SI-SNU`,
+          });
           await young.save({ fromUser: { firstName: "Rattrappage CLE des young avec une cohorte différente de sa classe" } });
           youngUpdated.push(young._id);
           logger.info(`Young ${young._id} updated with cohortId ${classe.cohortId} and cohort ${classe.cohort}`);


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Script-de-migration-pour-rattraper-les-l-ves-qui-ne-sont-pas-dans-la-m-me-cohorte-que-leur-classe-11372a322d5080b98755d2e7c32c3da0