### PR TITLE
feat(api, admin): 3283 - Add manual inscription rights according to dynamic CLE settings

### DIFF
--- a/admin/src/scenes/classe/header/index.tsx
+++ b/admin/src/scenes/classe/header/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { HiOutlineClipboardList } from "react-icons/hi";
+import cx from "classnames";
 
 import { ROLES, STATUS_CLASSE, YOUNG_STATUS, ClasseFileKeys, ClasseCertificateKeys, ClassesRoutes } from "snu-lib";
 import { User } from "@/types";
@@ -23,9 +24,10 @@ interface Props {
   url: string;
   id: string;
   studentStatus: any;
+  canPerformManualInscriptionActions: boolean;
 }
 
-export const getHeaderActionList = ({ user, classe, setClasse, isLoading, setIsLoading, url, id, studentStatus }: Props) => {
+export const getHeaderActionList = ({ user, classe, setClasse, isLoading, setIsLoading, url, id, studentStatus, canPerformManualInscriptionActions }: Props) => {
   const isClasseDeletable = () => {
     if (studentStatus?.[YOUNG_STATUS.VALIDATED] > 0) return false;
     if (classe?.cohesionCenterId) return false;
@@ -146,9 +148,22 @@ export const getHeaderActionList = ({ user, classe, setClasse, isLoading, setIsL
   if (classe?.status === STATUS_CLASSE.CREATED && [ROLES.ADMIN, ROLES.ADMINISTRATEUR_CLE, ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role)) {
     actionsList.push(<VerifClassButton key="verify" classe={classe} setClasse={setClasse} isLoading={isLoading} setLoading={setIsLoading} />);
   }
-  if (classe?.status && STATUS_CLASSE.OPEN === classe.status) {
-    actionsList.push(<DropdownButton key="inscription" title="Inscrire les élèves" type="wired" optionsGroup={optionsInscription} position="right" buttonClassName="mr-2" />);
-  }
+
+  const isManualInscriptionActionDisabled = !(classe?.status === STATUS_CLASSE.OPEN || canPerformManualInscriptionActions);
+
+  actionsList.push(
+    <DropdownButton
+      key="inscription"
+      title="Inscrire les élèves"
+      type="wired"
+      optionsGroup={optionsInscription}
+      position="right"
+      buttonClassName={cx("mr-2", isManualInscriptionActionDisabled && "cursor-not-allowed")}
+      disabled={isManualInscriptionActionDisabled}
+      {...(isManualInscriptionActionDisabled && { tooltip: "Les inscriptions sont fermées. Vous n’avez pas les droits pour inscrire un élève." })}
+    />,
+  );
+
   if (classe?.status && (classe.status === STATUS_CLASSE.OPEN || classe.status === STATUS_CLASSE.CLOSED) && [ROLES.REFERENT_CLASSE, ROLES.ADMINISTRATEUR_CLE].includes(user.role)) {
     actionsList.push(
       <DropdownButton

--- a/admin/src/scenes/classe/header/index.tsx
+++ b/admin/src/scenes/classe/header/index.tsx
@@ -150,13 +150,23 @@ export const getHeaderActionList = ({ user, classe, setClasse, isLoading, setIsL
   }
 
   const isManualInscriptionActionDisabled = !(classe?.status === STATUS_CLASSE.OPEN || canPerformManualInscriptionActions);
+  const optionsInscriptionFiltered =
+    classe?.status !== STATUS_CLASSE.OPEN && canPerformManualInscriptionActions
+      ? [
+          {
+            ...optionsInscription[0],
+            // override items to keep only manual inscription
+            items: optionsInscription[0].items.filter((i) => i.key === "manual"),
+          },
+        ]
+      : optionsInscription;
 
   actionsList.push(
     <DropdownButton
       key="inscription"
       title="Inscrire les élèves"
       type="wired"
-      optionsGroup={optionsInscription}
+      optionsGroup={optionsInscriptionFiltered}
       position="right"
       buttonClassName={cx("mr-2", isManualInscriptionActionDisabled && "cursor-not-allowed")}
       disabled={isManualInscriptionActionDisabled}

--- a/admin/src/scenes/classe/view.tsx
+++ b/admin/src/scenes/classe/view.tsx
@@ -7,7 +7,7 @@ import { toastr } from "react-redux-toastr";
 import { Page, Header, Badge } from "@snu/ds/admin";
 import { capture } from "@/sentry";
 import api from "@/services/api";
-import { translate, YOUNG_STATUS, STATUS_CLASSE, translateStatusClasse, COHORT_TYPE, FUNCTIONAL_ERRORS, LIMIT_DATE_ESTIMATED_SEATS, ClassesRoutes, ROLES } from "snu-lib";
+import { translate, YOUNG_STATUS, STATUS_CLASSE, translateStatusClasse, COHORT_TYPE, FUNCTIONAL_ERRORS, LIMIT_DATE_ESTIMATED_SEATS, ClassesRoutes, canInviteYoung } from "snu-lib";
 import { appURL } from "@/config";
 import Loader from "@/components/Loader";
 import { AuthState } from "@/redux/auth/reducer";
@@ -225,20 +225,8 @@ export default function View() {
   };
 
   const canPerformManualInscriptionActions = useMemo(() => {
-    if (!cohort) return false;
-
-    switch (user.role) {
-      case ROLES.REFERENT_DEPARTMENT:
-        return cohort.inscriptionOpenForReferentDepartment === true;
-      case ROLES.REFERENT_REGION:
-        return cohort.inscriptionOpenForReferentRegion === true;
-      case ROLES.REFERENT_CLASSE:
-        return cohort.inscriptionOpenForReferentClasse === true;
-      case ROLES.ADMINISTRATEUR_CLE:
-        return cohort.inscriptionOpenForAdministrateurCle === true;
-      default:
-        return false;
-    }
+    return canInviteYoung(user, cohort ?? null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user.role, cohort]);
 
   if (!classe) return <Loader />;

--- a/admin/src/scenes/classe/view.tsx
+++ b/admin/src/scenes/classe/view.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import dayjs from "dayjs";
@@ -7,7 +7,7 @@ import { toastr } from "react-redux-toastr";
 import { Page, Header, Badge } from "@snu/ds/admin";
 import { capture } from "@/sentry";
 import api from "@/services/api";
-import { translate, YOUNG_STATUS, STATUS_CLASSE, translateStatusClasse, COHORT_TYPE, FUNCTIONAL_ERRORS, LIMIT_DATE_ESTIMATED_SEATS, ClassesRoutes } from "snu-lib";
+import { translate, YOUNG_STATUS, STATUS_CLASSE, translateStatusClasse, COHORT_TYPE, FUNCTIONAL_ERRORS, LIMIT_DATE_ESTIMATED_SEATS, ClassesRoutes, ROLES } from "snu-lib";
 import { appURL } from "@/config";
 import Loader from "@/components/Loader";
 import { AuthState } from "@/redux/auth/reducer";
@@ -224,6 +224,23 @@ export default function View() {
     setErrors({});
   };
 
+  const canPerformManualInscriptionActions = useMemo(() => {
+    if (!cohort) return false;
+
+    switch (user.role) {
+      case ROLES.REFERENT_DEPARTMENT:
+        return cohort.inscriptionOpenForReferentDepartment === true;
+      case ROLES.REFERENT_REGION:
+        return cohort.inscriptionOpenForReferentRegion === true;
+      case ROLES.REFERENT_CLASSE:
+        return cohort.inscriptionOpenForReferentClasse === true;
+      case ROLES.ADMINISTRATEUR_CLE:
+        return cohort.inscriptionOpenForAdministrateurCle === true;
+      default:
+        return false;
+    }
+  }, [user.role, cohort]);
+
   if (!classe) return <Loader />;
 
   return (
@@ -239,7 +256,7 @@ export default function View() {
           },
           { title: "Fiche de la classe" },
         ]}
-        actions={getHeaderActionList({ user, classe, setClasse, isLoading, setIsLoading, url, id, studentStatus })}
+        actions={getHeaderActionList({ user, classe, setClasse, isLoading, setIsLoading, url, id, studentStatus, canPerformManualInscriptionActions })}
       />
       <GeneralInfos
         classe={classe}

--- a/admin/src/scenes/inscription/index.jsx
+++ b/admin/src/scenes/inscription/index.jsx
@@ -318,7 +318,7 @@ export default function Inscription() {
         <div className="flex items-center justify-between py-8">
           <Title>Inscriptions</Title>
           <div className="flex items-center gap-2">
-            {!invitationState.isLoading || invitationState.canInvite ? (
+            {!invitationState.isLoading && invitationState.canInvite ? (
               <Link
                 to={baseInscriptionPath}
                 onClick={handleClickInscription}

--- a/admin/src/scenes/settings/index.jsx
+++ b/admin/src/scenes/settings/index.jsx
@@ -28,6 +28,8 @@ import { settings, uselessSettings } from "./utils";
 import { InformationsConvoyage } from "@/scenes/settings/InformationsConvoyage";
 import { CleSettings } from "@/scenes/settings/CleSettings";
 
+import { ManualInscriptionSettings } from "./phase0/ManualInscriptionSettings";
+
 export default function Settings() {
   const { user } = useSelector((state) => state.Auth);
 
@@ -337,6 +339,7 @@ export default function Settings() {
                       </>
                     )}
                   </div>
+                  <ManualInscriptionSettings cohort={data} setCohort={setData} isLoading={isLoading} readOnly={readOnly} />
                 </div>
                 <div className="flex w-[10%] justify-center items-center">
                   <div className="w-[1px] h-[90%] border-r-[1px] border-gray-200"></div>

--- a/admin/src/scenes/settings/phase0/ManualInscriptionSettings.tsx
+++ b/admin/src/scenes/settings/phase0/ManualInscriptionSettings.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useMemo } from "react";
+import { CohortDto } from "snu-lib";
+import { getManualInscriptionTogglesByCohortType } from "./getManualInscriptionTogglesByCohortType";
+import ReactTooltip from "react-tooltip";
+import React from "react";
+import { MdInfoOutline } from "react-icons/md";
+
+interface ManualInscriptionSettingsProps {
+  cohort: CohortDto;
+  setCohort: React.Dispatch<React.SetStateAction<CohortDto>>;
+  isLoading: boolean;
+  readOnly: boolean;
+}
+
+export const ManualInscriptionSettings: React.FC<ManualInscriptionSettingsProps> = ({ cohort, setCohort, isLoading, readOnly }) => {
+  const handleToggleChange = useCallback(
+    (field: keyof CohortDto) => {
+      setCohort((prev) => ({ ...prev, [field]: !prev[field] }));
+    },
+    [setCohort],
+  );
+
+  const renderedManualInscriptionTogglesByCohortType = useMemo(
+    () => getManualInscriptionTogglesByCohortType({ cohort, handleToggleChange, isLoading, readOnly }),
+    // Disabled exhaustive-deps because we don't want to re-render the component when the all props data changes only specific fields should trigger a re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      cohort.type,
+      cohort.inscriptionOpenForReferentRegion,
+      cohort.inscriptionOpenForReferentDepartment,
+      cohort.inscriptionOpenForReferentClasse,
+      cohort.inscriptionOpenForAdministrateurCle,
+      handleToggleChange,
+      isLoading,
+      readOnly,
+    ],
+  );
+
+  // If no rendered toggles according to the cohort type, we don't display anything
+  if (!renderedManualInscriptionTogglesByCohortType) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <p className="text-gray-900  text-xs font-medium">Inscriptions manuelles</p>
+        <MdInfoOutline data-tip data-for="inscriptions" className="text-gray-400 h-5 w-5 cursor-pointer" />
+        <ReactTooltip id="inscriptions" type="light" place="top" effect="solid" className="custom-tooltip-radius !opacity-100 !shadow-md rounded-[6px]">
+          <p className=" text-left text-gray-600 text-xs w-[275px] !px-2 !py-1.5 list-outside">
+            Ouverture et fermeture pour les utilisateurs de la possibilité d’inscrire manuellement des jeunes.
+          </p>
+        </ReactTooltip>
+      </div>
+      {renderedManualInscriptionTogglesByCohortType}
+    </div>
+  );
+};

--- a/admin/src/scenes/settings/phase0/getManualInscriptionTogglesByCohortType.tsx
+++ b/admin/src/scenes/settings/phase0/getManualInscriptionTogglesByCohortType.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { CohortDto, COHORT_TYPE } from "snu-lib";
+import SimpleToggle from "@/components/ui/forms/dateForm/SimpleToggle";
+
+type ToggleItem = {
+  label: string;
+  value: boolean;
+  field: keyof CohortDto;
+};
+
+interface ManualInscriptionCLETogglesProps {
+  cohort: CohortDto;
+  handleToggleChange: (field: keyof CohortDto) => void;
+  isLoading: boolean;
+  readOnly: boolean;
+}
+
+const renderManualInscriptionCLEToggles = ({ cohort, handleToggleChange, isLoading, readOnly }: ManualInscriptionCLETogglesProps) => {
+  const toggles: ToggleItem[] = [
+    {
+      label: "Référents régionaux",
+      value: cohort.inscriptionOpenForReferentRegion ?? false,
+      field: "inscriptionOpenForReferentRegion" as keyof CohortDto,
+    },
+    {
+      label: "Référents départementaux",
+      value: cohort.inscriptionOpenForReferentDepartment ?? false,
+      field: "inscriptionOpenForReferentDepartment" as keyof CohortDto,
+    },
+    {
+      label: "Référents de classe",
+      value: cohort.inscriptionOpenForReferentClasse ?? false,
+      field: "inscriptionOpenForReferentClasse" as keyof CohortDto,
+    },
+    {
+      label: "Administrateurs CLE",
+      value: cohort.inscriptionOpenForAdministrateurCle ?? false,
+      field: "inscriptionOpenForAdministrateurCle" as keyof CohortDto,
+    },
+  ];
+
+  return (
+    <>
+      {toggles.map((toggle) => (
+        <SimpleToggle key={toggle.field} label={toggle.label} value={toggle.value} disabled={isLoading || readOnly} onChange={() => handleToggleChange(toggle.field)} />
+      ))}
+    </>
+  );
+};
+
+export const getManualInscriptionTogglesByCohortType = ({ cohort, handleToggleChange, isLoading, readOnly }: ManualInscriptionCLETogglesProps) => {
+  const cohortType = cohort.type as (typeof COHORT_TYPE)[keyof typeof COHORT_TYPE];
+  switch (cohortType) {
+    case COHORT_TYPE.CLE:
+      return renderManualInscriptionCLEToggles({ cohort, handleToggleChange, isLoading, readOnly });
+    default:
+      return null;
+  }
+};

--- a/admin/src/scenes/volontaires/create.tsx
+++ b/admin/src/scenes/volontaires/create.tsx
@@ -518,8 +518,6 @@ export default function Create() {
     }
   }, [values.schoolDepartment, values.department, values.schoolRegion, values.region, values.grade, values.birthdateAt]);
 
-  console.log(values.cohort, values.cohortId);
-
   return (
     <div className="py-4 px-8">
       <ConfirmationModal

--- a/api/migrations/20241002075633-add-inscription-controls-to-cohort.js
+++ b/api/migrations/20241002075633-add-inscription-controls-to-cohort.js
@@ -1,0 +1,29 @@
+module.exports = {
+  async up(db) {
+    await db.collection("cohorts").updateMany(
+      {},
+      {
+        $set: {
+          inscriptionOpenForReferentClasse: false,
+          inscriptionOpenForReferentRegion: false,
+          inscriptionOpenForReferentDepartment: false,
+          inscriptionOpenForAdministrateurCle: false,
+        },
+      },
+    );
+  },
+
+  async down(db) {
+    await db.collection("cohorts").updateMany(
+      {},
+      {
+        $unset: {
+          inscriptionOpenForReferentClasse: "",
+          inscriptionOpenForReferentRegion: "",
+          inscriptionOpenForReferentDepartment: "",
+          inscriptionOpenForAdministrateurCle: "",
+        },
+      },
+    );
+  },
+};

--- a/api/migrations/20241002075633-add-inscription-controls-to-cohort.js
+++ b/api/migrations/20241002075633-add-inscription-controls-to-cohort.js
@@ -4,10 +4,10 @@ module.exports = {
       {},
       {
         $set: {
-          inscriptionOpenForReferentClasse: false,
-          inscriptionOpenForReferentRegion: false,
-          inscriptionOpenForReferentDepartment: false,
-          inscriptionOpenForAdministrateurCle: false,
+          inscriptionOpenForReferentClasse: true,
+          inscriptionOpenForReferentRegion: true,
+          inscriptionOpenForReferentDepartment: true,
+          inscriptionOpenForAdministrateurCle: true,
         },
       },
     );

--- a/api/src/__tests__/young.test.ts
+++ b/api/src/__tests__/young.test.ts
@@ -475,39 +475,55 @@ describe("Young", () => {
     });
   });
 
-  // Dans __tests__/young.test.ts
-
   describe("POST /young/invite", () => {
     it("should return 403 when user is not authorized to invite young", async () => {
       const referent = await createReferentHelper(getNewReferentFixture({ role: ROLES.REFERENT_DEPARTMENT }));
       const cohort = await createCohortHelper(getNewCohortFixture({ inscriptionOpenForReferentDepartment: false }));
-      const youngFixture = getNewYoungFixture({ cohort: cohort.name });
+      const youngFixture = getNewYoungFixture({ cohortId: cohort._id.toString() });
 
       const passport = require("passport");
       passport.user = referent;
 
       const res = await request(getAppHelper()).post("/young/invite").send(youngFixture);
 
-      expect(res.status).toBe(403);
+      expect(res.statusCode).toBe(403);
       expect(res.body.code).toBe(ERRORS.OPERATION_NOT_ALLOWED);
     });
 
     it("should return 200 when user is authorized to invite young", async () => {
       const referent = await createReferentHelper(getNewReferentFixture({ role: ROLES.REFERENT_DEPARTMENT }));
       const cohort = await createCohortHelper(getNewCohortFixture({ inscriptionOpenForReferentDepartment: true }));
-      const youngFixture = getNewYoungFixture({ cohort: cohort.name });
+      const youngFixture = getNewYoungFixture({ cohortId: cohort._id.toString() });
 
       const passport = require("passport");
       passport.user = referent;
 
       const res = await request(getAppHelper()).post("/young/invite").send(youngFixture);
 
-      expect(res.status).toBe(200);
+      expect(res.statusCode).toBe(200);
       expect(res.body.young).toBeDefined();
       expect(res.body.ok).toBe(true);
     });
-  });
 
+    it("should create a new young user and send an invitation email", async () => {
+      const referent = await createReferentHelper(getNewReferentFixture({ role: ROLES.REFERENT_CLASSE }));
+      const cohort = await createCohortHelper(getNewCohortFixture({ inscriptionOpenForReferentClasse: true }));
+      const young = getNewYoungFixture({ cohortId: cohort._id.toString() });
+
+      const passport = require("passport");
+      passport.user = referent;
+
+      const res = await request(getAppHelper()).post("/young/invite").send(young);
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toHaveProperty("young");
+      expect(res.body.young).toHaveProperty("invitationToken");
+      expect(res.body.young).toHaveProperty("invitationExpires");
+      expect(res.body.young).toHaveProperty("status", "WAITING_VALIDATION");
+      expect(res.body.young).toHaveProperty("cohort", cohort.name);
+      expect(res.body.young).toHaveProperty("cohortId", cohort._id.toString());
+    });
+  });
 
   describe("POST /young/signup_verify", () => {
     it("should return 400 when missing invitationToken", async () => {
@@ -768,25 +784,6 @@ describe("Young", () => {
 
       const updatedClasse = await ClasseModel.findById(classeId);
       expect(updatedClasse?.seatsTaken).toBe(1);
-    });
-  });
-
-  describe("POST /young/invite", () => {
-    it("should create a new young user and send an invitation email", async () => {
-      const cohort = await createCohortHelper(getNewCohortFixture());
-      const young = getNewYoungFixture({ cohortId: cohort._id.toString() });
-
-      const res = await request(getAppHelper({ role: ROLES.ADMIN }))
-        .post("/young/invite")
-        .send(young);
-
-      expect(res.statusCode).toEqual(200);
-      expect(res.body).toHaveProperty("young");
-      expect(res.body.young).toHaveProperty("invitationToken");
-      expect(res.body.young).toHaveProperty("invitationExpires");
-      expect(res.body.young).toHaveProperty("status", "WAITING_VALIDATION");
-      expect(res.body.young).toHaveProperty("cohort", cohort.name);
-      expect(res.body.young).toHaveProperty("cohortId", cohort._id.toString());
     });
   });
 });

--- a/api/src/cohort/cohortValidator.ts
+++ b/api/src/cohort/cohortValidator.ts
@@ -12,6 +12,10 @@ export const validateCohortDto = (dto: UpdateCohortDto): Joi.ValidationResult<Up
     inscriptionEndDate: Joi.date().required(),
     reInscriptionStartDate: Joi.date().allow(null),
     reInscriptionEndDate: Joi.date().allow(null),
+    inscriptionOpenForReferentClasse: Joi.boolean().default(false),
+    inscriptionOpenForReferentRegion: Joi.boolean().default(false),
+    inscriptionOpenForReferentDepartment: Joi.boolean().default(false),
+    inscriptionOpenForAdministrateurCle: Joi.boolean().default(false),
     // --
     inscriptionModificationEndDate: Joi.date(),
     instructionEndDate: Joi.date().required(),

--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -231,7 +231,9 @@ router.post("/invite", passport.authenticate("referent", { session: false, failW
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
 
-    if (!canInviteYoung(req.user)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
+    const cohortObj = await CohortModel.findOne({ name: value.cohort });
+
+    if (!canInviteYoung(req.user, cohortObj)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
 
     const obj = { ...value };
 

--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -232,7 +232,7 @@ router.post("/invite", passport.authenticate("referent", { session: false, failW
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
 
-    const cohortObj = await CohortModel.findOne({ name: value.cohort });
+    const cohortObj = await CohortModel.findById(value.cohortId);
     const cohortDto: CohortDto | null = cohortObj ? (cohortObj.toObject() as CohortDto) : null;
 
     if (!canInviteYoung(req.user, cohortDto)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });

--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -57,6 +57,7 @@ import {
   ReferentType,
   getDepartmentForEligibility,
   FUNCTIONAL_ERRORS,
+  CohortDto,
 } from "snu-lib";
 import { getFilteredSessions } from "../../utils/cohort";
 import { anonymizeApplicationsFromYoungId } from "../../services/application";
@@ -232,8 +233,9 @@ router.post("/invite", passport.authenticate("referent", { session: false, failW
     }
 
     const cohortObj = await CohortModel.findOne({ name: value.cohort });
+    const cohortDto: CohortDto | null = cohortObj ? (cohortObj.toObject() as CohortDto) : null;
 
-    if (!canInviteYoung(req.user, cohortObj)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
+    if (!canInviteYoung(req.user, cohortDto)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
 
     const obj = { ...value };
 

--- a/packages/lib/src/dto/cohortDto.ts
+++ b/packages/lib/src/dto/cohortDto.ts
@@ -63,6 +63,10 @@ export type CohortDto = {
     editionOpenForReferentDepartment?: boolean;
     editionOpenForHeadOfCenter?: boolean;
   } | null;
+  inscriptionOpenForReferentClasse?: boolean;
+  inscriptionOpenForReferentRegion?: boolean;
+  inscriptionOpenForReferentDepartment?: boolean;
+  inscriptionOpenForAdministrateurCle?: boolean;
 };
 
 export type UpdateCohortDto = Omit<CohortDto, "name" | "type" | "snuId">;

--- a/packages/lib/src/mongoSchema/cohort.ts
+++ b/packages/lib/src/mongoSchema/cohort.ts
@@ -341,6 +341,35 @@ export const CohortSchema = {
 
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },
+
+  inscriptionOpenForReferentClasse: {
+    type: Boolean,
+    default: true,
+    documentation: {
+      description: "Ouverture ou fermeture de l'inscription manuelle pour les référents de classe",
+    },
+  },
+  inscriptionOpenForReferentRegion: {
+    type: Boolean,
+    default: true,
+    documentation: {
+      description: "Ouverture ou fermeture de l'inscription manuelle pour les référents régionaux",
+    },
+  },
+  inscriptionOpenForReferentDepartment: {
+    type: Boolean,
+    default: true,
+    documentation: {
+      description: "Ouverture ou fermeture de l'inscription manuelle pour les référents départementaux",
+    },
+  },
+  inscriptionOpenForAdministrateurCle: {
+    type: Boolean,
+    default: true,
+    documentation: {
+      description: "Ouverture ou fermeture de l'inscription manuelle pour les administrateurs CLE",
+    },
+  },
 };
 
 const schema = new Schema(CohortSchema);

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -1,4 +1,4 @@
-import { ReferentDto, UserDto } from "./dto";
+import { CohortDto, ReferentDto, UserDto } from "./dto";
 import { region2department } from "./region-and-departments";
 import { isNowBetweenDates } from "./utils/date";
 import { LIMIT_DATE_ESTIMATED_SEATS, LIMIT_DATE_TOTAL_SEATS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, YOUNG_STATUS_PHASE3 } from "./constants/constants";
@@ -667,8 +667,21 @@ function canDownloadYoungDocuments(actor: UserDto, target?: UserDto, type?: stri
   }
 }
 
-function canInviteYoung(actor) {
-  return [ROLES.ADMIN, ROLES.REFERENT_REGION, ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_CLASSE, ROLES.ADMINISTRATEUR_CLE].includes(actor.role);
+function canInviteYoung(actor: UserDto, cohort: CohortDto | null) {
+    if (!cohort) return false;
+
+    switch (actor.role) {
+      case ROLES.REFERENT_DEPARTMENT:
+        return cohort.inscriptionOpenForReferentDepartment === true;
+      case ROLES.REFERENT_REGION:
+        return cohort.inscriptionOpenForReferentRegion === true;
+      case ROLES.REFERENT_CLASSE:
+        return cohort.inscriptionOpenForReferentClasse === true;
+      case ROLES.ADMINISTRATEUR_CLE:
+        return cohort.inscriptionOpenForAdministrateurCle === true;
+      default:
+        return false;
+    }
 }
 
 function canSendTemplateToYoung(actor, young) {

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -671,6 +671,8 @@ function canInviteYoung(actor: UserDto, cohort: CohortDto | null) {
     if (!cohort) return false;
 
     switch (actor.role) {
+      case ROLES.ADMIN:
+        return true;
       case ROLES.REFERENT_DEPARTMENT:
         return cohort.inscriptionOpenForReferentDepartment === true;
       case ROLES.REFERENT_REGION:


### PR DESCRIPTION
**Description**

Après la date de fermeture des inscriptions, les référent départementaux, référent régionaux, administrateurs CLE, référents de classe n’ont plus la possibilité d’inscrire manuellement des jeunes.

Il existe des exceptions (ex : DROM) pour lesquels les référents doivent avoir la main passé la date de fin d’inscription pour pouvoir continuer à inscrire des jeunes.

Le but était d'ajouter des paramètres dynamiques pour surcharger les droits d'affichage des boutons d'actions liés aux inscriptions, en fonction des différents types de référents, même si la date des inscriptions est dépassée.

**Todo**

- [x] Identifier les variables booléennes à créer
- [x] Rédiger le script de migration
- [x] Modifier toutes les couches pour inclure ces variables (Schema, DTO, cohortValidator)
- [x] Modifier la page de paramétrage dynamique (création des composants + modification de l'existant)
- [x] Modifier la condition d'affichage du bouton dans le Dropdown ActionsList "Inscrire un élève" sur la partie admin

**Ticket / Issue**

[Notion ticket #3283](https://www.notion.so/jeveuxaider/Param-trage-dynamique-CLE-G-rer-les-droits-d-inscription-c9fd8f0d1dda42049bbcfa03515e5e18)

**Testing instructions**

- Rechercher une classe avec un filtre sur une cohorte 2024 avec un statut fermé.
- Copier l'adresse du référent de classe, la rechercher dans les utilisateurs, puis prendre sa place.
- Prendre une des classes avec un statut d'inscription fermé.
- Le dropdown d'action "Inscrire les élèves" est désactivé par défaut avec un tooltip explicatif.
- Noter le nom de la cohorte (pour la rechercher dans la liste des cohortes sur les paramétrages dynamiques).

> Ouvrir une fenêtre de navigation privée 

- Se connecter avec votre compte Modérateur et le sous-rôle "god", puis aller dans les paramétrages dynamiques.
- Choisir la cohorte sélectionnée dans votre autre fenêtre de navigation.
- Dans le bloc Inscriptions (phase 0), de nouveaux paramètres sous forme de toggle apparaissent.
- Activer les paramètres pour les rôles "Référent de classe" et "Administrateur CLE".
- Sauvegarder.
- Dans votre autre fenêtre de navigation (celle du référent de classe), rafraîchir la page.
- Le dropdown d'action "Inscrire les élèves" est maintenant activé et vous pouvez sélectionner l'inscription manuelle.