### PR TITLE
fix(api): script de migrations pour renommer les department et acadenie des centres

### DIFF
--- a/api/migrations/20241003102056-mapper_department.js
+++ b/api/migrations/20241003102056-mapper_department.js
@@ -6,7 +6,7 @@ module.exports = {
     const centers = await CohesionCenterModel.find({ matricule: { $exists: true } });
     for (const center of centers) {
       const academy = mapAcademy(center.academy);
-      const department = mapDepartment(center.department, "name");
+      const department = mapDepartment(center.department);
       center.set({ academy, department });
       await center.save({ fromUser: { firstName: "Migration mapper department&academy for center" } });
     }

--- a/api/migrations/20241003102056-mapper_department.js
+++ b/api/migrations/20241003102056-mapper_department.js
@@ -1,0 +1,14 @@
+const { CohesionCenterModel } = require("../src/models");
+import { mapAcademy, mapDepartment } from "../src/cohesionCenter/import/cohesionCenterImportMapper";
+
+module.exports = {
+  async up() {
+    const centers = await CohesionCenterModel.find({ matricule: { $exists: true } });
+    for (const center of centers) {
+      const academy = mapAcademy(center.academy);
+      const department = mapDepartment(center.department);
+      center.set({ academy, department });
+      await center.save({ fromUser: { firstName: "Migration mapper department&academy for center" } });
+    }
+  },
+};

--- a/api/migrations/20241003102056-mapper_department.js
+++ b/api/migrations/20241003102056-mapper_department.js
@@ -6,7 +6,7 @@ module.exports = {
     const centers = await CohesionCenterModel.find({ matricule: { $exists: true } });
     for (const center of centers) {
       const academy = mapAcademy(center.academy);
-      const department = mapDepartment(center.department);
+      const department = mapDepartment(center.department, "name");
       center.set({ academy, department });
       await center.save({ fromUser: { firstName: "Migration mapper department&academy for center" } });
     }

--- a/api/src/cohesionCenter/import/cohesionCenterImportMapper.ts
+++ b/api/src/cohesionCenter/import/cohesionCenterImportMapper.ts
@@ -9,7 +9,7 @@ export const mapCohesionCentersForSept2024 = (cohesionCenters: CohesionCenterCSV
       address: cohesionCenter.Adresse,
       city: cohesionCenter.Commune,
       zip: cohesionCenter["Code postal"],
-      department: mapDepartment(cohesionCenter["Département"], "name"),
+      department: mapDepartment(cohesionCenter["Département"]),
       region: mapRegion(cohesionCenter["Région académique"]),
       placesTotal: parseInt(cohesionCenter["Capacité d'accueil Maximale"]),
       pmr: cohesionCenter["Acceuil PMR"] === "TRUE" ? "true" : "false",
@@ -22,7 +22,7 @@ export const mapCohesionCentersForSept2024 = (cohesionCenters: CohesionCenterCSV
       COR: cohesionCenter["Organisme de rattachement"],
       code: cohesionCenter["Matricule du Centre"],
       code2022: cohesionCenter["Matricule du Centre"],
-      departmentCode: mapDepartment(cohesionCenter["Département"], "code"),
+      departmentCode: mapDepartmentCode(cohesionCenter["Département"]),
       matricule: cohesionCenter["Matricule du Centre"],
     };
     if (cohesionCenter["ID temporaire"]) {
@@ -84,7 +84,27 @@ export const mapAcademy = (academyCsv: string) => {
   return foundAcademy || "NO_ACADEMY";
 };
 
-export const mapDepartment = (departmentCsv: string, type: string) => {
+export const mapDepartment = (departmentCsv: string) => {
+  let convertedDepartment = departmentCsv;
+
+  if (departmentCsv === "COTE D'OR") {
+    convertedDepartment = "COTE-D'OR";
+  }
+  if (departmentCsv === "COTES D'ARMOR") {
+    convertedDepartment = "COTES-D'ARMOR";
+  }
+  if (departmentCsv === "NOUVELLE CALEDONIE") {
+    convertedDepartment = "NOUVELLE-CALEDONIE";
+  }
+
+  const foundDepartment = departmentList.find((dep) => normalizeString(dep) === normalizeString(convertedDepartment));
+  if (!foundDepartment) {
+    logger.warn(`No department found for : ${departmentCsv} was converted to ${convertedDepartment}`);
+  }
+  return foundDepartment || "NO_DEPARTMENT";
+};
+
+export const mapDepartmentCode = (departmentCsv: string) => {
   let department = departmentCsv;
   if (departmentCsv === "COTE D'OR") {
     department = "COTE-D'OR";
@@ -95,20 +115,11 @@ export const mapDepartment = (departmentCsv: string, type: string) => {
   if (departmentCsv === "NOUVELLE CALEDONIE") {
     department = "NOUVELLE-CALEDONIE";
   }
-  if (type === "code") {
-    let departmentCode = Object.keys(departmentLookUp).find((key) => normalizeString(departmentLookUp[key]) === normalizeString(department));
-    if (!departmentCode) {
-      logger.warn(`mapDepartmentCode() - No department code for : ${departmentCsv} was converted to ${department}`);
-    }
-    return departmentCode || "NO_DEPARTMENT";
-  } else if (type === "name") {
-    let departmentName = Object.values(departmentLookUp).find((value) => normalizeString(value) === normalizeString(department));
-
-    if (!departmentName) {
-      logger.warn(`No department found for : ${departmentCsv} was converted to ${department}`);
-    }
-    return departmentName || "NO_DEPARTMENT";
+  let departmentCode = Object.keys(departmentLookUp).find((key) => normalizeString(departmentLookUp[key]) === normalizeString(department));
+  if (!departmentCode) {
+    logger.warn(`mapDepartmentCode() - No department code for : ${departmentCsv} was converted to ${department}`);
   }
+  return departmentCode || "NO_DEPARTMENT";
 };
 
 export const mapDomain = (domainCsv: string): CohesionCenterDomainEnum => {

--- a/api/src/cohesionCenter/import/cohesionCenterImportMapper.ts
+++ b/api/src/cohesionCenter/import/cohesionCenterImportMapper.ts
@@ -1,4 +1,4 @@
-import { CohesionCenterDomainEnum, CohesionCenterTypologyEnum, departmentLookUp, regionList } from "snu-lib";
+import { CohesionCenterDomainEnum, CohesionCenterTypologyEnum, departmentLookUp, regionList, departmentList, academyList } from "snu-lib";
 import { logger } from "../../logger";
 import { CohesionCenterCSV, CohesionCenterImportMapped } from "./cohesionCenterImport";
 
@@ -9,7 +9,7 @@ export const mapCohesionCentersForSept2024 = (cohesionCenters: CohesionCenterCSV
       address: cohesionCenter.Adresse,
       city: cohesionCenter.Commune,
       zip: cohesionCenter["Code postal"],
-      department: cohesionCenter["Département"],
+      department: mapDepartment(cohesionCenter["Département"]),
       region: mapRegion(cohesionCenter["Région académique"]),
       placesTotal: parseInt(cohesionCenter["Capacité d'accueil Maximale"]),
       pmr: cohesionCenter["Acceuil PMR"] === "TRUE" ? "true" : "false",
@@ -68,6 +68,40 @@ export const mapRegion = (regionCsv: string) => {
     logger.warn(`No region found for : ${regionCsv} was converted to ${convertedRegion}`);
   }
   return foundRegion || "NO_REGION";
+};
+
+export const mapDepartment = (departmentCsv: string) => {
+  let convertedDepartment = departmentCsv;
+
+  if (departmentCsv === "COTE D'OR") {
+    convertedDepartment = "COTE-D'OR";
+  }
+  if (departmentCsv === "COTES D'ARMOR") {
+    convertedDepartment = "COTES-D'ARMOR";
+  }
+  if (departmentCsv === "NOUVELLE CALEDONIE") {
+    convertedDepartment = "NOUVELLE-CALEDONIE";
+  }
+
+  const foundDepartment = departmentList.find((dep) => normalizeString(dep) === normalizeString(convertedDepartment));
+  if (!foundDepartment) {
+    logger.warn(`No department found for : ${departmentCsv} was converted to ${convertedDepartment}`);
+  }
+  return foundDepartment || "NO_DEPARTMENT";
+};
+
+export const mapAcademy = (academyCsv: string) => {
+  let convertedAcademy = academyCsv;
+
+  if (academyCsv === "NOUVELLE CALEDONIE") {
+    convertedAcademy = "NOUVELLE-CALEDONIE";
+  }
+
+  const foundAcademy = academyList.find((academy) => normalizeString(academy) === normalizeString(convertedAcademy));
+  if (!foundAcademy) {
+    logger.warn(`No academy found for : ${academyCsv} was converted to ${convertedAcademy}`);
+  }
+  return foundAcademy || "NO_ACADEMY";
 };
 
 export const mapDepartmentCode = (departmentCsv: string) => {

--- a/api/src/cohesionCenter/import/cohesionCenterImportMapper.ts
+++ b/api/src/cohesionCenter/import/cohesionCenterImportMapper.ts
@@ -9,11 +9,11 @@ export const mapCohesionCentersForSept2024 = (cohesionCenters: CohesionCenterCSV
       address: cohesionCenter.Adresse,
       city: cohesionCenter.Commune,
       zip: cohesionCenter["Code postal"],
-      department: mapDepartment(cohesionCenter["Département"]),
+      department: mapDepartment(cohesionCenter["Département"], "name"),
       region: mapRegion(cohesionCenter["Région académique"]),
       placesTotal: parseInt(cohesionCenter["Capacité d'accueil Maximale"]),
       pmr: cohesionCenter["Acceuil PMR"] === "TRUE" ? "true" : "false",
-      academy: cohesionCenter.Académie,
+      academy: mapAcademy(cohesionCenter.Académie),
       typology: mapTypology(cohesionCenter["Typologie du centre"]),
       domain: mapDomain(cohesionCenter["Domaine d'activité"]),
       complement: cohesionCenter["Complément adresse"],
@@ -22,7 +22,7 @@ export const mapCohesionCentersForSept2024 = (cohesionCenters: CohesionCenterCSV
       COR: cohesionCenter["Organisme de rattachement"],
       code: cohesionCenter["Matricule du Centre"],
       code2022: cohesionCenter["Matricule du Centre"],
-      departmentCode: mapDepartmentCode(cohesionCenter["Département"]),
+      departmentCode: mapDepartment(cohesionCenter["Département"], "code"),
       matricule: cohesionCenter["Matricule du Centre"],
     };
     if (cohesionCenter["ID temporaire"]) {
@@ -70,26 +70,6 @@ export const mapRegion = (regionCsv: string) => {
   return foundRegion || "NO_REGION";
 };
 
-export const mapDepartment = (departmentCsv: string) => {
-  let convertedDepartment = departmentCsv;
-
-  if (departmentCsv === "COTE D'OR") {
-    convertedDepartment = "COTE-D'OR";
-  }
-  if (departmentCsv === "COTES D'ARMOR") {
-    convertedDepartment = "COTES-D'ARMOR";
-  }
-  if (departmentCsv === "NOUVELLE CALEDONIE") {
-    convertedDepartment = "NOUVELLE-CALEDONIE";
-  }
-
-  const foundDepartment = departmentList.find((dep) => normalizeString(dep) === normalizeString(convertedDepartment));
-  if (!foundDepartment) {
-    logger.warn(`No department found for : ${departmentCsv} was converted to ${convertedDepartment}`);
-  }
-  return foundDepartment || "NO_DEPARTMENT";
-};
-
 export const mapAcademy = (academyCsv: string) => {
   let convertedAcademy = academyCsv;
 
@@ -104,7 +84,7 @@ export const mapAcademy = (academyCsv: string) => {
   return foundAcademy || "NO_ACADEMY";
 };
 
-export const mapDepartmentCode = (departmentCsv: string) => {
+export const mapDepartment = (departmentCsv: string, type: string) => {
   let department = departmentCsv;
   if (departmentCsv === "COTE D'OR") {
     department = "COTE-D'OR";
@@ -115,11 +95,20 @@ export const mapDepartmentCode = (departmentCsv: string) => {
   if (departmentCsv === "NOUVELLE CALEDONIE") {
     department = "NOUVELLE-CALEDONIE";
   }
-  let departmentCode = Object.keys(departmentLookUp).find((key) => normalizeString(departmentLookUp[key]) === normalizeString(department));
-  if (!departmentCode) {
-    logger.warn(`mapDepartmentCode() - No department code for : ${departmentCsv} was converted to ${department}`);
+  if (type === "code") {
+    let departmentCode = Object.keys(departmentLookUp).find((key) => normalizeString(departmentLookUp[key]) === normalizeString(department));
+    if (!departmentCode) {
+      logger.warn(`mapDepartmentCode() - No department code for : ${departmentCsv} was converted to ${department}`);
+    }
+    return departmentCode || "NO_DEPARTMENT";
+  } else if (type === "name") {
+    let departmentName = Object.values(departmentLookUp).find((value) => normalizeString(value) === normalizeString(department));
+
+    if (!departmentName) {
+      logger.warn(`No department found for : ${departmentCsv} was converted to ${department}`);
+    }
+    return departmentName || "NO_DEPARTMENT";
   }
-  return departmentCode || "NO_DEPARTMENT";
 };
 
 export const mapDomain = (domainCsv: string): CohesionCenterDomainEnum => {


### PR DESCRIPTION
- ajout de mapper dans l'import des centres pour traduire correctement les champ departement et academie des centre
- script de rattrappage sur les centres

Pour tester : 
http://localhost:8082/centre/66943b3ac1fcf9010a7ebc56
ce centre avait ses champ departement et academie en undefined