### PR TITLE
feat(admin,api): 3488 - Gestion des PDR pour gérer les imports

### DIFF
--- a/api/src/__tests__/ligne-de-bus.test.ts
+++ b/api/src/__tests__/ligne-de-bus.test.ts
@@ -26,7 +26,7 @@ const mockModelMethodWithError = (model, method) => {
 beforeAll(dbConnect);
 afterAll(dbClose);
 
-describe("LigneDeBus", () => {
+describe("Ligne de bus", () => {
   describe("GET /all", () => {
     afterEach(async () => {
       await Promise.all([LigneBusModel.deleteMany(), PointDeRassemblementModel.deleteMany(), LigneToPointModel.deleteMany()]);

--- a/api/src/controllers/elasticsearch/lignebus.js
+++ b/api/src/controllers/elasticsearch/lignebus.js
@@ -22,6 +22,17 @@ router.post("/by-point-de-rassemblement/aggs", passport.authenticate(["referent"
           filter: [
             { terms: { "meetingPointsIds.keyword": queryFilters.meetingPointIds } },
             queryFilters.cohort.length ? { terms: { "cohort.keyword": queryFilters.cohort } } : null,
+            { bool: { must_not: { exists: { field: "deletedAt" } } } },
+            {
+              nested: {
+                path: "pointDeRassemblements",
+                query: {
+                  bool: {
+                    must: [{ exists: { field: "pointDeRassemblements.matricule" } }, { bool: { must_not: { exists: { field: "pointDeRassemblements.deletedAt" } } } }],
+                  },
+                },
+              },
+            },
           ].filter(Boolean),
         },
       },
@@ -49,7 +60,7 @@ router.post("/search", passport.authenticate(["referent"], { session: false, fai
   try {
     // Configuration
     const { user, body } = req;
-    const searchFields = ["busId", "pointDeRassemblements.region", "pointDeRassemblements.city", "centerCode", "centerCity", "centerRegion"];
+    const searchFields = ["busId", "pointDeRassemblements.region", "pointDeRassemblements.city", "pointDeRassemblements.matricule", "centerCode", "centerCity", "centerRegion"];
     const filterFields = [
       "busId.keyword",
       "cohort.keyword",
@@ -60,6 +71,7 @@ router.post("/search", passport.authenticate(["referent"], { session: false, fai
       "pointDeRassemblements.department.keyword",
       "pointDeRassemblements.city.keyword",
       "pointDeRassemblements.code.keyword",
+      "pointDeRassemblements.matricule.keyword",
       "centerName.keyword",
       "centerRegion.keyword",
       "centerDepartment.keyword",

--- a/api/src/controllers/elasticsearch/populate/populateYoung.js
+++ b/api/src/controllers/elasticsearch/populate/populateYoung.js
@@ -26,7 +26,9 @@ async function populateYoungExport(data, exportFields) {
     const lignesToPoint = await allRecords("lignetopoint", { bool: { must: { terms: { "meetingPointId.keyword": meetingPointsIds } } } });
     data = data.map((item) => ({ ...item, ligneToPoint: lignesToPoint?.find((e) => e.meetingPointId === item.meetingPointId && e.lineId === item.ligneId) }));
     //get meetingPoint
-    const meetingPoints = await allRecords("pointderassemblement", { bool: { must: { ids: { values: meetingPointsIds } } } });
+    const meetingPoints = await allRecords("pointderassemblement", {
+      bool: { must: [{ ids: { values: meetingPointsIds } }, { exists: { field: "matricule" } }], must_not: { exists: { field: "deleted" } } },
+    });
     data = data.map((item) => ({ ...item, meetingPoint: meetingPoints?.find((e) => e._id.toString() === item.meetingPointId) }));
   }
 

--- a/api/src/controllers/elasticsearch/young.js
+++ b/api/src/controllers/elasticsearch/young.js
@@ -235,6 +235,16 @@ router.post("/by-point-de-rassemblement/aggs", passport.authenticate(["referent"
             { terms: { "meetingPointId.keyword": queryFilters.meetingPointIds } },
             { terms: { "status.keyword": ["VALIDATED"] } },
             queryFilters.cohort.length ? { terms: { "cohort.keyword": queryFilters.cohort } } : null,
+            {
+              nested: {
+                path: "meetingPoint",
+                query: {
+                  bool: {
+                    must: [{ exists: { field: "meetingPoint.matricule" } }, { bool: { must_not: { exists: { field: "meetingPoint.deletedAt" } } } }],
+                  },
+                },
+              },
+            },
           ].filter(Boolean),
         },
       },

--- a/api/src/controllers/planDeTransport/edit-transport.js
+++ b/api/src/controllers/planDeTransport/edit-transport.js
@@ -36,7 +36,7 @@ router.post("/youngs/", passport.authenticate("referent", { session: false, fail
 router.post("/meetingPoints", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
   try {
     if (req.user.role !== "admin") return res.status(401).send({ ok: false, code: ERRORS.UNAUTHORIZED });
-    let meetingPoints = await PointDeRassemblementModel.find({ _id: { $in: [...req.body] } });
+    let meetingPoints = await PointDeRassemblementModel.find({ _id: { $in: [...req.body] }, deletedAt: { $exists: false } });
     if (!meetingPoints || !meetingPoints.length) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
     res.status(200).send({ ok: true, data: meetingPoints });
   } catch (error) {

--- a/api/src/controllers/planDeTransport/ligne-de-bus.js
+++ b/api/src/controllers/planDeTransport/ligne-de-bus.js
@@ -42,7 +42,7 @@ router.get("/all", passport.authenticate("referent", { session: false, failWithE
     const ligneBus = await LigneBusModel.find({ deletedAt: { $exists: false } });
     let arrayMeetingPoints = [];
     ligneBus.map((l) => (arrayMeetingPoints = arrayMeetingPoints.concat(l.meetingPointsIds)));
-    const meetingPoints = await PointDeRassemblementModel.find({ _id: { $in: arrayMeetingPoints } });
+    const meetingPoints = await PointDeRassemblementModel.find({ _id: { $in: arrayMeetingPoints }, deletedAt: { $exists: false } });
     const ligneToPoints = await LigneToPointModel.find({ lineId: { $in: ligneBus.map((l) => l._id) } });
     return res.status(200).send({ ok: true, data: { ligneBus, meetingPoints, ligneToPoints } });
   } catch (error) {

--- a/api/src/controllers/session-phase1.ts
+++ b/api/src/controllers/session-phase1.ts
@@ -420,7 +420,7 @@ router.post("/check-token/:token", async (req: UserRequest, res: Response) => {
       let arrayMeetingPoints: string[] = [];
       ligneBus.map((l) => (arrayMeetingPoints = arrayMeetingPoints.concat(l.meetingPointsIds)));
 
-      const meetingPoints = await PointDeRassemblementModel.find({ _id: { $in: arrayMeetingPoints } });
+      const meetingPoints = await PointDeRassemblementModel.find({ _id: { $in: arrayMeetingPoints }, deletedAt: { $exists: false } });
 
       for (const young of youngs) {
         const tempYoung = {

--- a/api/src/controllers/young/phase1.js
+++ b/api/src/controllers/young/phase1.js
@@ -83,7 +83,7 @@ router.post("/affectation", passport.authenticate("referent", { session: false, 
 
     let bus = null;
     if (meetingPointId) {
-      const meetingPoint = await PointDeRassemblementModel.findById(meetingPointId);
+      const meetingPoint = await PointDeRassemblementModel.findOne({ _id: meetingPointId, deletedAt: { $exists: false } });
       if (!meetingPoint) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
 
       bus = await LigneBusModel.findById(ligneId);

--- a/api/src/controllers/young/point-de-rassemblement.js
+++ b/api/src/controllers/young/point-de-rassemblement.js
@@ -55,7 +55,7 @@ router.put("/", passport.authenticate(["young", "referent"], { session: false, f
 
     //choosing a meetingPoint
     if (meetingPointId) {
-      const meetingPoint = await PointDeRassemblementModel.findById(meetingPointId);
+      const meetingPoint = await PointDeRassemblementModel.findOne({ _id: meetingPointId, deletedAt: { $exists: false } });
       if (!meetingPoint) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
       bus = await LigneBusModel.findById(ligneId);
       if (!bus) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });

--- a/api/src/planDeTransport/pointDeRassemblement/pointDeRassemblementController.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/pointDeRassemblementController.ts
@@ -41,7 +41,7 @@ router.get("/available", passport.authenticate("young", { session: false, failWi
     // - are in a bus line that is affected to the young's session
     // - are in a bus line that still has available seats
 
-    const meetingPointsInSameDepartment = await PointDeRassemblementModel.find({ department: req.user.department });
+    const meetingPointsInSameDepartment = await PointDeRassemblementModel.find({ department: req.user.department, deletedAt: { $exists: false } });
 
     // get all buses to cohesion center using previous meeting points, find used meeting points with hours and get a new meeting point list
     let meetingPointIds = meetingPointsInSameDepartment.map((m) => m._id.toString());

--- a/api/src/services/dashboard/todo-sejour.service.js
+++ b/api/src/services/dashboard/todo-sejour.service.js
@@ -78,6 +78,8 @@ service[DASHBOARD_TODOS_FUNCTIONS.SEJOUR.MEETING_POINT_TO_DECLARE] = async (user
             queryFromFilter(user.role, user.region, user.department, [
               { terms: { "cohort.keyword": [cohort] } },
               { terms: { "department.keyword": departmentsCohortsFromRepartition.filter((e) => e.cohort === cohort).map((e) => e.fromDepartment) } },
+              { exists: { field: "matricule" } },
+              { bool: { must_not: { exists: { field: "deleted" } } } },
             ]),
             "department.keyword",
           ),


### PR DESCRIPTION
**Description**

- Ajout des filtres (matricule et deletedAt) afin de distinguer les PDRs existants de ceux importés, ces derniers étant considérés comme source de vérité.

**Ticket / Issue**


[Notion ticket #3488](https://www.notion.so/jeveuxaider/MAJ-back-des-points-de-rassemblements-11872a322d50803e8715eb98702f95e8)

Todo

- depends on #4388 