### PR TITLE
fix(lib): 3535 - retirer le required sur l'academie des PDR pour Toussaint

### DIFF
--- a/api/migrations/20241011121242-rattrappage_PDR_Academie.js
+++ b/api/migrations/20241011121242-rattrappage_PDR_Academie.js
@@ -1,11 +1,11 @@
-const { PointDeRassemblementModel } = require("../src/models");
+const { PointDeRassemblementModel, PlanTransportModel } = require("../src/models");
 const { departmentToAcademy } = require("snu-lib");
 const { logger } = require("../src/logger");
 
 module.exports = {
   async up(db, client) {
-    const PointDeRassemblements = await PointDeRassemblementModel.find({ academie: { $exists: false } });
-    for (const pointDeRassemblement of PointDeRassemblements) {
+    const pointDeRassemblements = await PointDeRassemblementModel.find({ academie: { $exists: false } });
+    for (const pointDeRassemblement of pointDeRassemblements) {
       let academie = departmentToAcademy[pointDeRassemblement.department];
       if (!academie) {
         logger.error(`No academy found for department ${pointDeRassemblement.department}`);
@@ -14,6 +14,21 @@ module.exports = {
       }
       pointDeRassemblement.set({ academie });
       await pointDeRassemblement.save({ fromUser: { firstName: "Migration mapper department to academy for pointDeRassemblement" } });
+    }
+
+    const planDeTransports = await PlanTransportModel.find({ cohort: "Toussaint 2024" });
+    for (const planDeTransport of planDeTransports) {
+      const pointDeRassemblements = planDeTransport.pointDeRassemblements;
+      for (const pointDeRassemblement of pointDeRassemblements) {
+        let academie = departmentToAcademy[pointDeRassemblement.department];
+        if (!academie) {
+          logger.error(`No academy found for department ${pointDeRassemblement.department}`);
+          academie = "NO_ACADEMY";
+          continue;
+        }
+        pointDeRassemblement.academie = academie;
+      }
+      await planDeTransport.save({ fromUser: { firstName: "Migration mapper department to academy for pointDeRassemblement in planDeTransport" } });
     }
   },
 };

--- a/api/migrations/20241011121242-rattrappage_PDR_Academie.js
+++ b/api/migrations/20241011121242-rattrappage_PDR_Academie.js
@@ -1,0 +1,19 @@
+const { PointDeRassemblementModel } = require("../src/models");
+const { departmentToAcademy } = require("snu-lib");
+const { logger } = require("../src/logger");
+
+module.exports = {
+  async up(db, client) {
+    const PointDeRassemblements = await PointDeRassemblementModel.find({ academie: { $exists: false } });
+    for (const pointDeRassemblement of PointDeRassemblements) {
+      let academie = departmentToAcademy[pointDeRassemblement.department];
+      if (!academie) {
+        logger.error(`No academy found for department ${pointDeRassemblement.department}`);
+        academie = "NO_ACADEMY";
+        continue;
+      }
+      pointDeRassemblement.set({ academie });
+      await pointDeRassemblement.save({ fromUser: { firstName: "Migration mapper department to academy for pointDeRassemblement" } });
+    }
+  },
+};

--- a/packages/lib/src/mongoSchema/planDeTransport/pointDeRassemblement.ts
+++ b/packages/lib/src/mongoSchema/planDeTransport/pointDeRassemblement.ts
@@ -119,9 +119,8 @@ export const PointDeRassemblementSchema = {
   },
 
   academie: {
-    //TODO: remettre required apres la Toussaint
     type: String,
-    //required: true,
+    required: true,
     documentation: {
       description: "Académie du point de rassemblement",
     },

--- a/packages/lib/src/mongoSchema/planDeTransport/pointDeRassemblement.ts
+++ b/packages/lib/src/mongoSchema/planDeTransport/pointDeRassemblement.ts
@@ -119,8 +119,9 @@ export const PointDeRassemblementSchema = {
   },
 
   academie: {
+    //TODO: remettre required apres la Toussaint
     type: String,
-    required: true,
+    //required: true,
     documentation: {
       description: "Académie du point de rassemblement",
     },


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/HTS-Toussaint-Impossibilit-de-modifier-les-capacit-s-des-lignes-de-transport-du-PDT-11c72a322d5080a58633fb2c57efe616?pvs=4

On ne pouvait pas modifier une ligne de bus (et donc un planDeTransport) car le champ academie des pdr etaient required, et certains pdr de Toussaint n'en ont pas.
