### PR TITLE
fix(lib): 3536 - vérification des objectifs pour les jeunes résidant à l'étranger

### DIFF
--- a/api/src/__tests__/application.test.ts
+++ b/api/src/__tests__/application.test.ts
@@ -22,10 +22,11 @@ jest.mock("../brevo", () => ({
 
 beforeAll(() => dbConnect(__filename.slice(__dirname.length + 1, -3)));
 afterAll(dbClose);
+afterEach(resetAppAuth);
 
 describe("Application", () => {
-  afterEach(resetAppAuth);
   describe("POST /application", () => {
+    beforeEach(resetAppAuth);
     it("should return 404 when young is not found", async () => {
       const application = getNewApplicationFixture();
       const res = await request(getAppHelper())
@@ -55,7 +56,7 @@ describe("Application", () => {
       expect(res.status).toBe(200);
       expect(res.body.data.youngId).toBe(young._id.toString());
     });
-    it("should not allow young to apply for pohers", async () => {
+    it("should not allow young to apply for others", async () => {
       const cohort = await createCohortHelper(getNewCohortFixture({ name: "Test" }));
       const young = await createYoungHelper(getNewYoungFixture({ cohort: cohort.name, cohortId: cohort._id, statusPhase1: YOUNG_STATUS_PHASE1.DONE }));
       const secondYoung = await createYoungHelper(getNewYoungFixture({ cohort: cohort.name, cohortId: cohort._id, statusPhase1: YOUNG_STATUS_PHASE1.DONE }));

--- a/api/src/__tests__/cohort-session.test.ts
+++ b/api/src/__tests__/cohort-session.test.ts
@@ -8,7 +8,7 @@ import { COHORT_TYPE, ERRORS, GRADES, ROLES, YOUNG_STATUS } from "snu-lib";
 
 import { CohortModel } from "../models";
 import { dbConnect, dbClose } from "./helpers/db";
-import getAppHelper from "./helpers/app";
+import getAppHelper, { resetAppAuth } from "./helpers/app";
 
 // young
 import getNewYoungFixture from "./fixtures/young";
@@ -25,6 +25,7 @@ describe("Cohort Session Controller", () => {
   beforeEach(async () => {
     await CohortModel.deleteMany({});
   });
+  afterEach(resetAppAuth);
 
   describe("POST /cohort-session/eligibility/:year", () => {
     // TODO: move auth young tests to preinscription
@@ -102,7 +103,7 @@ describe("Cohort Session Controller", () => {
       );
       const timeZoneOffset = -24 * 3600; // 24 hours in seconds
       // avec un header x-user-timezone
-      const response = await request(getAppHelper(null, "young")).post(`/cohort-session/eligibility/2023`).set("x-user-timezone", String(timeZoneOffset)).send(young);
+      const response = await request(getAppHelper()).post(`/cohort-session/eligibility/2023`).set("x-user-timezone", String(timeZoneOffset)).send(young);
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
       expect(Array.isArray(response.body.data)).toBe(true);

--- a/api/src/__tests__/fixtures/young.ts
+++ b/api/src/__tests__/fixtures/young.ts
@@ -21,7 +21,7 @@ export default function getNewYoungFixture(fields: Partial<YoungType> = {}): Par
     birthCountry: faker.location.country(),
     birthCity: faker.location.city(),
     birthCityZip: faker.location.zipCode(),
-    email: faker.internet.email({ firstName: faker.lorem.words[0], lastName: faker.lorem.words[1] }).toLowerCase(),
+    email: faker.internet.email({ firstName: faker.person.firstName(), lastName: faker.person.lastName() }).toLowerCase(),
     phone: faker.phone.number(),
     phoneZone: "FRANCE",
     gender: faker.person.gender(),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -15,8 +15,8 @@
     "lint": "eslint ./src --ext .js,.ts",
     "lint:fix": "eslint ./src --ext .js,.ts --fix",
     "lint:report": "eslint ./src --ext .js,.ts --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
-    "test": "jest --env=node --detectOpenHandles --verbose --forceExit --testTimeout=20000 --maxWorkers=2",
-    "coverage": "jest --runInBand --coverage --silent",
+    "test": "jest --env=node --detectOpenHandles --verbose --forceExit --testTimeout=20000 --maxWorkers=3",
+    "coverage": "jest --coverage --silent",
     "clean": "rm -fr node_modules .turbo common-js dist .rollup.cache coverage"
   },
   "author": "",

--- a/packages/lib/src/region-and-departments.spec.ts
+++ b/packages/lib/src/region-and-departments.spec.ts
@@ -1,0 +1,87 @@
+import { YoungType } from "src";
+import { getDepartmentForEligibility, getRegionForEligibility } from "./region-and-departments";
+
+describe("getDepartmentForEligibility", () => {
+  it("when young is schooled should return the school department", () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "true", schoolDepartment: "TestDepartment" };
+    expect(getDepartmentForEligibility(young)).toBe("TestDepartment");
+  });
+
+  it("when young is not schooled and doesn't have school department should returns the department", () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "false", department: "TestDepartment" };
+    expect(getDepartmentForEligibility(young)).toBe("TestDepartment");
+  });
+
+  it("when the both are available and the young is schooled should returns the school department", () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "true", schoolDepartment: "SchoolDepartment", department: "Department" };
+    expect(getDepartmentForEligibility(young)).toBe("SchoolDepartment");
+  });
+
+  it("when the both are available should return the school department", () => {
+    const young: Partial<YoungType> = { _id: "123", schoolDepartment: "SchoolDepartment", department: "Department" };
+    expect(getDepartmentForEligibility(young)).toBe("SchoolDepartment");
+  });
+
+  it("when school country is not FRANCE should department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "youngDepartment", schoolCountry: "ESPAGNE", schoolDepartment: "134" };
+    expect(getDepartmentForEligibility(young)).toBe("youngDepartment");
+  });
+
+  it("when school country is not FRANCE and schooled should department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "youngDepartment", schooled: "true", schoolCountry: "ESPAGNE", schoolDepartment: "134" };
+    expect(getDepartmentForEligibility(young)).toBe("youngDepartment");
+  });
+
+  it('when department not found should returns "Etranger"', () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "false" };
+    expect(getDepartmentForEligibility(young)).toBe("Etranger");
+  });
+
+  it("when department prepended with 0 should return good department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "044" };
+    expect(getDepartmentForEligibility(young)).toBe("Loire-Atlantique");
+  });
+
+  it("when department corse with return good department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "2A" };
+    expect(getDepartmentForEligibility(young)).toBe("Corse-du-Sud");
+  });
+});
+
+describe("getRegionForEligibility", () => {
+  it("should return schoolRegion if young is schooled", () => {
+    const young: Partial<YoungType> = {
+      schooled: "true",
+      schoolRegion: "TestRegion",
+      region: "AnotherRegion",
+      department: "TestDepartment",
+      schoolDepartment: "AnotherDepartment",
+      schoolCountry: "TestCountry",
+      zip: "12345",
+    };
+
+    expect(getRegionForEligibility(young)).toBe("TestRegion");
+  });
+
+  it("should return region if young is not schooled", () => {
+    const young: Partial<YoungType> = {
+      schooled: "false",
+      schoolRegion: "TestRegion",
+      region: "AnotherRegion",
+      department: "TestDepartment",
+      schoolDepartment: "AnotherDepartment",
+      schoolCountry: "TestCountry",
+      zip: "12345",
+    };
+
+    expect(getRegionForEligibility(young)).toBe("AnotherRegion");
+  });
+
+  it('should return "Etranger" if no region is available', () => {
+    const young: Partial<YoungType> = {
+      schooled: "false",
+    };
+
+    expect(getRegionForEligibility(young)).toBe("Etranger");
+  });
+});

--- a/packages/lib/src/region-and-departments.ts
+++ b/packages/lib/src/region-and-departments.ts
@@ -342,26 +342,25 @@ const region2zone = {
   Etranger: "Etranger",
 };
 
-const getRegionForEligibility = (young: Pick<YoungType, "schooled" | "schoolRegion" | "region" | "department" | "schoolDepartment" | "zip">) => {
+const getRegionForEligibility = (young: Pick<YoungType, "schooled" | "schoolRegion" | "region" | "department" | "schoolDepartment" | "schoolCountry" | "zip">) => {
   let region = young.schooled === "true" ? young.schoolRegion : young.region;
   if (!region) {
-    let dep = young?.schoolDepartment || young?.department || getDepartmentByZip(young?.zip);
-    if (dep && (!isNaN(dep) || ["2A", "2B", "02A", "02B"].includes(dep))) {
-      if (dep.substring(0, 1) === "0" && dep.length === 3) dep = departmentLookUp[dep.substring(1)];
-      else dep = departmentLookUp[dep];
-    }
+    const dep = getDepartmentForEligibility(young);
     region = department2region[dep] || getRegionByZip(young?.zip);
   }
   if (!region) region = "Etranger";
   return region;
 };
 
-const getDepartmentForEligibility = (young: Pick<YoungType, "schooled" | "schoolRegion" | "region" | "department" | "schoolDepartment" | "zip"> & { _id?: YoungType["_id"] }) => {
+const getDepartmentForEligibility = (
+  young: Pick<YoungType, "schooled" | "schoolRegion" | "region" | "department" | "schoolDepartment" | "schoolCountry" | "zip"> & { _id?: YoungType["_id"] },
+) => {
   let dep;
-  if (young._id && young.schooled === "true") dep = young.schoolDepartment;
+  const schoolDepartment = !young?.schoolCountry || young.schoolCountry === "FRANCE" ? young?.schoolDepartment : null;
+  if (young._id && young.schooled === "true") dep = schoolDepartment;
   if (young._id && young.schooled === "false") dep = young.department;
 
-  if (!dep) dep = young?.schoolDepartment || young?.department || getDepartmentByZip(young?.zip);
+  if (!dep) dep = schoolDepartment || young?.department || getDepartmentByZip(young?.zip);
   if (dep && (!isNaN(dep) || ["2A", "2B", "02A", "02B"].includes(dep))) {
     if (dep.substring(0, 1) === "0" && dep.length === 3) dep = departmentLookUp[dep.substring(1)];
     else dep = departmentLookUp[dep];


### PR DESCRIPTION
**Description**

Changer la fonction de récupération du département (qui est partagé avec l'éligibilité) pour regarder le pays de scolarisation et ainsi ignorer le département de scolarisation si ce n'est pas la france.

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

https://www.notion.so/jeveuxaider/v-rification-des-objectifs-pour-les-jeunes-r-sidant-l-tranger-11c72a322d508091b4aceb4630c0f12f?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
