### PR TITLE
chore(api): ajout d'un cron pour check la coherence des cohortId

### DIFF
--- a/api/src/crons/__tester__.ts
+++ b/api/src/crons/__tester__.ts
@@ -1,11 +1,11 @@
 // To test run:
-// ts-node ./src/crons/__tester__.js patch/young
+// ts-node ./src/crons/__tester__.ts patch/young
 
 // uncomment when running in local
 // process.env["NODE_CONFIG_DIR"] = "<RELATIVE PATH>/service-national-universel/api/config/";
 
-require("config");
-const { initDB } = require("../mongo");
+import config from "config";
+import { initDB } from "../mongo";
 
 // You need to run in local apps and target the right database (Prod usually)
 
@@ -40,6 +40,11 @@ const { initDB } = require("../mongo");
     case "goal":
       await require("./computeGoalsInscription").handler();
       break;
+    case "check-coherence":
+      await require("./checkCoherence").handler();
+      break;
+    default:
+      console.log("No cron found for " + process.argv[2]);
   }
   process.exit(0);
 })();

--- a/api/src/crons/checkCoherence.ts
+++ b/api/src/crons/checkCoherence.ts
@@ -1,0 +1,84 @@
+import { YoungModel } from "../models";
+import { logger } from "../logger";
+import { capture } from "../sentry";
+import slack from "../slack";
+
+export const handler = async () => {
+  try {
+    // get all young without cohortId
+    const youngs = await YoungModel.find({ cohort: { $exists: true }, cohortId: { $exists: false } }).select({ _id: 1, cohort: 1 });
+
+    if (youngs.length > 0) {
+      const youngsCountByCohort = youngs.reduce((acc, cur) => {
+        acc[cur.cohort!] = (acc[cur.cohort!] || 0) + 1;
+        return acc;
+      }, {});
+      logger.info(`Young without cohortId: ${youngs.length}, cohorts: ${JSON.stringify(youngsCountByCohort)}`);
+      await slack.error({
+        title: "CheckCoherence",
+        text: `Young without cohortId: ${youngs.length}, cohorts: ${JSON.stringify(youngsCountByCohort)}`,
+      });
+    } else {
+      logger.debug("CheckCoherence: No youngs without cohortId");
+    }
+
+    // get all young with cohort not corresponding to cohortId
+    const cohortIncoherence = (await YoungModel.aggregate([
+      {
+        $addFields: {
+          convertedId: {
+            $toObjectId: "$cohortId",
+          },
+        },
+      },
+      {
+        $lookup: {
+          as: "cohortByName",
+          from: "cohorts",
+          foreignField: "name",
+          localField: "cohort",
+        },
+      },
+      {
+        $unwind: "$cohortByName",
+      },
+      {
+        $addFields: {
+          cohortByNameId: "$cohortByName._id",
+        },
+      },
+      {
+        $match: {
+          cohortId: { $exists: true },
+          $expr: { $ne: ["$convertedId", "$cohortByNameId"] },
+        },
+      },
+      {
+        $project: {
+          _id: 1,
+          cohortId: 1,
+          cohort: 1,
+          convertedId: 1,
+          cohortByNameId: 1,
+        },
+      },
+    ]).exec()) as { _id: string; cohortId: string; cohort: string; convertedId: string; cohortByNameId: string }[];
+    if (cohortIncoherence.length > 0) {
+      const youngsCountByCohort = youngs.reduce((acc, cur) => {
+        acc[cur.cohort!] = (acc[cur.cohort!] || 0) + 1;
+        return acc;
+      }, {});
+      logger.info(`Young with incoherent cohortId: ${cohortIncoherence.length}, cohorts: ${JSON.stringify(youngsCountByCohort)}`);
+      await slack.error({
+        title: "CheckCoherence",
+        text: `Young with incoherent cohortId: ${cohortIncoherence.length}, cohorts: ${JSON.stringify(youngsCountByCohort)}`,
+      });
+    } else {
+      logger.debug("CheckCoherence: No youngs with incoherent cohortId");
+    }
+  } catch (e) {
+    capture(e);
+    slack.error({ title: "CheckCoherence", text: JSON.stringify(e) });
+    throw e;
+  }
+};

--- a/api/src/crons/index.js
+++ b/api/src/crons/index.js
@@ -28,6 +28,7 @@ const clotureMissionReminder = require("./clotureInscriptionReminder");
 const deleteCNIAdnSpecificAmenagementType = require("./deleteCNIAndSpecificAmenagementType");
 const mongoMonitoring = require("./mongoMonitoring");
 const classesStatusUpdate = require("./classesStatusUpdate");
+const checkCoherence = require("./checkCoherence");
 
 // doubt ? -> https://crontab.guru/
 
@@ -109,6 +110,7 @@ const CRONS = [
   cron("syncContactSupport", "15 1 * * *", syncContactSupport.handler),
   cron("mongoMonitoring", "*/5 * * * *", mongoMonitoring.handler),
   cron("classesStatusUpdate", "2 */1 * * *", classesStatusUpdate.handler),
+  cron("checkCoherence", "30 8,13,17 * * *", checkCoherence.handler),
 ];
 
 module.exports = CRONS;


### PR DESCRIPTION
**Description**

Suite à la detection de plusieurs incohérences entre le champ `cohort` et `cohortId` chez les jeunes, cette PR vise à rajouter un controle de cohérence des données 3 fois par jour afin d'alerter de ces problèmes qui peuvent être critique par la suite.

**Todo**

- [x] Vérification de l'existence du champ `cohortId`
- [x] Vérification que `cohort` (name) correspond bien à l'id indiqué 

**Ticket / Issue**

<!-- If you have a Notion Ticket / GitHub Issue -->
<!-- Fixes [Notion ticket #123](https://notion.so/abc) -->

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
