### PR TITLE
fix(api): 3542 - verification objectif affectation manuel

### DIFF
--- a/admin/src/scenes/volontaires/components/ModalAffectation.jsx
+++ b/admin/src/scenes/volontaires/components/ModalAffectation.jsx
@@ -115,7 +115,10 @@ export default function ModalAffectations({ isOpen, onCancel, young, center = nu
         meetingPointId: selectedPdr?.pdr._id,
         ligneId: selectedPdr?.data.ligneBus._id,
       });
-      if (!response.ok) return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune", translate(response.code));
+      if (!response.ok)
+        return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune", translate(response.code), {
+          timeOut: 10000,
+        });
       /*
       await api.post(`/young/${young._id}/email/${SENDINBLUE_TEMPLATES.young.PHASE_1_AFFECTATION}`);
       */

--- a/admin/src/scenes/volontaires/components/ModalAffectation.jsx
+++ b/admin/src/scenes/volontaires/components/ModalAffectation.jsx
@@ -13,7 +13,7 @@ import { MultiLine } from "../../../components/list";
 import ModalConfirm from "../../../components/modals/ModalConfirm";
 import ModalTailwind from "../../../components/modals/ModalTailwind";
 import api from "../../../services/api";
-import { debounce, formatDateFR, getZonedDate, translate } from "../../../utils";
+import { debounce, formatDateFR, FUNCTIONAL_ERRORS, getZonedDate, translate } from "../../../utils";
 import RightArrow from "./RightArrow";
 import MeetingInfo from "./phase1/MeetingInfo";
 
@@ -115,10 +115,11 @@ export default function ModalAffectations({ isOpen, onCancel, young, center = nu
         meetingPointId: selectedPdr?.pdr._id,
         ligneId: selectedPdr?.data.ligneBus._id,
       });
-      if (!response.ok)
+      if (!response.ok) {
         return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune", translate(response.code), {
           timeOut: 10000,
         });
+      }
       /*
       await api.post(`/young/${young._id}/email/${SENDINBLUE_TEMPLATES.young.PHASE_1_AFFECTATION}`);
       */
@@ -126,10 +127,15 @@ export default function ModalAffectations({ isOpen, onCancel, young, center = nu
       toastr.success(`L'affectation du jeune a bien été effectuée`);
       history.go(`/volontaire/${young._id}/phase1`);
     } catch (error) {
-      if (error.code === "OPERATION_NOT_ALLOWED")
+      if (error.code === "OPERATION_NOT_ALLOWED") {
         return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune. Il semblerait que ce centre soit déjà complet", translate(error?.code), {
           timeOut: 5000,
         });
+      } else if (error.code === FUNCTIONAL_ERRORS.INSCRIPTION_GOAL_REACHED) {
+        return toastr.error("Vous ne pouvez pas affecter ce jeune", translate(error.code), {
+          timeOut: 10000,
+        });
+      }
       return toastr.error("Oups, une erreur est survenue lors du traitement de l'affectation du jeune", translate(error?.code));
     }
   };

--- a/admin/src/scenes/volontaires/components/ModalChangePDRSameLine.jsx
+++ b/admin/src/scenes/volontaires/components/ModalChangePDRSameLine.jsx
@@ -49,7 +49,10 @@ export default function ModalChangePDRSameLine({ isOpen, onCancel, young, cohort
         meetingPointId: selectedPdr?._id,
         ligneId: bus?._id,
       });
-      if (!response.ok) return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune", translate(response.code));
+      if (!response.ok)
+        return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune", translate(response.code), {
+          timeOut: 10000,
+        });
       toastr.success(`L'affectation du jeune a bien été effectuée`);
       history.go(`/volontaire/${young._id}/phase1`);
     } catch (error) {

--- a/admin/src/scenes/volontaires/components/ModalChangePDRSameLine.jsx
+++ b/admin/src/scenes/volontaires/components/ModalChangePDRSameLine.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { toastr } from "react-redux-toastr";
-import { formatDateFR, getZonedDate, translate } from "snu-lib";
+import { formatDateFR, FUNCTIONAL_ERRORS, getZonedDate, translate } from "snu-lib";
 import LinearIceBerg from "../../../assets/Linear-IceBerg";
 import LinearMap from "../../../assets/Linear-Map";
 import ModalTailwind from "../../../components/modals/ModalTailwind";
@@ -49,17 +49,24 @@ export default function ModalChangePDRSameLine({ isOpen, onCancel, young, cohort
         meetingPointId: selectedPdr?._id,
         ligneId: bus?._id,
       });
-      if (!response.ok)
+      if (!response.ok) {
         return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune", translate(response.code), {
           timeOut: 10000,
         });
+      }
       toastr.success(`L'affectation du jeune a bien été effectuée`);
       history.go(`/volontaire/${young._id}/phase1`);
     } catch (error) {
-      if (error.code === "OPERATION_NOT_ALLOWED")
+      console.log(error);
+      if (error.code === "OPERATION_NOT_ALLOWED") {
         return toastr.error("Oups, une erreur est survenue lors de l'affectation du jeune. Il semblerait que ce centre soit déjà complet", translate(error?.code), {
           timeOut: 5000,
         });
+      } else if (error.code === FUNCTIONAL_ERRORS.INSCRIPTION_GOAL_REACHED) {
+        return toastr.error("Vous ne pouvez pas affecter ce jeune", translate(error.code), {
+          timeOut: 10000,
+        });
+      }
       return toastr.error("Oups, une erreur est survenue lors du traitement de l'affectation du jeune", translate(error?.code));
     }
   };

--- a/api/src/__tests__/fixtures/young.ts
+++ b/api/src/__tests__/fixtures/young.ts
@@ -21,7 +21,7 @@ export default function getNewYoungFixture(fields: Partial<YoungType> = {}): Par
     birthCountry: faker.location.country(),
     birthCity: faker.location.city(),
     birthCityZip: faker.location.zipCode(),
-    email: faker.internet.email({ firstName: faker.person.firstName(), lastName: faker.person.lastName() }).toLowerCase(),
+    email: faker.internet.email({ firstName: faker.person.firstName(), lastName: faker.string.uuid() }).toLowerCase(),
     phone: faker.phone.number(),
     phoneZone: "FRANCE",
     gender: faker.person.gender(),

--- a/api/src/__tests__/helpers/app.ts
+++ b/api/src/__tests__/helpers/app.ts
@@ -17,6 +17,7 @@ export function resetAppAuth() {
   passport.user = getNewReferentFixture();
   // @ts-ignore
   passport.user._id = new ObjectId();
+  // @ts-ignore
   passport.authStrategy = undefined;
   // passport.lastTypeCalledOnAuthenticate = undefined;
 }

--- a/api/src/__tests__/young-phase1.test.ts
+++ b/api/src/__tests__/young-phase1.test.ts
@@ -1,0 +1,80 @@
+import request from "supertest";
+import { Types } from "mongoose";
+const { ObjectId } = Types;
+
+import { FUNCTIONAL_ERRORS, YOUNG_STATUS } from "snu-lib";
+
+import { LigneBusModel } from "../models";
+
+import { dbConnect, dbClose } from "./helpers/db";
+import getAppHelper from "./helpers/app";
+
+import getNewYoungFixture from "./fixtures/young";
+import { createYoungHelper } from "./helpers/young";
+import { createCohortHelper } from "./helpers/cohort";
+import getNewCohortFixture from "./fixtures/cohort";
+import { createSessionPhase1 } from "./helpers/sessionPhase1";
+import { getNewSessionPhase1Fixture } from "./fixtures/sessionPhase1";
+import getNewLigneBusFixture from "./fixtures/PlanDeTransport/ligneBus";
+import { createPointDeRassemblementHelper } from "./helpers/PlanDeTransport/pointDeRassemblement";
+import getNewPointDeRassemblementFixture from "./fixtures/PlanDeTransport/pointDeRassemblement";
+import { createInscriptionGoal } from "./helpers/inscriptionGoal";
+import getNewInscriptionGoalFixture from "./fixtures/inscriptionGoal";
+
+beforeAll(() => dbConnect(__filename.slice(__dirname.length + 1, -3)));
+afterAll(dbClose);
+
+describe("Young Phase1 Controller", () => {
+  describe("POST /young/:id/phase1/affectation", () => {
+    it("should update validated young", async () => {
+      const cohort = await createCohortHelper(getNewCohortFixture({ manualAffectionOpenForAdmin: true }));
+      const young = await createYoungHelper(getNewYoungFixture({ status: YOUNG_STATUS.VALIDATED, cohort: cohort.name, cohortId: cohort._id }));
+      const sessionPhase1 = await createSessionPhase1(getNewSessionPhase1Fixture({ cohort: cohort.name, cohortId: cohort._id, cohesionCenterId: new ObjectId().toString() }));
+      const ligneBus = await LigneBusModel.create(
+        getNewLigneBusFixture({ sessionId: sessionPhase1._id, centerId: sessionPhase1.cohesionCenterId, cohort: sessionPhase1.cohort, cohortId: sessionPhase1.cohortId }),
+      );
+      const pointDeRassemblement = await createPointDeRassemblementHelper(getNewPointDeRassemblementFixture());
+
+      const res = await request(getAppHelper()).post(`/young/${young._id.toString()}/phase1/affectation`).send({
+        centerId: cohort._id,
+        sessionId: sessionPhase1._id,
+        meetingPointId: pointDeRassemblement._id,
+        ligneId: ligneBus._id,
+        id: young._id,
+        pdrOption: "ref-select",
+      });
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.ok).toEqual(true);
+    });
+
+    it("should not update waiting_list young and goal reached", async () => {
+      const cohort = await createCohortHelper(getNewCohortFixture({ name: "youngCohort", manualAffectionOpenForAdmin: true }));
+      const young = await createYoungHelper(
+        getNewYoungFixture({ status: YOUNG_STATUS.WAITING_LIST, cohort: cohort.name, cohortId: cohort._id, department: "Loire-Atlantique", schoolDepartment: "Loire-Atlantique" }),
+      );
+      const sessionPhase1 = await createSessionPhase1(
+        getNewSessionPhase1Fixture({ cohort: cohort.name, cohortId: cohort._id, cohesionCenterId: new ObjectId().toString(), department: young.department }),
+      );
+      const ligneBus = await LigneBusModel.create(
+        getNewLigneBusFixture({ sessionId: sessionPhase1._id, centerId: sessionPhase1.cohesionCenterId, cohort: sessionPhase1.cohort, cohortId: sessionPhase1.cohortId }),
+      );
+      const pointDeRassemblement = await createPointDeRassemblementHelper(getNewPointDeRassemblementFixture());
+
+      await createYoungHelper(getNewYoungFixture({ status: YOUNG_STATUS.VALIDATED, department: young.department, cohort: young.cohort, cohortId: young.cohortId }));
+      await createInscriptionGoal(getNewInscriptionGoalFixture({ department: young.department, cohort: young.cohort, max: 1 }));
+
+      const response = await request(getAppHelper()).post(`/young/${young._id.toString()}/phase1/affectation`).send({
+        centerId: cohort._id,
+        sessionId: sessionPhase1._id,
+        meetingPointId: pointDeRassemblement._id,
+        ligneId: ligneBus._id,
+        id: young._id,
+        pdrOption: "ref-select",
+      });
+
+      expect(response.statusCode).not.toEqual(200);
+      expect(response.body.code).toBe(FUNCTIONAL_ERRORS.INSCRIPTION_GOAL_REACHED);
+    });
+  });
+});

--- a/api/src/controllers/young/index.js
+++ b/api/src/controllers/young/index.js
@@ -1128,7 +1128,7 @@ router.get("/file/:youngId/:key/:fileName", passport.authenticate("young", { ses
 router.use("/:id/documents", require("./documents"));
 router.use("/:id/meeting-point", require("./meeting-point"));
 router.use("/:id/session", require("./session"));
-router.use("/:id/phase1", require("./phase1"));
+router.use("/:id/phase1", require("./phase1").default);
 router.use("/:id/phase2", require("./phase2"));
 router.use("/reinscription", require("./reinscription"));
 router.use("/inscription2023", require("./inscription2023"));

--- a/api/src/controllers/young/phase1.ts
+++ b/api/src/controllers/young/phase1.ts
@@ -5,11 +5,10 @@
  *   POST  /young/:youngId/phase1/dispense        -> Passe le statut d'un jeune en dispensé
  */
 
-const express = require("express");
-const passport = require("passport");
-const Joi = require("joi");
-
-const {
+import express from "express";
+import passport from "passport";
+import Joi from "joi";
+import {
   canEditPresenceYoung,
   ROLES,
   canAssignManually,
@@ -18,27 +17,22 @@ const {
   YOUNG_STATUS_PHASE1,
   REFERENT_DEPARTMENT_SUBROLE,
   getDepartmentByZip,
-} = require("snu-lib");
-
-const config = require("config");
-const { capture } = require("../../sentry");
-const { sendTemplate } = require("../../brevo");
-
-const { YoungModel } = require("../../models");
-const { SessionPhase1Model } = require("../../models");
-const { CohesionCenterModel } = require("../../models");
-const { PointDeRassemblementModel } = require("../../models");
-const { LigneBusModel } = require("../../models");
-const { CohortModel } = require("../../models");
-const { ReferentModel } = require("../../models");
-const { DepartmentServiceModel } = require("../../models");
-
-const { ERRORS, updatePlacesSessionPhase1, updateSeatsTakenInBusLine, autoValidationSessionPhase1Young } = require("../../utils");
-const { serializeYoung, serializeSessionPhase1 } = require("../../utils/serializer");
+  getDepartmentForEligibility,
+  FUNCTIONAL_ERRORS,
+  DepartmentServiceType,
+} from "snu-lib";
+import config from "config";
+import { capture } from "../../sentry";
+import { sendTemplate } from "../../brevo";
+import { YoungModel, SessionPhase1Model, CohesionCenterModel, PointDeRassemblementModel, LigneBusModel, CohortModel, ReferentModel, DepartmentServiceModel } from "../../models";
+import { ERRORS, updatePlacesSessionPhase1, updateSeatsTakenInBusLine, autoValidationSessionPhase1Young } from "../../utils";
+import { serializeYoung, serializeSessionPhase1 } from "../../utils/serializer";
+import { UserRequest } from "../request";
+import { FILLING_RATE_LIMIT, getFillingRate } from "../../services/inscription-goal";
 
 const router = express.Router({ mergeParams: true });
 
-router.post("/affectation", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
+router.post("/affectation", passport.authenticate("referent", { session: false, failWithError: true }), async (req: UserRequest, res) => {
   try {
     const allowedKeys = ["self-going", "ref-select", "young-select", "local"];
     const { error, value } = Joi.object({
@@ -94,10 +88,16 @@ router.post("/affectation", passport.authenticate("referent", { session: false, 
 
     // update youngs infos
     if (young.status === "WAITING_LIST") {
+      // schoolDepartment pour les scolarisés et HZR sinon department pour les non scolarisés
+      const departement = getDepartmentForEligibility(young);
+      const fillingRate = await getFillingRate(departement, cohort.name);
+      if (fillingRate >= FILLING_RATE_LIMIT) {
+        return res.status(400).send({ ok: false, code: FUNCTIONAL_ERRORS.INSCRIPTION_GOAL_REACHED, fillingRate });
+      }
       young.set({ status: "VALIDATED" });
     }
 
-    if ([YOUNG_STATUS_PHASE1.WAITING_AFFECTATION, YOUNG_STATUS_PHASE1.AFFECTED].includes(young.statusPhase1)) {
+    if (([YOUNG_STATUS_PHASE1.WAITING_AFFECTATION, YOUNG_STATUS_PHASE1.AFFECTED] as string[]).includes(young.statusPhase1)) {
       young.set({ statusPhase1: YOUNG_STATUS_PHASE1.AFFECTED });
     }
 
@@ -133,11 +133,15 @@ router.post("/affectation", passport.authenticate("referent", { session: false, 
     });
   } catch (error) {
     capture(error);
-    res.status(500).send({ ok: false, code: ERRORS.SERVER_ERROR });
+    if (Object.keys(FUNCTIONAL_ERRORS).includes(error.message)) {
+      res.status(400).send({ ok: false, code: error.message });
+    } else {
+      res.status(500).send({ ok: false, code: ERRORS.SERVER_ERROR });
+    }
   }
 });
 
-router.post("/dispense", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
+router.post("/dispense", passport.authenticate("referent", { session: false, failWithError: true }), async (req: UserRequest, res) => {
   try {
     const { error, value } = Joi.object({
       statusPhase1MotifDetail: Joi.string().required(),
@@ -171,7 +175,7 @@ router.post("/dispense", passport.authenticate("referent", { session: false, fai
   }
 });
 
-router.post("/depart", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
+router.post("/depart", passport.authenticate("referent", { session: false, failWithError: true }), async (req: UserRequest, res) => {
   try {
     const { error, value } = Joi.object({
       departSejourMotif: Joi.string().required(),
@@ -216,13 +220,13 @@ router.post("/depart", passport.authenticate("referent", { session: false, failW
 
     // si toujours rien on envoie a son contact Convocation
 
-    let contactsConv = [];
+    let contactsConv: DepartmentServiceType["contacts"] = [];
     if (!managers.length && !secretariat.length) {
       const serviceDep = await DepartmentServiceModel.find({ department: young.department });
       if (!serviceDep) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
       contactsConv = serviceDep[0].contacts.filter((contact) => contact.cohort === young.cohort);
       contactsConv = contactsConv.map((contact) => {
-        const [firstName, lastName] = contact.contactName.split(" ");
+        const [firstName, lastName] = contact.contactName!.split(" ");
         const email = contact.contactMail;
 
         return {
@@ -261,7 +265,7 @@ router.post("/depart", passport.authenticate("referent", { session: false, failW
   }
 });
 
-router.put("/depart", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
+router.put("/depart", passport.authenticate("referent", { session: false, failWithError: true }), async (req: UserRequest, res) => {
   try {
     const { error, value } = Joi.object({
       id: Joi.string().required(),
@@ -291,7 +295,7 @@ router.put("/depart", passport.authenticate("referent", { session: false, failWi
   }
 });
 
-router.post("/:key", passport.authenticate("referent", { session: false, failWithError: true }), async (req, res) => {
+router.post("/:key", passport.authenticate("referent", { session: false, failWithError: true }), async (req: UserRequest, res) => {
   try {
     const allowedKeys = ["cohesionStayPresence", "presenceJDM", "cohesionStayMedicalFileReceived", "youngPhase1Agreement", "isTravelingByPlane"];
     const { error, value } = Joi.object({
@@ -334,7 +338,7 @@ router.post("/:key", passport.authenticate("referent", { session: false, failWit
     }
 
     if (key === "cohesionStayPresence" && newValue === "true") {
-      let emailTo = [{ name: `${young.parent1FirstName} ${young.parent1LastName}`, email: young.parent1Email }];
+      let emailTo = [{ name: `${young.parent1FirstName} ${young.parent1LastName}`, email: young.parent1Email! }];
       if (young.parent2Email) emailTo.push({ name: `${young.parent2FirstName} ${young.parent2LastName}`, email: young.parent2Email });
       await sendTemplate(SENDINBLUE_TEMPLATES.YOUNG_ARRIVED_IN_CENTER_TO_REPRESENTANT_LEGAL, {
         emailTo,
@@ -352,4 +356,4 @@ router.post("/:key", passport.authenticate("referent", { session: false, failWit
   }
 });
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
**Description**

Lors de l'affectation manuel d'un jeune en LC, celui-ci est passé automatiquement en LP sans vérification du dépassement des objectifs départementaux...

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/d7c46a2f-2512-4bd1-90a0-05782a105dee">


**Todo**

- [x] Ajout de la vérification sur la route `/young/${young._id}/phase1/affectation`
- [x] Ajouter tests d'intégration

**Ticket / Issue**

https://www.notion.so/jeveuxaider/HTS-Toussaint-D-passement-des-objectifs-pour-la-Nouvelle-Aquitaine-12072a322d5080d4b662dbb3242c58ee

**Testing instructions**

- Prendre un jeune en LC pour une cohort et un departement en dépassement : Gironde / Toussaint 2024
- Affecter le jeune depuis sa fiche (choix du centre et PDR)
- Le serveur doit remonter une erreur à la validation de la dernière étape