### PR TITLE
chore(api): correction de la coherence des cohortId (young)

### DIFF
--- a/api/migrations/20241016100908-fix-young-cohort-id-coherence.js
+++ b/api/migrations/20241016100908-fix-young-cohort-id-coherence.js
@@ -1,0 +1,97 @@
+import { logger } from "../src/logger";
+import { YoungModel } from "../src/models";
+
+module.exports = {
+  async up() {
+    const missingCohortIds = await YoungModel.aggregate([
+      {
+        $lookup: {
+          as: "cohortByName",
+          from: "cohorts",
+          foreignField: "name",
+          localField: "cohort",
+        },
+      },
+      {
+        $unwind: "$cohortByName",
+      },
+      {
+        $addFields: {
+          cohortByNameId: "$cohortByName._id",
+        },
+      },
+      {
+        $match: {
+          cohortId: { $exists: false },
+        },
+      },
+      {
+        $project: {
+          _id: 1,
+          cohortId: 1,
+          cohort: 1,
+          cohortByNameId: 1,
+        },
+      },
+    ]);
+    logger.info(`Young with no cohortId: ${missingCohortIds.length}`);
+    for (const missingCohortYoung of missingCohortIds) {
+      logger.info(`Update young: ${missingCohortYoung._id}, ${missingCohortYoung.cohortByNameId}`);
+      await YoungModel.updateOne({ _id: missingCohortYoung._id }, { $set: { cohortId: missingCohortYoung.cohortByNameId } });
+    }
+
+    const cohortIncoherences = await YoungModel.aggregate([
+      {
+        $addFields: {
+          convertedId: {
+            $toObjectId: "$cohortId",
+          },
+        },
+      },
+      {
+        $lookup: {
+          as: "cohortByName",
+          from: "cohorts",
+          foreignField: "name",
+          localField: "cohort",
+        },
+      },
+      {
+        $unwind: "$cohortByName",
+      },
+      {
+        $addFields: {
+          cohortByNameId: "$cohortByName._id",
+        },
+      },
+      {
+        $match: {
+          cohortId: { $exists: true },
+          $expr: { $ne: ["$convertedId", "$cohortByNameId"] },
+        },
+      },
+      {
+        $project: {
+          _id: 1,
+          cohortId: 1,
+          cohort: 1,
+          convertedId: 1,
+          cohortByNameId: 1,
+        },
+      },
+    ]);
+    logger.info(`Young with incohorent cohortId: ${cohortIncoherences.length}`);
+    const youngsByCohort = cohortIncoherences.reduce((acc, cur) => {
+      const key = cur.cohortByNameId;
+      const youngs = acc[key] || [];
+      acc[key] = [...youngs, cur._id];
+      return acc;
+    }, {});
+    for (const cohortId of Object.keys(youngsByCohort)) {
+      logger.info(`Update youngs: ${cohortId}, ${youngsByCohort[cohortId]}`);
+      await YoungModel.updateMany({ _id: { $in: youngsByCohort[cohortId] } }, { $set: { cohortId: cohortId } });
+    }
+  },
+
+  async down(db, client) {},
+};

--- a/api/src/crons/checkCoherence.ts
+++ b/api/src/crons/checkCoherence.ts
@@ -62,9 +62,9 @@ export const handler = async () => {
           cohortByNameId: 1,
         },
       },
-    ]).exec()) as { _id: string; cohortId: string; cohort: string; convertedId: string; cohortByNameId: string }[];
+    ])) as { _id: string; cohortId: string; cohort: string; convertedId: string; cohortByNameId: string }[];
     if (cohortIncoherence.length > 0) {
-      const youngsCountByCohort = youngs.reduce((acc, cur) => {
+      const youngsCountByCohort = cohortIncoherence.reduce((acc, cur) => {
         acc[cur.cohort!] = (acc[cur.cohort!] || 0) + 1;
         return acc;
       }, {});


### PR DESCRIPTION
**Description**

Suite à la mise en place du cron de vérification https://github.com/betagouv/service-national-universel/pull/4450, cette PR fait passer une migration de données pour remettre à niveau les cohortId.
