### PR TITLE
fix(admin,lib): 3541 - Force le timezone sur les dates

### DIFF
--- a/admin/src/scenes/plan-transport/ligne-bus/List.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/List.jsx
@@ -7,7 +7,7 @@ import { HiHome, HiOutlineAdjustments } from "react-icons/hi";
 import { LuArrowRightCircle, LuArrowLeftCircle, LuHistory } from "react-icons/lu";
 import { GoPlus } from "react-icons/go";
 
-import { ROLES, canExportConvoyeur, getDepartmentNumber, translate } from "snu-lib";
+import { ROLES, canExportConvoyeur, getDepartmentNumber, translate, getZonedDate } from "snu-lib";
 import { Button, Container, Header, Page, Navbar, DropdownButton } from "@snu/ds/admin";
 
 import { capture } from "@/sentry";
@@ -386,8 +386,8 @@ const returnSelect = (cohort, selectedFilters, user) => {
                     "REGION DU CENTRE": data.centerRegion,
                     "ID CENTRE": data.centerId,
                     "NOM + ADRESSE DU CENTRE": data.centerName + " / " + data.centerAddress,
-                    "HEURE D'ARRIVEE AU CENTRE": data.centerArrivalTime,
-                    "HEURE DE DÉPART DU CENTRE": data.centerDepartureTime,
+                    "HEURE D'ARRIVEE AU CENTRE": getZonedDate(data.centerArrivalTime),
+                    "HEURE DE DÉPART DU CENTRE": getZonedDate(data.centerDepartureTime),
 
                     // * followerCapacity !== Total des followers mais c'est la sémantique ici
                     "TOTAL ACCOMPAGNATEURS": data.followerCapacity,

--- a/admin/src/scenes/plan-transport/ligne-bus/View/View.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/View/View.jsx
@@ -3,7 +3,7 @@ import { HiOutlineBell, HiOutlineChatAlt } from "react-icons/hi";
 import { useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
 
-import { ROLES, canExportLigneBus, isLigneBusDemandeDeModificationOpen, ligneBusCanCreateDemandeDeModification, translate } from "snu-lib";
+import { ROLES, canExportLigneBus, getZonedDate, isLigneBusDemandeDeModificationOpen, ligneBusCanCreateDemandeDeModification, translate } from "snu-lib";
 
 import Bus from "../../../../assets/icons/Bus";
 import Breadcrumbs from "../../../../components/Breadcrumbs";
@@ -229,8 +229,8 @@ export default function View(props) {
           <div className="flex gap-4">
             <Itineraire
               meetingsPoints={data.meetingsPointsDetail}
-              aller={data.departuredDate}
-              retour={data.returnDate}
+              aller={getZonedDate(data.departuredDate)}
+              retour={getZonedDate(data.returnDate)}
               center={{ ...data.centerDetail, departureHour: data.centerArrivalTime, returnHour: data.centerDepartureTime }}
               bus={data}
               setBus={setData}

--- a/admin/src/scenes/plan-transport/ligne-bus/View/components/Info.jsx
+++ b/admin/src/scenes/plan-transport/ligne-bus/View/components/Info.jsx
@@ -3,7 +3,7 @@ import { BsArrowLeft, BsArrowRight } from "react-icons/bs";
 import { useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
 import { useHistory, Link } from "react-router-dom";
-import { canEditLigneBusGeneralInfo, isBusEditionOpen, translate } from "snu-lib";
+import { canEditLigneBusGeneralInfo, getZonedDate, isBusEditionOpen, translate } from "snu-lib";
 import Pencil from "../../../../../assets/icons/Pencil";
 import Loader from "../../../../../components/Loader";
 import { capture } from "../../../../../sentry";
@@ -154,7 +154,7 @@ export default function Info({ bus, setBus, dataForCheck, nbYoung, cohort }) {
                 label="Date de départ"
                 Icon={BsArrowRight}
                 onChange={(e) => setData({ ...data, departuredDate: e })}
-                value={new Date(data.departuredDate)}
+                value={getZonedDate(data.departuredDate)}
                 error={errors?.departuredDate}
                 readOnly={!editInfo}
               />
@@ -162,7 +162,7 @@ export default function Info({ bus, setBus, dataForCheck, nbYoung, cohort }) {
                 label="Date de retour"
                 Icon={BsArrowLeft}
                 onChange={(e) => setData({ ...data, returnDate: e })}
-                value={new Date(data.returnDate)}
+                value={getZonedDate(data.returnDate)}
                 error={errors?.returnDate}
                 readOnly={!editInfo}
               />

--- a/admin/src/scenes/volontaires/view/phase1.jsx
+++ b/admin/src/scenes/volontaires/view/phase1.jsx
@@ -3,7 +3,7 @@ import { ImQuotesLeft } from "react-icons/im";
 import { useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
 
-import { YOUNG_SOURCE } from "snu-lib";
+import { YOUNG_SOURCE, getZonedDate } from "snu-lib";
 
 import ModalConfirm from "@/components/modals/ModalConfirm";
 import dayjs from "@/utils/dayjs.utils";
@@ -191,11 +191,11 @@ export default function Phase1(props) {
                         />
                         <Field
                           title="Heure&nbsp;de&nbsp;départ"
-                          value={dayjs(meetingPoint?.bus.departuredDate).format("dddd D MMMM YYYY") + ", " + meetingPoint?.ligneToPoint.departureHour}
+                          value={dayjs(getZonedDate(meetingPoint?.bus.departuredDate)).format("dddd D MMMM YYYY") + ", " + meetingPoint?.ligneToPoint.departureHour}
                         />
                         <Field
                           title="Heure&nbsp;de&nbsp;retour"
-                          value={dayjs(meetingPoint?.bus.returnDate).format("dddd D MMMM YYYY") + ", " + meetingPoint?.ligneToPoint.returnHour}
+                          value={dayjs(getZonedDate(meetingPoint?.bus.returnDate)).format("dddd D MMMM YYYY") + ", " + meetingPoint?.ligneToPoint.returnHour}
                         />
                         <Field title="N˚&nbsp;transport" value={meetingPoint?.bus.busId} externalLink={`${adminURL}/ligne-de-bus/${meetingPoint?.bus._id}`} />
                       </div>

--- a/packages/lib/src/sessions.ts
+++ b/packages/lib/src/sessions.ts
@@ -10,11 +10,11 @@ import { shouldDisplayDateByCohortName } from "./utils/cohortUtils";
 const COHORTS_WITH_JDM_COUNT = ["2019", "2020", "2021", "2022", "Février 2022", "Juin 2022", "Juillet 2022", "Février 2023 - C", "Avril 2023 - B", "Avril 2023 - A", "Juin 2023"];
 
 const getCohortStartDate = (cohort) => {
-  return new Date(cohort.dateStart);
+  return getZonedDate(cohort.dateStart);
 };
 
 const getCohortEndDate = (cohort) => {
-  return new Date(cohort.dateEnd);
+  return getZonedDate(cohort.dateEnd);
 };
 
 const getSchoolYear = (etablissement: EtablissementDto) => {
@@ -33,7 +33,7 @@ const getCohortPeriod = (cohort, withBold = false) => {
 
   // Fonction pour formater les dates avec la localisation française
   const formatDate = (dateString, dateFormat) => {
-    return format(new Date(dateString), dateFormat, { locale: fr });
+    return format(getZonedDate(dateString), dateFormat, { locale: fr });
   };
 
   // Formater les mois et années pour comparaison

--- a/packages/lib/src/transport-info.ts
+++ b/packages/lib/src/transport-info.ts
@@ -1,5 +1,6 @@
 import { YOUNG_STATUS_PHASE1 } from "./constants/constants";
 import { regionsListDROMS } from "./region-and-departments";
+import { getZonedDate } from "./utils/date";
 
 const TRANSPORT_TIMES = {
   ALONE_ARRIVAL_HOUR: "16:00",
@@ -19,24 +20,25 @@ const TRANSPORT_TIMES = {
 function getDepartureDate(young, session, cohort, meetingPoint: any = null) {
   if (meetingPoint?.bus || meetingPoint?.ligneBus || meetingPoint?.departuredDate) return getMeetingPointDepartureDate(meetingPoint);
   if (young?.status && young.status !== YOUNG_STATUS_PHASE1.WAITING_AFFECTATION) return getCenterArrivalDate(young, session, cohort);
-  return getGlobalDepartureDate(young, cohort);
+  return getZonedDate(getGlobalDepartureDate(young, cohort));
 }
 
 function getMeetingPointDepartureDate(meetingPoint) {
-  if (meetingPoint?.bus?.departuredDate) return new Date(meetingPoint?.bus?.departuredDate);
-  if (meetingPoint?.ligneBus?.departuredDate) return new Date(meetingPoint?.ligneBus?.departuredDate);
-  return new Date(meetingPoint?.departuredDate);
+  if (meetingPoint?.bus?.departuredDate) return getZonedDate(new Date(meetingPoint?.bus?.departuredDate));
+  if (meetingPoint?.ligneBus?.departuredDate) return getZonedDate(new Date(meetingPoint?.ligneBus?.departuredDate));
+  return getZonedDate(new Date(meetingPoint?.departuredDate));
 }
 
 function getCenterArrivalDate(young, session, cohort) {
-  if (session?.dateStart) return new Date(session?.dateStart);
-  return getGlobalDepartureDate(young, cohort);
+  if (session?.dateStart) return getZonedDate(new Date(session?.dateStart));
+  return getZonedDate(getGlobalDepartureDate(young, cohort));
 }
 
 function getGlobalDepartureDate(young, cohort) {
   if (young.cohort === "Juillet 2023" && [...regionsListDROMS, "Polynésie française"].includes(young.region)) {
     return new Date(2023, 6, 4);
   }
+
   if (cohort?.dateStart) return new Date(cohort.dateStart);
   return new Date();
 }
@@ -54,18 +56,18 @@ function getGlobalDepartureDate(young, cohort) {
 function getReturnDate(young, session, cohort, meetingPoint: any = null) {
   if (meetingPoint?.bus || meetingPoint?.ligneBus || meetingPoint?.departuredDate) return getMeetingPointReturnDate(meetingPoint);
   if (young?.status && young.status !== YOUNG_STATUS_PHASE1.WAITING_AFFECTATION) return getCenterReturnDate(young, session, cohort);
-  return getGlobalReturnDate(young, cohort);
+  return getZonedDate(getGlobalReturnDate(young, cohort));
 }
 
 function getMeetingPointReturnDate(meetingPoint) {
-  if (meetingPoint?.bus?.returnDate) return new Date(meetingPoint?.bus?.returnDate);
-  if (meetingPoint?.ligneBus?.returnDate) return new Date(meetingPoint?.ligneBus?.returnDate);
-  return new Date(meetingPoint?.returnDate);
+  if (meetingPoint?.bus?.returnDate) return getZonedDate(new Date(meetingPoint?.bus?.returnDate));
+  if (meetingPoint?.ligneBus?.returnDate) return getZonedDate(new Date(meetingPoint?.ligneBus?.returnDate));
+  return getZonedDate(new Date(meetingPoint?.returnDate));
 }
 
 function getCenterReturnDate(young, session, cohort) {
-  if (session?.dateEnd) return new Date(session?.dateEnd);
-  return getGlobalReturnDate(young, cohort);
+  if (session?.dateEnd) return getZonedDate(new Date(session?.dateEnd));
+  return getZonedDate(getGlobalReturnDate(young, cohort));
 }
 
 function getGlobalReturnDate(young, cohort) {


### PR DESCRIPTION
**Description**

Pour le séjour de la Toussaint, du 21 au 31 octobre, un parent s'est plaint d’avoir des dates différentes entre la convocation et le profil du volontaire. Le problème est que les dates affichées n'ont pas de fuseau horaire forcé.

**Ticket / Issue**

 [Notion ticket #3541](https://www.notion.so/jeveuxaider/HTS-Toussaint-Affichage-de-mauvaises-dates-sur-le-profil-des-volontaires-12072a322d50807fae26c4e7e583de61)

**Testing instructions**
- Changer son timezone en **Papeete - Polynésie française** par exemple
- Naviguer sur les pages ou l'on a les dates
