### PR TITLE
feat(api): 3556 - MAJ de l'import de PDR (uniquement par matricule)

### DIFF
--- a/api/src/__tests__/fixtures/PlanDeTransport/pointDeRassemblement.ts
+++ b/api/src/__tests__/fixtures/PlanDeTransport/pointDeRassemblement.ts
@@ -19,6 +19,11 @@ function getNewPointDeRassemblementFixture(object: Partial<PointDeRassemblementT
     },
     matricule: faker.lorem.words(),
     particularitesAcces: faker.lorem.words(),
+    uai: faker.string.alpha(8).toUpperCase(),
+    numeroOrdre: faker.number.int({ min: 4, max: 16 }).toString().padStart(3, "0"),
+    dateCreation: faker.date.past(),
+    dateDebutValidite: faker.date.past(),
+    dateDerniereModification: faker.date.past(),
     ...object,
   };
 }

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImport.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImport.ts
@@ -29,6 +29,5 @@ export type PointDeRassemblementImportMapped = Pick<
   PointDeRassemblementType,
   "name" | "address" | "city" | "zip" | "department" | "region" | "academie" | "particularitesAcces" | "matricule"
 > & {
-  _id?: string;
   complementAddress: string;
 };

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImport.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImport.ts
@@ -12,7 +12,7 @@ export interface ImportPointDeRassemblementRoute extends BasicRoute {
 
 export interface PointDeRassemblementCSV {
   "Matricule du point de rassemblement": string;
-  "Point de Rassemblement : Désignation du Point de Rassemblement": string;
+  "Point de Rassemblement : Désignation": string;
   Adresse: string;
   "Code postal": string;
   Commune: string;
@@ -24,8 +24,8 @@ export interface PointDeRassemblementCSV {
   UAI: string;
   "Numéro d'ordre": string;
   "Date  début validité de l'enregistrement": string;
-  "Point de Rassemblement : Date de création": string;
-  "Point de Rassemblement : Date de dernière modification": string;
+  "Point de Rassemblement : Date de création": string;
+  "Point de Rassemblement : Date de dernière modification": string;
 }
 
 export type PointDeRassemblementImportMapped = Pick<

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImport.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImport.ts
@@ -20,14 +20,30 @@ export interface PointDeRassemblementCSV {
   "Région académique": string;
   Académie: string;
   Département: string;
+  "ID temporaire PDR": string;
+  UAI: string;
   "Numéro d'ordre": string;
   "Date  début validité de l'enregistrement": string;
-  "ID temporaire PDR": string;
+  "Point de Rassemblement : Date de création": string;
+  "Point de Rassemblement : Date de dernière modification": string;
 }
 
 export type PointDeRassemblementImportMapped = Pick<
   PointDeRassemblementType,
-  "name" | "address" | "city" | "zip" | "department" | "region" | "academie" | "particularitesAcces" | "matricule"
+  | "name"
+  | "address"
+  | "city"
+  | "zip"
+  | "department"
+  | "region"
+  | "academie"
+  | "particularitesAcces"
+  | "matricule"
+  | "uai"
+  | "numeroOrdre"
+  | "dateCreation"
+  | "dateDebutValidite"
+  | "dateDerniereModification"
 > & {
   complementAddress: string;
 };

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportMapper.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportMapper.ts
@@ -21,9 +21,6 @@ export const mapPointDeRassemblements = (rawPdrs: PointDeRassemblementCSV[]): Po
     if (!rawPdrWithoutId.name) {
       throw new Error("NO NAME " + rawPdrWithoutId.matricule);
     }
-    if (rawPdr["ID temporaire PDR"]) {
-      return { _id: rawPdr["ID temporaire PDR"].toLowerCase(), ...rawPdrWithoutId };
-    }
     return rawPdrWithoutId;
   });
 };

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportMapper.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportMapper.ts
@@ -1,4 +1,5 @@
 import { academyList, departmentList, regionList } from "snu-lib";
+const { parse: parseDate } = require("date-fns");
 import { logger } from "../../../logger";
 import { PointDeRassemblementCSV, PointDeRassemblementImportMapped } from "./pointDeRassemblementImport";
 
@@ -16,6 +17,11 @@ export const mapPointDeRassemblements = (rawPdrs: PointDeRassemblementCSV[]): Po
       region: mapRegion(rawPdr["Région académique"]),
       academie: mapAcademy(rawPdr["Académie"]),
       matricule: rawPdr["Matricule du point de rassemblement"],
+      uai: rawPdr["UAI"],
+      numeroOrdre: rawPdr["Numéro d'ordre"],
+      dateCreation: parseDate(rawPdr["Point de Rassemblement : Date de création"], "dd/MM/yyyy", new Date()),
+      dateDebutValidite: parseDate(rawPdr["Date  début validité de l'enregistrement"], "dd/MM/yyyy", new Date()),
+      dateDerniereModification: parseDate(rawPdr["Point de Rassemblement : Date de dernière modification"], "dd/MM/yyyy", new Date()),
       // code: rawPdr["Matricule du point de rassemblement"],
     };
     if (!rawPdrWithoutId.name) {

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportMapper.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportMapper.ts
@@ -7,7 +7,7 @@ export const mapPointDeRassemblements = (rawPdrs: PointDeRassemblementCSV[]): Po
   return rawPdrs.map((rawPdr) => {
     const rawPdrWithoutId: PointDeRassemblementImportMapped = {
       // attention de garder le caractere spécial à la place de l'espace dans le nom de colonne
-      name: rawPdr["Point de Rassemblement : Désignation du Point de Rassemblement"],
+      name: rawPdr["Point de Rassemblement : Désignation"],
       address: rawPdr.Adresse,
       complementAddress: rawPdr["Particularités pour accès"],
       particularitesAcces: rawPdr["Particularités pour accès"],
@@ -19,9 +19,9 @@ export const mapPointDeRassemblements = (rawPdrs: PointDeRassemblementCSV[]): Po
       matricule: rawPdr["Matricule du point de rassemblement"],
       uai: rawPdr["UAI"],
       numeroOrdre: rawPdr["Numéro d'ordre"],
-      dateCreation: parseDate(rawPdr["Point de Rassemblement : Date de création"], "dd/MM/yyyy", new Date()),
+      dateCreation: parseDate(rawPdr["Point de Rassemblement : Date de création"], "dd/MM/yyyy", new Date()),
       dateDebutValidite: parseDate(rawPdr["Date  début validité de l'enregistrement"], "dd/MM/yyyy", new Date()),
-      dateDerniereModification: parseDate(rawPdr["Point de Rassemblement : Date de dernière modification"], "dd/MM/yyyy", new Date()),
+      dateDerniereModification: parseDate(rawPdr["Point de Rassemblement : Date de dernière modification"], "dd/MM/yyyy", new Date()),
       // code: rawPdr["Matricule du point de rassemblement"],
     };
     if (!rawPdrWithoutId.name) {

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportService.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportService.ts
@@ -63,7 +63,7 @@ export const importPointDeRassemblement = async (pdrFilePath: string) => {
   }
 
   // suppression logique de tous les PDR sans matricule (legacy)
-  await PointDeRassemblementModel.updateMany({ matricule: { $exists: false } }, { $set: { deletedAt: new Date() } });
+  await PointDeRassemblementModel.updateMany({ matricule: { $exists: false }, deletedAt: { $exists: false } }, { $set: { deletedAt: new Date() } });
 
   return report;
 };

--- a/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportService.ts
+++ b/api/src/planDeTransport/pointDeRassemblement/import/pointDeRassemblementImportService.ts
@@ -47,15 +47,9 @@ export const importPointDeRassemblement = async (pdrFilePath: string) => {
           matricule: pdr.matricule,
         });
         continue;
-      } else if (pdr._id) {
-        processedPdr = await processPdrWithId(pdr);
-        if (processedPdr.action === "error") {
-          processedPdr = await processPdrWithoutId(pdr);
-        }
-      } else if (pdr.matricule) {
-        processedPdr = await processPdrWithoutId(pdr);
+      } else {
+        processedPdr = await processPdrWitMatricule(pdr);
       }
-      // @ts-expect-error - processedPdr is defined
       report.push(processedPdr);
     } catch (e) {
       logger.error(e);
@@ -75,38 +69,13 @@ export const importPointDeRassemblement = async (pdrFilePath: string) => {
 };
 
 const filterPdrs = (mappedPdrs: PointDeRassemblementImportMapped[]) => {
-  // on supprime les lignes avec 2 fois le même _id
-  const duplicatedPdrs = mappedPdrs.filter((pdr) => pdr._id && mappedPdrs.find(({ _id, matricule }) => _id === pdr._id && matricule !== pdr.matricule));
-  duplicatedPdrs.forEach((pdr) => {
-    logger.info(`importCohesionCenter() - remove _id from PDR ${pdr.matricule} (duplicated _id: ${pdr._id})`);
-    pdr._id = undefined;
-  });
   return mappedPdrs;
 };
 
-export const processPdrWithId = async (pdr: PointDeRassemblementImportMapped): Promise<PointDeRassemblementImportReport> => {
-  const { _id, ...pdrToUpdate } = pdr;
-  try {
-    const existingPdr = await PointDeRassemblementModel.findById(_id);
-    if (existingPdr && !existingPdr.deletedAt) {
-      return await updatePdr(pdrToUpdate, existingPdr, "Id provided - Pdr found by Id");
-    }
-  } catch (e) {
-    logger.warn(e);
-  }
-  return {
-    _id: _id,
-    matricule: "",
-    name: "",
-    action: "error",
-    comment: "Id provided - no pdr found by Id",
-  };
-};
-
-export const processPdrWithoutId = async (pdr: PointDeRassemblementImportMapped): Promise<PointDeRassemblementImportReport> => {
+export const processPdrWitMatricule = async (pdr: PointDeRassemblementImportMapped): Promise<PointDeRassemblementImportReport> => {
   const foundPdrs = await PointDeRassemblementModel.find({ matricule: pdr.matricule, deletedAt: { $exists: false } });
   if (foundPdrs.length === 1) {
-    logger.info(`processPdrWithoutId() - Pdr with matricule ${pdr.matricule} already exists`);
+    logger.info(`processPdrWitMatricule() - Pdr with matricule ${pdr.matricule} already exists`);
     return await updatePdr(pdr, foundPdrs[0], "No Id - Pdr found by matricule");
   } else if (foundPdrs.length > 1) {
     // return await processPdrsByMatriculeFound(pdr, foundPdrs);
@@ -142,7 +111,6 @@ export const processPdrsByMatriculeFound = async (pdr: PointDeRassemblementImpor
 
 export const createPdr = async (pdr: PointDeRassemblementImportMapped): Promise<PointDeRassemblementImportReport> => {
   const { extraInfos, report } = await getPdrExtraInfos(pdr);
-  pdr._id = undefined;
   const createdPdr = await PointDeRassemblementModel.create({ ...pdr, ...extraInfos });
   await createdPdr.save({ fromUser: { firstName: "IMPORT_POINT_DE_RASSEMBLEMENT" } });
   return {

--- a/packages/lib/src/mongoSchema/planDeTransport/pointDeRassemblement.ts
+++ b/packages/lib/src/mongoSchema/planDeTransport/pointDeRassemblement.ts
@@ -49,6 +49,41 @@ export const PointDeRassemblementSchema = {
     },
   },
 
+  uai: {
+    type: String,
+    documentation: {
+      description: "UAI du point de rassemblement",
+    },
+  },
+
+  numeroOrdre: {
+    type: String,
+    documentation: {
+      description: "Numéro d'ordre du point de rassemblement",
+    },
+  },
+
+  dateCreation: {
+    type: Date,
+    documentation: {
+      description: "Date de création du point de rassemblement",
+    },
+  },
+
+  dateDebutValidite: {
+    type: Date,
+    documentation: {
+      description: "Date de début de validité du point de rassemblement",
+    },
+  },
+
+  dateDerniereModification: {
+    type: Date,
+    documentation: {
+      description: "Date de dernière modification du point de rassemblement",
+    },
+  },
+
   // LEGACY
   complementAddress: {
     type: [


### PR DESCRIPTION
**Description**

Adapatation de l'import pour ne plus prendre en compte l'id temporaire (on se base maintenant uniquement sur les matricule pour les maj)

**Todo**

- [x] Suppression du mapping par "id"
- [x] Se base uniquement sur le matricule pour l'import 

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Importer-le-PDR-12272a322d5080f387f6f136cae02e68?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
