### PR TITLE
fix(api): sentry - fix missionPatches cron

### DIFF
--- a/api/src/crons/patch/mission.js
+++ b/api/src/crons/patch/mission.js
@@ -67,7 +67,7 @@ async function createLog(patch, actualMission, event, value) {
     body: JSON.stringify({
       evenement_nom: event,
       evenement_type: "mission",
-      evenement_valeur: value.toString() || "",
+      evenement_valeur: value?.toString() || "",
       mission_id: patch.ref.toString(),
       mission_structureId: actualMission.structureId.toString(),
       mission_status: mission.status || actualMission.status,


### PR DESCRIPTION
sentry [issue](https://sentry.selego.co/organizations/sentry/issues/6393/?environment=production&project=160&query=toString&referrer=issue-stream&statsPeriod=15h&stream_index=0)

`TypeError: Cannot read properties of null (reading 'toString')
    at createLog (/app/api/src/crons/patch/mission.js:70:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async processPatch (/app/api/src/crons/patch/mission.js:42:11)
    at async /app/api/src/crons/patch/utils.js:60:7
TypeError: Cannot read properties of null (reading 'toString')
    at createLog (/app/api/src/crons/patch/mission.js:70:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async processPatch (/app/api/src/crons/patch/mission.js:42:11)
    at async /app/api/src/crons/patch/utils.js:60:7
TypeError: Cannot read properties of null (reading 'toString')
    at createLog (/app/api/src/crons/patch/mission.js:70:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async processPatch (/app/api/src/crons/patch/mission.js:42:11)
    at async /app/api/src/crons/patch/utils.js:60:7`