### PR TITLE
fix(api) - supression du model des mails dans la liste usefull du script reindex

### DIFF
--- a/api/src/scripts/reindex_es_all_models/index.js
+++ b/api/src/scripts/reindex_es_all_models/index.js
@@ -106,7 +106,6 @@ async function reindexESAllModels() {
       YoungModel,
       LigneBusModel,
       PlanTransportModel,
-      EmailModel,
       ClasseModel,
       EtablissementModel,
     ];


### PR DESCRIPTION
Le job reindex de scaleway fail si lancé avec parametre usefull car il est trop long (max 2h)
Je retire le model Email de la liste usefull pour eviter cela
Il reste dans la liste all