### PR TITLE
feat(api): 3576 - Bloquer l’impersonate pour le sous rôle god

### DIFF
--- a/admin/src/app.jsx
+++ b/admin/src/app.jsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState, lazy, Suspense } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect, BrowserRouter as Router, Switch, useLocation } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { isFeatureEnabled, FEATURES_NAME } from "snu-lib";
+import { isFeatureEnabled, FEATURES_NAME, SUB_ROLES } from "snu-lib";
 import * as Sentry from "@sentry/react";
 
 import { queryClient } from "./services/react-query";
@@ -243,7 +243,7 @@ const Home = () => {
                   <RestrictedRoute path="/dsnj-export" component={DSNJExport} />
                   <RestrictedRoute path="/injep-export" component={INJEPExport} />
                   {/* Plan de transport */}
-                  {user?.role === "admin" && user?.subRole === "god" ? <RestrictedRoute path="/edit-transport" component={EditTransport} /> : null}
+                  {user?.role === "admin" && user?.subRole === SUB_ROLE_GOD ? <RestrictedRoute path="/edit-transport" component={EditTransport} /> : null}
                   {/* Table de répartition */}
                   <RestrictedRoute path="/table-repartition" component={TableDeRepartition} />
                   {/* Ligne de bus */}

--- a/admin/src/app.jsx
+++ b/admin/src/app.jsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState, lazy, Suspense } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect, BrowserRouter as Router, Switch, useLocation } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { isFeatureEnabled, FEATURES_NAME, SUB_ROLES } from "snu-lib";
+import { isFeatureEnabled, FEATURES_NAME, SUB_ROLE_GOD } from "snu-lib";
 import * as Sentry from "@sentry/react";
 
 import { queryClient } from "./services/react-query";

--- a/admin/src/components/drawer/SideBar.tsx
+++ b/admin/src/components/drawer/SideBar.tsx
@@ -5,7 +5,7 @@ import cx from "classnames";
 import { HiOutlineOfficeBuilding } from "react-icons/hi";
 import { HiOutlineCommandLine } from "react-icons/hi2";
 
-import { FEATURES_NAME, ROLES, isFeatureEnabled } from "snu-lib";
+import { FEATURES_NAME, ROLES, SUB_ROLE_GOD, isFeatureEnabled } from "snu-lib";
 
 import api from "@/services/api";
 import useDevice from "@/hooks/useDevice";
@@ -254,7 +254,7 @@ const SideBar = ({ sessionsList }) => {
       case ROLES.REFERENT_REGION:
         return refItems;
       case ROLES.ADMIN:
-        return user.subRole === "god" ? godItems : adminItems;
+        return user.subRole === SUB_ROLE_GOD ? godItems : adminItems;
       case ROLES.HEAD_CENTER:
         return headCenterItems;
       case ROLES.TRANSPORTER:

--- a/admin/src/scenes/contact/list.jsx
+++ b/admin/src/scenes/contact/list.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { Page, Header, Container, Badge, DropdownButton } from "@snu/ds/admin";
-import { formatLongDateFR, getDepartmentNumber, ROLES, translate } from "snu-lib";
+import { formatLongDateFR, getDepartmentNumber, ROLES, SUB_ROLE_GOD, translate } from "snu-lib";
 import { ExportComponent, Filters, ResultTable, Save, SelectedFilters, SortOption } from "@/components/filters-system-v2";
 import { BsDownload } from "react-icons/bs";
 import api from "@/services/api";
@@ -294,7 +294,7 @@ const Hit = ({ hit }) => {
         {hit.role && (
           <>
             <Badge title={translate(hit.role)} />
-            {hit.subRole && hit.subRole !== "god" ? <Badge title={translate(hit.subRole)} status={"secondary"} /> : null}
+            {hit.subRole && hit.subRole !== SUB_ROLE_GOD ? <Badge title={translate(hit.subRole)} status={"secondary"} /> : null}
           </>
         )}
       </td>

--- a/admin/src/scenes/dashboardV2/moderator-ref/subscenes/engagement/index.tsx
+++ b/admin/src/scenes/dashboardV2/moderator-ref/subscenes/engagement/index.tsx
@@ -138,7 +138,7 @@ export default function Index() {
   };
 
   const computeDepartmentOptions = () => {
-    setDepartmentOptions(user?.department?.map((d) => ({ key: d, label: d })));
+    setDepartmentOptions((user?.department as string[])?.map((d) => ({ key: d, label: d })));
   };
 
   async function loadData() {}

--- a/admin/src/scenes/utilisateur/composants/UserHeader.jsx
+++ b/admin/src/scenes/utilisateur/composants/UserHeader.jsx
@@ -10,7 +10,7 @@ import { setUser as setUserInRedux } from "../../../redux/auth/actions";
 import TabList from "../../../components/views/TabList";
 import plausibleEvent from "../../../services/plausible";
 import Tab from "../../phase0/components/Tab";
-import { ROLES, translate } from "../../../utils";
+import { canSigninAs, ROLES, translate } from "../../../utils";
 import { Badge } from "@snu/ds/admin";
 import { signinAs } from "@/utils/signinAs";
 
@@ -51,12 +51,14 @@ export default function UserHeader({ user, tab, currentUser }) {
               <span className="text-xs">{getSubtitle(user)}</span>
             </div>
             <div className="flex items-center">
-              {user.structureId ? (
+              {user.structureId && (
                 <Link to={`/structure/${user.structureId}`} onClick={() => plausibleEvent("Utilisateurs/Profil CTA - Voir structure")}>
                   <PanelActionButton icon="eye" title="Voir la structure" className="m-0 mr-2" />
                 </Link>
-              ) : null}
-              {currentUser.role === ROLES.ADMIN ? <PanelActionButton className="m-0" onClick={handleImpersonate} icon="impersonate" title="Prendre&nbsp;sa&nbsp;place" /> : null}
+              )}
+              {canSigninAs(currentUser, user, "referent") && (
+                <PanelActionButton className="m-0" onClick={handleImpersonate} icon="impersonate" title="Prendre&nbsp;sa&nbsp;place" />
+              )}
             </div>
           </div>
 

--- a/admin/src/scenes/utilisateur/list.jsx
+++ b/admin/src/scenes/utilisateur/list.jsx
@@ -2,13 +2,12 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
 import { Link, useHistory } from "react-router-dom";
-import { HiHome } from "react-icons/hi";
 
 import dayjs from "@/utils/dayjs.utils";
 import { Badge, Container, DropdownButton, Header, Page } from "@snu/ds/admin";
 import { BsDownload } from "react-icons/bs";
 import { IoFlashOutline } from "react-icons/io5";
-import { canViewReferent, formatLongDateFR, getDepartmentNumber, canSigninAs, ERRORS } from "snu-lib";
+import { canViewReferent, formatLongDateFR, getDepartmentNumber, canSigninAs, ERRORS, SUB_ROLE_GOD } from "snu-lib";
 import Loader from "../../components/Loader";
 import { ExportComponent, Filters, ResultTable, Save, SelectedFilters, SortOption } from "../../components/filters-system-v2";
 import ModalChangeTutor from "../../components/modals/ModalChangeTutor";
@@ -243,7 +242,7 @@ const Hit = ({ hit, onClick, user, structure }) => {
         {hit.role && (
           <>
             <Badge title={translate(hit.role)} />
-            {hit.subRole && hit.subRole !== "god" ? <Badge title={translate(hit.subRole)} status={"secondary"} /> : null}
+            {hit.subRole && hit.subRole !== SUB_ROLE_GOD ? <Badge title={translate(hit.subRole)} status={"secondary"} /> : null}
           </>
         )}
       </td>

--- a/admin/src/scenes/utilisateur/list.tsx
+++ b/admin/src/scenes/utilisateur/list.tsx
@@ -164,7 +164,6 @@ export default function List() {
               paramData={paramData}
               setParamData={setParamData}
               size={size}
-              // @ts-expect-error jsx component
               intermediateFilters={[getCohortGroups("cohorts")]}
             />
             <SortOption

--- a/admin/src/scenes/utilisateur/list.tsx
+++ b/admin/src/scenes/utilisateur/list.tsx
@@ -2,12 +2,17 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { toastr } from "react-redux-toastr";
 import { Link, useHistory } from "react-router-dom";
-
-import dayjs from "@/utils/dayjs.utils";
-import { Badge, Container, DropdownButton, Header, Page } from "@snu/ds/admin";
 import { BsDownload } from "react-icons/bs";
 import { IoFlashOutline } from "react-icons/io5";
-import { canViewReferent, formatLongDateFR, getDepartmentNumber, canSigninAs, ERRORS, SUB_ROLE_GOD } from "snu-lib";
+
+import { canViewReferent, formatLongDateFR, getDepartmentNumber, canSigninAs, ERRORS, SUB_ROLE_GOD, StructureType, DepartmentServiceType, ReferentType } from "snu-lib";
+import { Badge, Container, DropdownButton, Header, Page } from "@snu/ds/admin";
+
+import dayjs from "@/utils/dayjs.utils";
+import { signinAs } from "@/utils/signinAs";
+import { getCohortGroups } from "@/services/cohort.service";
+import { AuthState } from "@/redux/auth/reducer";
+
 import Loader from "../../components/Loader";
 import { ExportComponent, Filters, ResultTable, Save, SelectedFilters, SortOption } from "../../components/filters-system-v2";
 import ModalChangeTutor from "../../components/modals/ModalChangeTutor";
@@ -19,17 +24,15 @@ import plausibleEvent from "../../services/plausible";
 import { ROLES, canDeleteReferent, translate } from "../../utils";
 import ModalUniqueResponsable from "./composants/ModalUniqueResponsable";
 import Panel from "./panel";
-import { signinAs } from "@/utils/signinAs";
-import { getCohortGroups } from "@/services/cohort.service";
 
 export default function List() {
-  const [responsable, setResponsable] = useState(null);
-  const { user, sessionPhase1 } = useSelector((state) => state.Auth);
-  const [structures, setStructures] = useState();
-  const [services, setServices] = useState();
+  const [responsable, setResponsable] = useState<ReferentType | null>(null);
+  const { user, sessionPhase1 } = useSelector((state: AuthState) => state.Auth);
+  const [structures, setStructures] = useState<StructureType[]>();
+  const [services, setServices] = useState<DepartmentServiceType[]>();
 
   //List params
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<ReferentType[]>([]);
   const pageId = "referent-list";
   const [selectedFilters, setSelectedFilters] = useState({});
   const [paramData, setParamData] = useState({
@@ -102,6 +105,7 @@ export default function List() {
             title="Exporter"
             exportTitle="Utilisateurs"
             route={`/elasticsearch/referent/export${user.role === ROLES.HEAD_CENTER ? "?cohort=" + sessionPhase1?.cohort : ""}`}
+            // @ts-expect-error jsx component
             filters={filterArray}
             selectedFilters={selectedFilters}
             setIsOpen={() => true}
@@ -113,15 +117,13 @@ export default function List() {
             }}
             transform={(all) => {
               return all.map((data) => {
-                let structure = {};
+                let structure: Partial<StructureType> = {};
                 if (data.structureId && structures) {
-                  structure = structures.find((s) => s._id === data.structureId);
-                  if (!structure) structure = {};
+                  structure = structures.find((s) => s._id === data.structureId) || {};
                 }
-                let service = {};
+                let service: Partial<DepartmentServiceType> = {};
                 if (data.role === ROLES.REFERENT_DEPARTMENT && services) {
-                  service = services.find((s) => s.department === data.department);
-                  if (!service) service = {};
+                  service = services.find((s) => s.department === data.department) || {};
                 }
                 return {
                   _id: data._id,
@@ -136,7 +138,7 @@ export default function List() {
                   Région: data.region,
                   Structure: structure?.name || "",
                   "Nom de la direction du service départemental": service?.directionName || "",
-                  "Adresse du service départemental": service?.address + service?.complementAddress || "",
+                  "Adresse du service départemental": (service?.address || "") + (service?.complementAddress || ""),
                   "Code Postal du service départemental": service?.zip || "",
                   "Ville du service départemental": service?.city || "",
                   "Créé lé": formatLongDateFR(data.createdAt),
@@ -162,6 +164,7 @@ export default function List() {
               paramData={paramData}
               setParamData={setParamData}
               size={size}
+              // @ts-expect-error jsx component
               intermediateFilters={[getCohortGroups("cohorts")]}
             />
             <SortOption
@@ -265,14 +268,30 @@ const Hit = ({ hit, onClick, user, structure }) => {
   );
 };
 
-const Action = ({ hit, structure }) => {
-  const user = useSelector((state) => state.Auth.user);
+interface ActionProps {
+  hit: ReferentType;
+  structure: StructureType;
+}
+
+interface ModalState {
+  isOpen: boolean;
+  onConfirm?: (() => void) | null;
+  title?: string;
+  message?: string;
+  value?: string;
+}
+
+const Action = ({ hit, structure }: ActionProps) => {
+  const user = useSelector((state: AuthState) => state.Auth.user);
   const dispatch = useDispatch();
   const history = useHistory();
-  const [modal, setModal] = useState({ isOpen: false, onConfirm: null });
-  const [modalTutor, setModalTutor] = useState({ isOpen: false, onConfirm: null });
-  const [modalUniqueResponsable, setModalUniqueResponsable] = useState({ isOpen: false });
-  const [modalReferentDeleted, setModalReferentDeleted] = useState({ isOpen: false });
+  const [modal, setModal] = useState<ModalState>({ isOpen: false, onConfirm: null });
+  const [modalTutor, setModalTutor] = useState<ModalState>({
+    isOpen: false,
+    onConfirm: null,
+  });
+  const [modalUniqueResponsable, setModalUniqueResponsable] = useState<ModalState & { responsable?: ReferentType }>({ isOpen: false });
+  const [modalReferentDeleted, setModalReferentDeleted] = useState<ModalState>({ isOpen: false });
   const [handleImpersonateLoading, setHandleImpersonateLoading] = useState(false);
 
   const handleImpersonate = async () => {
@@ -289,20 +308,20 @@ const Action = ({ hit, structure }) => {
       toastr.error("Oops, une erreur est survenu lors de la masquarade !", translate(e.code));
     }
   };
-  const onClickDelete = () => {
+  const handleClickDelete = () => {
     setModal({
       isOpen: true,
-      onConfirm: onConfirmDelete,
+      onConfirm: handleConfirmDelete,
       title: `Êtes-vous sûr(e) de vouloir supprimer le compte de ${hit.firstName} ${hit.lastName} ?`,
       message: "Cette action est irréversible.",
     });
   };
 
-  const onDeleteTutorLinked = (target) => {
+  const handleDeleteTutorLinked = (target) => {
     setModalTutor({
       isOpen: true,
       value: target,
-      onConfirm: () => onConfirmDelete(target),
+      onConfirm: () => handleConfirmDelete(),
     });
   };
 
@@ -319,12 +338,12 @@ const Action = ({ hit, structure }) => {
     });
   };
 
-  const onConfirmDelete = async () => {
+  const handleConfirmDelete = async () => {
     try {
       const { ok, code } = await api.remove(`/referent/${hit._id}`);
-      if (!ok && code === ERRORS.OPERATION_UNAUTHORIZED) return toastr.error("Vous n'avez pas les droits pour effectuer cette action");
+      if (!ok && code === ERRORS.OPERATION_UNAUTHORIZED) return toastr.error("Vous n'avez pas les droits pour effectuer cette action", "");
       if (!ok && code === ERRORS.LINKED_STRUCTURE) return onUniqueResponsible(hit);
-      if (!ok && code === ERRORS.LINKED_MISSIONS) return onDeleteTutorLinked(hit);
+      if (!ok && code === ERRORS.LINKED_MISSIONS) return handleDeleteTutorLinked(hit);
       if (!ok && code === ERRORS.LINKED_CLASSES) return onUniqueResponsible(hit);
       if (!ok && code === ERRORS.LINKED_ETABLISSEMENT) return onUniqueResponsible(hit);
       if (!ok) return toastr.error("Une erreur s'est produite :", translate(code));
@@ -347,6 +366,7 @@ const Action = ({ hit, structure }) => {
           {
             key: "actions",
             title: "",
+            // @ts-expect-error null value are filtered
             items: [
               {
                 key: "view",
@@ -357,30 +377,32 @@ const Action = ({ hit, structure }) => {
                 ),
               },
               canSigninAs(user, hit, "referent") ? { key: "takePlace", render: <p>Prendre sa place</p>, action: handleImpersonate } : null,
-              canDeleteReferent({ actor: user, originalTarget: hit, structure }) ? { key: "delete", render: <p>Supprimer le profil</p>, action: onClickDelete } : null,
+              canDeleteReferent({ actor: user, originalTarget: hit, structure }) ? { key: "delete", render: <p>Supprimer le profil</p>, action: handleClickDelete } : null,
             ].filter(Boolean),
           },
         ]}
       />
 
+      {/* @ts-expect-error jsx component */}
       <ModalConfirm
         isOpen={modal?.isOpen}
         title={modal?.title}
         message={modal?.message}
         onCancel={() => setModal({ isOpen: false, onConfirm: null })}
         onConfirm={() => {
-          modal?.onConfirm();
+          modal?.onConfirm?.();
           setModal({ isOpen: false, onConfirm: null });
         }}
       />
+      {/* @ts-expect-error jsx component */}
       <ModalChangeTutor
         isOpen={modalTutor?.isOpen}
-        title={modalTutor?.title}
-        message={modalTutor?.message}
+        // title={modalTutor?.title}
+        // message={modalTutor?.message}
         tutor={modalTutor?.value}
         onCancel={() => setModalTutor({ isOpen: false, onConfirm: null })}
         onConfirm={() => {
-          modalTutor?.onConfirm();
+          modalTutor?.onConfirm?.();
           setModalTutor({ isOpen: false, onConfirm: null });
         }}
       />

--- a/admin/src/utils/signinAs.ts
+++ b/admin/src/utils/signinAs.ts
@@ -3,7 +3,7 @@ import plausibleEvent from "@/services/plausible";
 import store from "@/redux/store";
 import { setUser, setPreviousSignin } from "@/redux/auth/actions";
 
-const signinAs = async (type, userId) => {
+export const signinAs = async (type: "referent" | "young", userId: string) => {
   const { ok, data, token } = await api.post(`/referent/signin_as/${type}/${userId}`);
   if (!ok) throw new Error("Une erreur est survenue lors de la connexion");
   if (!data) throw new Error("Erreur : aucune données d'utilisateur");
@@ -17,7 +17,7 @@ const signinAs = async (type, userId) => {
   return data;
 };
 
-const restorePreviousSignin = async () => {
+export const restorePreviousSignin = async () => {
   const { previousSigninToken } = store.getState().Auth;
   if (!previousSigninToken) throw new Error("Aucune connexion précédente");
 
@@ -33,5 +33,3 @@ const restorePreviousSignin = async () => {
     console.log(e);
   }
 };
-
-export { signinAs, restorePreviousSignin };

--- a/api/src/__tests__/cle/appelAProjet.test.ts
+++ b/api/src/__tests__/cle/appelAProjet.test.ts
@@ -1,13 +1,13 @@
 import request from "supertest";
 import fetch from "node-fetch";
 import getAppHelper from "../helpers/app";
-import { ROLES, InvitationType } from "snu-lib";
+import { ROLES, InvitationType, SUB_ROLE_GOD } from "snu-lib";
 import { getMockAppelAProjetDto } from "../fixtures/cle/appelAProjet";
 import * as apiEducationModule from "../../services/gouv.fr/api-education";
 import passport from "passport";
 import { dbConnect, dbClose } from "../helpers/db";
 import { getEtablissementsFromAnnuaire } from "../fixtures/providers/annuaireEtablissement";
-import { ClasseDocument, ClasseModel, EtablissementDocument, EtablissementModel, ReferentDocument, ReferentModel } from "../../models";
+import { ClasseModel, EtablissementModel, ReferentModel } from "../../models";
 import * as featureServiceModule from "../../featureFlag/featureFlagService";
 
 jest.mock("../../utils", () => ({
@@ -44,7 +44,7 @@ describe("Appel A Projet Controller", () => {
   describe("POST /cle/appel-a-projet/simulate", () => {
     it("should return 200 OK with appelAProjet data for super admin", async () => {
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
 
       const response1 = Promise.resolve({
         json: () => {
@@ -79,7 +79,7 @@ describe("Appel A Projet Controller", () => {
 
     it("should return a zip file", async () => {
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
       const response = Promise.resolve({
         json: () => {
           return getMockAppelAProjetDto(false);
@@ -99,7 +99,7 @@ describe("Appel A Projet Controller", () => {
 
     it("should DS be called a maximum of 50 times", async () => {
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
 
       const response1 = Promise.resolve({
         json: () => {
@@ -121,7 +121,7 @@ describe("Appel A Projet Controller", () => {
       const etablissementBeforeSync = await EtablissementModel.findOne({ uai: "UAI_42" });
       expect(etablissementBeforeSync).toBeNull();
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
       const responseAppelAProjetMock = Promise.resolve({
         json: () => {
           return getMockAppelAProjetDto(false);
@@ -165,7 +165,7 @@ describe("Appel A Projet Controller", () => {
       await EtablissementModel.create(mockEtablissement);
 
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
       const responseAppelAProjetMock = Promise.resolve({
         json: () => {
           return getMockAppelAProjetDto(false);
@@ -215,7 +215,7 @@ describe("Appel A Projet Controller", () => {
       await ReferentModel.create(mockReferent);
 
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
       const responseAppelAProjetMock = Promise.resolve({
         json: () => {
           return getMockAppelAProjetDto(false);
@@ -265,7 +265,7 @@ describe("Appel A Projet Controller", () => {
       const referent = await ReferentModel.create(mockReferent);
 
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
       const responseAppelAProjetMock = Promise.resolve({
         json: () => {
           return getMockAppelAProjetDto(false);
@@ -284,7 +284,7 @@ describe("Appel A Projet Controller", () => {
 
     it("should not change invitationType if run twice", async () => {
       // @ts-ignore
-      passport.user.subRole = "god";
+      passport.user.subRole = SUB_ROLE_GOD;
       const responseAppelAProjetMock = Promise.resolve({
         json: () => {
           return getMockAppelAProjetDto(false);

--- a/api/src/__tests__/cle/classe.test.ts
+++ b/api/src/__tests__/cle/classe.test.ts
@@ -2,7 +2,7 @@ import request from "supertest";
 import { Types } from "mongoose";
 const { ObjectId } = Types;
 import emailsEmitter from "../../emails";
-import snuLib, { FUNCTIONAL_ERRORS, LIMIT_DATE_ESTIMATED_SEATS } from "snu-lib";
+import snuLib, { FUNCTIONAL_ERRORS, LIMIT_DATE_ESTIMATED_SEATS, SUB_ROLE_GOD } from "snu-lib";
 import { ROLES, SUB_ROLES, STATUS_CLASSE, SENDINBLUE_TEMPLATES, CLE_COLORATION, TYPE_CLASSE, ERRORS, ClasseCertificateKeys } from "snu-lib";
 import * as classeService from "../../cle/classe/classeService";
 import { dbConnect, dbClose } from "../helpers/db";
@@ -857,7 +857,7 @@ describe("PUT /cle/classe/:id/referent", () => {
       email: "john.doe@example.com",
     };
 
-    const res = await request(getAppHelper({ role: ROLES.ADMIN, subRole: "god" }))
+    const res = await request(getAppHelper({ role: ROLES.ADMIN, subRole: SUB_ROLE_GOD }))
       .put(`/cle/classe/${classe._id}/referent`)
       .send(newReferentDetails); // sending new referent data
     const updatedReferent: ReferentDocument = (await ReferentModel.findOne({ email: newReferentDetails.email }))!;

--- a/api/src/__tests__/cle/classeImport.test.ts
+++ b/api/src/__tests__/cle/classeImport.test.ts
@@ -6,7 +6,7 @@ import { ClasseModel, CohortModel } from "../../models";
 import { createFixtureClasse } from "../fixtures/classe";
 import getNewCohortFixture from "../fixtures/cohort";
 import passport from "passport";
-import { ERRORS, FUNCTIONAL_ERRORS, ROLES, STATUS_CLASSE } from "snu-lib";
+import { ERRORS, FUNCTIONAL_ERRORS, ROLES, STATUS_CLASSE, SUB_ROLE_GOD } from "snu-lib";
 import { dbClose, dbConnect } from "../helpers/db";
 import * as featureServiceModule from "../../featureFlag/featureFlagService";
 import mongoose from "mongoose";
@@ -28,7 +28,7 @@ beforeEach(async () => {
   //@ts-ignore
   passport.user.role = ROLES.ADMIN;
   //@ts-ignore
-  passport.user.subRole = "god";
+  passport.user.subRole = SUB_ROLE_GOD;
   jest.spyOn(featureServiceModule, "isFeatureAvailable").mockImplementation(() => Promise.resolve(true));
 });
 

--- a/api/src/__tests__/cle/classes.test.ts
+++ b/api/src/__tests__/cle/classes.test.ts
@@ -4,7 +4,7 @@ import passport from "passport";
 import mongoose from "mongoose";
 // @ts-ignore
 import emailsEmitter from "../../emails";
-import { ERRORS, ROLES } from "snu-lib";
+import { ERRORS, ROLES, SUB_ROLE_GOD } from "snu-lib";
 import { dbClose, dbConnect } from "../helpers/db";
 import getAppHelper from "../helpers/app";
 import { createClasse } from "../helpers/classe";
@@ -23,7 +23,7 @@ beforeEach(async () => {
   await EtablissementModel.deleteMany({});
   await ReferentModel.deleteMany({});
   passport.user.role = ROLES.ADMIN;
-  passport.user.subRole = "god";
+  passport.user.subRole = SUB_ROLE_GOD;
   newReferent = {
     firstName: "New",
     lastName: "Referent",
@@ -154,7 +154,7 @@ describe("PUT /update-referents-by-csv", () => {
 
   it("should return 400 when the CSV file is invalid", async () => {
     passport.user.role = ROLES.ADMIN;
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
     const res = await request(getAppHelper()).put("/cle/classes/update-referents-by-csv").attach("file", Buffer.from("invalid csv data"), "invalid.csv");
     expect(res.status).toBe(400);
     expect(res.body.code).toBe(ERRORS.INVALID_BODY);
@@ -162,7 +162,7 @@ describe("PUT /update-referents-by-csv", () => {
 
   it("should return 200 and update referents when the CSV file is valid", async () => {
     passport.user.role = ROLES.ADMIN;
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
     const classe = await createClasse(createFixtureClasse());
     const newReferent = { firstName: "New", lastName: "Referent", email: "new.referent@example.com" };
     const csvData = `classeId,firstName,lastName,email\n${classe._id.toString()},${newReferent.firstName},${newReferent.lastName},${newReferent.email}`;

--- a/api/src/__tests__/cle/referent.test.ts
+++ b/api/src/__tests__/cle/referent.test.ts
@@ -2,7 +2,7 @@ import request from "supertest";
 import passport from "passport";
 import { fakerFR as faker } from "@faker-js/faker";
 
-import { ClasseSchoolYear, InvitationType, ROLES, STATUS_CLASSE, SUB_ROLES, UserDto } from "snu-lib";
+import { ClasseSchoolYear, InvitationType, ROLES, STATUS_CLASSE, SUB_ROLE_GOD, SUB_ROLES, UserDto } from "snu-lib";
 
 import { ClasseModel, EtablissementModel, ReferentModel } from "../../models";
 import {
@@ -356,7 +356,7 @@ describe("POST /cle/referent/send-invitation-chef-etablissement", () => {
     // @ts-ignore
     passport.user.role = ROLES.ADMIN;
     // @ts-ignore
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
 
     const res = await request(getAppHelper()).post("/cle/referent/send-invitation-chef-etablissement").send();
 
@@ -395,7 +395,7 @@ describe("POST /cle/referent/send-invitation-referent-classe", () => {
     // @ts-ignore
     passport.user.role = ROLES.ADMIN;
     // @ts-ignore
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
 
     const res = await request(getAppHelper()).post("/cle/referent/send-invitation-referent-classe-verifiee").send();
 

--- a/api/src/__tests__/cohort.test.ts
+++ b/api/src/__tests__/cohort.test.ts
@@ -4,7 +4,7 @@ import getNewCohortFixture from "./fixtures/cohort";
 import { createCohortHelper } from "./helpers/cohort";
 import { createClasse } from "./helpers/classe";
 import { createFixtureClasse } from "./fixtures/classe";
-import { COHORT_TYPE, ROLES, STATUS_CLASSE } from "snu-lib";
+import { COHORT_TYPE, ROLES, STATUS_CLASSE, SUB_ROLE_GOD } from "snu-lib";
 import passport from "passport";
 import { dbConnect, dbClose } from "./helpers/db";
 import { ClasseModel } from "../models";
@@ -68,7 +68,7 @@ describe("PUT /:cohort", () => {
     // @ts-ignore
     const previous = passport.user.subRole;
     // @ts-ignore
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
     const cohortFixture = getNewCohortFixture();
     const res = await request(getAppHelper())
       .put(`/cohort/${cohortFixture.name}`)
@@ -84,7 +84,7 @@ describe("PUT /:cohort", () => {
     // @ts-ignore
     const previous = passport.user.subRole;
     // @ts-ignore
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
     const now = new Date();
     const cohortFixture = getNewCohortFixture();
     const cohort = await createCohortHelper(cohortFixture);
@@ -105,7 +105,7 @@ describe("PUT /:cohort", () => {
     // @ts-ignore
     const previous = passport.user.subRole;
     // @ts-ignore
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
     const now = new Date();
     const oneMonthAfter = new Date(now.getFullYear(), now.getMonth() + 1, now.getDate());
     const cohortFixture = getNewCohortFixture({ type: COHORT_TYPE.CLE });
@@ -134,7 +134,7 @@ describe("PUT /:cohort", () => {
     // @ts-ignore
     const previous = passport.user.subRole;
     // @ts-ignore
-    passport.user.subRole = "god";
+    passport.user.subRole = SUB_ROLE_GOD;
     const now = new Date();
     const oneMonthBefore = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
     const cohortFixture = getNewCohortFixture({ type: COHORT_TYPE.CLE });

--- a/api/src/__tests__/referent.test.ts
+++ b/api/src/__tests__/referent.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { Types } from "mongoose";
 const { ObjectId } = Types;
 
-import { ROLES, SENDINBLUE_TEMPLATES, YOUNG_STATUS, STATUS_CLASSE, FUNCTIONAL_ERRORS, YoungType, UserDto, department2region } from "snu-lib";
+import { ROLES, SENDINBLUE_TEMPLATES, YOUNG_STATUS, STATUS_CLASSE, FUNCTIONAL_ERRORS, YoungType, UserDto, SUB_ROLE_GOD } from "snu-lib";
 
 import { CohortModel, InscriptionGoalModel, YoungModel } from "../models";
 import { getCompletionObjectifs } from "../services/inscription-goal";
@@ -704,9 +704,17 @@ describe("Referent", () => {
         .send();
       expect(res.statusCode).toEqual(404);
     });
-    it("should return 404 if type param is not found", async () => {
+    it("should return 400 if type param is not found", async () => {
       const res = await request(getAppHelper()).post("/referent/signin_as/foo/bar").send();
-      expect(res.statusCode).toEqual(404);
+      expect(res.statusCode).toEqual(400);
+    });
+    it("should return 403 when impersonate user has subrole god", async () => {
+      const referent = await createReferentHelper(getNewReferentFixture({ subRole: SUB_ROLE_GOD }));
+
+      const res = await request(getAppHelper({ role: ROLES.ADMIN }))
+        .post("/referent/signin_as/referent/" + referent._id)
+        .send();
+      expect(res.statusCode).toEqual(403);
     });
     it("should return 200 if referent found", async () => {
       const referent: any = await createReferentHelper(getNewReferentFixture());

--- a/api/src/cle/classe/classeService.test.ts
+++ b/api/src/cle/classe/classeService.test.ts
@@ -14,6 +14,7 @@ import {
   ERRORS,
   FUNCTIONAL_ERRORS,
   EtablissementType,
+  SUB_ROLE_GOD,
 } from "snu-lib";
 
 import { ClasseModel, CohortModel, YoungModel, EtablissementDocument } from "../../models";
@@ -773,7 +774,7 @@ describe("isClasseStatusCreated", () => {
 
 describe("canUpdateReferentClasseBasedOnStatus", () => {
   it("should return true for super admin", async () => {
-    const user = { role: ROLES.ADMIN, subRole: "god" };
+    const user = { role: ROLES.ADMIN, subRole: SUB_ROLE_GOD };
     const classeId = new ObjectId().toString();
     const isClasseStatusCreatedSpy = jest.spyOn(classService, "isClasseStatusCreated");
 

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -30,6 +30,8 @@ import {
   SessionPhase1Document,
   CohesionCenterDocument,
   SchoolRAMSESModel,
+  YoungDocument,
+  ReferentDocument,
 } from "../models";
 
 import emailsEmitter from "../emails";
@@ -245,29 +247,42 @@ router.post("/reset_password", passport.authenticate("referent", { session: fals
 
 router.post("/signin_as/:type/:id", passport.authenticate("referent", { session: false, failWithError: true }), async (req: UserRequest, res: Response) => {
   try {
-    const { error, value: params } = Joi.object({ id: Joi.string().required(), type: Joi.string().required() }).unknown().validate(req.params, { stripUnknown: true });
+    const { error, value: params } = Joi.object({
+      id: idSchema(),
+      type: Joi.string().allow("young", "referent").required(),
+    })
+      .unknown()
+      .validate(req.params, { stripUnknown: true });
     if (error) {
       capture(error);
       return res.status(400).send({ ok: false, code: ERRORS.INVALID_PARAMS });
     }
     const { id, type } = params;
 
-    let user: any = null;
-    if (type === "referent") user = await ReferentModel.findById(id);
-    else if (type === "young") user = await YoungModel.findById(id);
-    if (!user) return res.status(404).send({ code: ERRORS.USER_NOT_FOUND, ok: false });
+    let user: ReferentDocument | YoungDocument | null = null;
+    if (type === "referent") {
+      user = await ReferentModel.findById(id);
+    } else if (type === "young") {
+      user = await YoungModel.findById(id);
+    }
+    if (!user) {
+      return res.status(404).send({ code: ERRORS.USER_NOT_FOUND, ok: false });
+    }
 
-    if (!canSigninAs(req.user, user, type)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
+    if (!canSigninAs(req.user, user, type)) {
+      return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
+    }
 
     const token = jwt.sign({ __v: JWT_SIGNIN_VERSION, _id: user.id, lastLogoutAt: user.lastLogoutAt, passwordChangedAt: user.passwordChangedAt }, config.JWT_SECRET, {
       expiresIn: JWT_SIGNIN_MAX_AGE_SEC,
     });
-    if (type === "referent") res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS) as any);
-    else if (type === "young") {
+    if (type === "referent") {
+      res.cookie("jwt_ref", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS) as any);
+    } else if (type === "young") {
       res.cookie("jwt_young", token, cookieOptions(COOKIE_SIGNIN_MAX_AGE_MS) as any);
     }
 
-    return res.status(200).send({ ok: true, token, data: isYoung(user) ? serializeYoung(user, user) : serializeReferent(user) });
+    return res.status(200).json({ ok: true, token, data: isYoung(user) ? serializeYoung(user, user) : serializeReferent(user) });
   } catch (error) {
     capture(error);
     return res.status(500).send({ ok: false, code: ERRORS.SERVER_ERROR });

--- a/api/src/utils/validator.ts
+++ b/api/src/utils/validator.ts
@@ -1,5 +1,5 @@
 import Joi from "joi";
-import { ROLES_LIST, SUB_ROLES_LIST, VISITOR_SUB_ROLES_LIST, PHONE_ZONES_NAMES_ARR, UserDto, YoungDto } from "snu-lib";
+import { ROLES_LIST, SUB_ROLES_LIST, VISITOR_SUB_ROLES_LIST, PHONE_ZONES_NAMES_ARR, UserDto, YoungDto, SUB_ROLE_GOD } from "snu-lib";
 import { isYoung } from "../utils";
 
 // Source: https://github.com/mkg20001/joi-objectid/blob/71b2a8c0ccd31153e4efd3e7c10602b4385242f6/index.js#L12
@@ -666,7 +666,7 @@ export function validateSelf(referent) {
       password: Joi.string().allow(null, ""),
       subRole: Joi.string()
         .allow(null, "")
-        .valid(...[...SUB_ROLES_LIST, ...VISITOR_SUB_ROLES_LIST, "god"]),
+        .valid(...[...SUB_ROLES_LIST, ...VISITOR_SUB_ROLES_LIST, SUB_ROLE_GOD]),
       phone: Joi.string().allow(null, ""),
       mobile: Joi.string().allow(null, ""),
     })

--- a/packages/lib/src/cohort/cohortService.spec.ts
+++ b/packages/lib/src/cohort/cohortService.spec.ts
@@ -1,5 +1,5 @@
 import { canUpdateCenter, canUpdateCohort } from "./cohortService";
-import { CohortDto, ReferentDto } from "../dto";
+import { CohortDto, ReferentDto, UserDto } from "../dto";
 import { ROLES } from "../roles";
 
 let from;
@@ -142,7 +142,7 @@ describe("cohortService", () => {
     } as CohortDto;
     const user = {
       role: ROLES.REFERENT_REGION,
-    } as ReferentDto;
+    } as UserDto;
 
     // Act
     const result = canUpdateCenter(cohort, user);
@@ -164,7 +164,7 @@ describe("cohortService", () => {
     } as CohortDto;
     const user = {
       role: ROLES.REFERENT_REGION,
-    } as ReferentDto;
+    } as UserDto;
 
     // Act
     const result = canUpdateCenter(cohort, user);
@@ -186,7 +186,7 @@ describe("cohortService", () => {
     } as CohortDto;
     const user = {
       role: ROLES.REFERENT_DEPARTMENT,
-    } as ReferentDto;
+    } as UserDto;
 
     // Act
     const result = canUpdateCenter(cohort, user);

--- a/packages/lib/src/cohort/cohortService.ts
+++ b/packages/lib/src/cohort/cohortService.ts
@@ -17,7 +17,7 @@ export const canUpdateCohort = (cohort?: CohortDto, user?: UserDto | ReferentDto
   );
 };
 
-export const canUpdateCenter = (cohort: CohortDto | undefined, user: ReferentDto | undefined): boolean => {
+export const canUpdateCenter = (cohort?: CohortDto, user?: UserDto): boolean => {
   if (!user) return false;
   if (!cohort) return true;
 

--- a/packages/lib/src/dto/referentDto.ts
+++ b/packages/lib/src/dto/referentDto.ts
@@ -1,11 +1,11 @@
-import { ROLES, SUB_ROLES, SUPPORT_ROLES_LIST, VISITOR_SUB_ROLES_LIST } from "../roles";
+import { ROLES, SUB_ROLE_GOD, SUB_ROLES, SUPPORT_ROLES, VISITOR_SUBROLES } from "../roles";
 
 export type ReferentDto = {
   _id: string;
   firstName?: string;
   lastName?: string;
   role: (typeof ROLES)[keyof typeof ROLES];
-  subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES_LIST | keyof typeof VISITOR_SUB_ROLES_LIST | "god";
+  subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES | keyof typeof VISITOR_SUBROLES | typeof SUB_ROLE_GOD;
   structureId?: string;
   phone?: string;
   email?: string;

--- a/packages/lib/src/dto/userDto.ts
+++ b/packages/lib/src/dto/userDto.ts
@@ -1,4 +1,4 @@
-import { ROLES, SUB_ROLES, SUPPORT_ROLES_LIST, VISITOR_SUB_ROLES_LIST } from "../roles";
+import { ROLES, SUB_ROLES, SUB_ROLE_GOD, SUPPORT_ROLES_LIST, VISITOR_SUB_ROLES_LIST } from "../roles";
 
 export type UserDto = {
   _id: string;
@@ -8,8 +8,8 @@ export type UserDto = {
   lastName: string;
   structureId: string;
   region: string;
-  department: string[];
-  subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES_LIST | keyof typeof VISITOR_SUB_ROLES_LIST | "god";
+  department: string[] | string;
+  subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES_LIST | keyof typeof VISITOR_SUB_ROLES_LIST | typeof SUB_ROLE_GOD;
   sessionPhase1Id?: string;
   // young
   meetingPointId?: string;

--- a/packages/lib/src/dto/userDto.ts
+++ b/packages/lib/src/dto/userDto.ts
@@ -1,4 +1,4 @@
-import { ROLES, SUB_ROLES, SUB_ROLE_GOD, SUPPORT_ROLES_LIST, VISITOR_SUB_ROLES_LIST } from "../roles";
+import { ROLES, SUB_ROLES, SUB_ROLE_GOD, SUPPORT_ROLES, VISITOR_SUBROLES } from "../roles";
 
 export type UserDto = {
   _id: string;
@@ -9,7 +9,7 @@ export type UserDto = {
   structureId: string;
   region: string;
   department: string[] | string;
-  subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES_LIST | keyof typeof VISITOR_SUB_ROLES_LIST | typeof SUB_ROLE_GOD;
+  subRole?: keyof typeof SUB_ROLES | keyof typeof SUPPORT_ROLES | keyof typeof VISITOR_SUBROLES | typeof SUB_ROLE_GOD;
   sessionPhase1Id?: string;
   // young
   meetingPointId?: string;

--- a/packages/lib/src/mongoSchema/referent.ts
+++ b/packages/lib/src/mongoSchema/referent.ts
@@ -3,7 +3,7 @@ import { Schema, InferSchemaType } from "mongoose";
 import { SUB_ROLES_LIST, ROLES_LIST, VISITOR_SUB_ROLES_LIST } from "../roles";
 import { ReferentCreatedBy, InvitationType } from "../constants/referentConstants";
 
-import { InterfaceExtended } from "..";
+import { InterfaceExtended, SUB_ROLE_GOD } from "..";
 
 const referentMetadataSchema = {
   createdBy: {
@@ -191,7 +191,7 @@ export const ReferentSchema = {
 
   subRole: {
     type: String,
-    enum: [...SUB_ROLES_LIST, ...VISITOR_SUB_ROLES_LIST, "god"],
+    enum: [...SUB_ROLES_LIST, ...VISITOR_SUB_ROLES_LIST, SUB_ROLE_GOD],
   },
 
   // Specific fields

--- a/packages/lib/src/roles.spec.ts
+++ b/packages/lib/src/roles.spec.ts
@@ -1,0 +1,40 @@
+import { UserDto } from "./dto";
+import { canSigninAs, ROLES, SUB_ROLE_GOD } from "./roles";
+
+describe("canSigninAs function", () => {
+  it("should return true if actor is admin and target is not god", () => {
+    const actor = { role: ROLES.ADMIN } as UserDto;
+    const target = { subRole: "not_god", department: ["dep1"], region: "region1" };
+    expect(canSigninAs(actor, target, "referent")).toBe(true);
+  });
+
+  it("should return false if actor is admin and target is god", () => {
+    const actor = { role: ROLES.ADMIN } as UserDto;
+    const target = { role: ROLES.ADMIN, subRole: SUB_ROLE_GOD, department: ["dep1"], region: "region1" };
+    expect(canSigninAs(actor, target, "referent")).toBe(false);
+  });
+
+  it("should return false if actor is not admin or referent reg dep", () => {
+    const actor = { role: ROLES.VISITOR } as UserDto;
+    const target = { role: ROLES.ADMINISTRATEUR_CLE, department: ["dep1"], region: "region1" };
+    expect(canSigninAs(actor, target, "referent")).toBe(false);
+  });
+
+  it("should return true if actor is referent department and target is in same department", () => {
+    const actor = { role: ROLES.REFERENT_DEPARTMENT, department: ["dep1"] } as UserDto;
+    const target = { role: ROLES.ADMINISTRATEUR_CLE, department: ["dep1"], region: "region1" };
+    expect(canSigninAs(actor, target, "referent")).toBe(true);
+  });
+
+  it("should return true if actor is referent region and target is in same region", () => {
+    const actor = { role: ROLES.REFERENT_REGION, region: "region1" } as UserDto;
+    const target = { department: "dep1", region: "region1" };
+    expect(canSigninAs(actor, target, "young")).toBe(true);
+  });
+
+  it("should return false if actor is referent region and target is not in same region", () => {
+    const actor = { role: ROLES.REFERENT_REGION, region: "region1" } as UserDto;
+    const target = { department: "dep1", region: "region2" };
+    expect(canSigninAs(actor, target, "young")).toBe(false);
+  });
+});

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -474,35 +474,40 @@ function canSendPlanDeTransport(user) {
   return [ROLES.ADMIN, ROLES.SUPERVISOR, ROLES.TRANSPORTER].includes(user.role);
 }
 
-function isAdmin(user: Pick<UserDto, "role">) {
+interface UserRoles {
+  role?: ReferentType["role"];
+  subRole?: ReferentType["subRole"];
+}
+
+function isAdmin(user: UserRoles) {
   return ROLES.ADMIN === user.role;
 }
 
-function isReferentRegDep(user: Pick<UserDto, "role">) {
-  return [ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role);
+function isReferentRegDep(user: UserRoles) {
+  return [ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role || "");
 }
 
-function isSupervisor(user: Pick<UserDto, "role">) {
+function isSupervisor(user: UserRoles) {
   return ROLES.SUPERVISOR === user.role;
 }
 
-function isReferentOrAdmin(user: Pick<UserDto, "role">) {
+function isReferentOrAdmin(user: UserRoles) {
   return isAdmin(user) || isReferentRegDep(user);
 }
 
-function isAdminCle(user: Pick<UserDto, "role">) {
+function isAdminCle(user: UserRoles) {
   return user?.role === ROLES.ADMINISTRATEUR_CLE;
 }
 
-function isChefEtablissement(user: Pick<UserDto, "role" | "subRole">) {
+function isChefEtablissement(user: UserRoles) {
   return isAdminCle(user) && user?.subRole === SUB_ROLES.referent_etablissement;
 }
 
-function isCoordinateurEtablissement(user: Pick<UserDto, "role" | "subRole">) {
+function isCoordinateurEtablissement(user: UserRoles) {
   return isAdminCle(user) && user?.subRole === SUB_ROLES.coordinateur_cle;
 }
 
-function isReferentClasse(user: Pick<UserDto, "role">) {
+function isReferentClasse(user: UserRoles) {
   return user?.role === ROLES.REFERENT_CLASSE;
 }
 


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

- [x] Empêche l'utilisation d'un referent "god" dans `canSigninAs` (+ ajout de TU)
- [x] Validation plus strict des paramètres niveaux controlleur.
- [x] Utilisation d'une constante dans le code pour "god"
- [x] Cleanup des types de la méthode d'impersonate

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Bloquer-l-impersonate-pour-le-sous-r-le-God-12772a322d5080c3b30cfae1307bf885?pvs=23

**Testing instructions**

https://snucustomz3ln7wxn-featdo-not-allow-got-impe-admin.functions.fnc.fr-par.scw.cloud/

- en tant que modérateur (role admin et pas de subrole), aller sur la liste des utilisateurs et essayer de prendre la place d'un god.
