### PR TITLE
fix(api,admin): 3603 - Bloquer les inscriptions aux objectifs départementaux et non régionaux

### DIFF
--- a/admin/src/scenes/phase0/YoungFooterNoRequest.tsx
+++ b/admin/src/scenes/phase0/YoungFooterNoRequest.tsx
@@ -166,7 +166,7 @@ export function getConfirmModalContent({
   } else if (isGoalReached) {
     title = (
       <span>
-        L&apos;objectif d&apos;inscription de votre région a été atteint à 100%. Le dossier d&apos;inscription de {young.firstName} {young.lastName} va être{" "}
+        L&apos;objectif d&apos;inscription de votre département a été atteint à 100%. Le dossier d&apos;inscription de {young.firstName} {young.lastName} va être{" "}
         <strong className="text-bold">validé sur liste complémentaire</strong>.
       </span>
     );
@@ -196,7 +196,7 @@ export function getConfirmModalContent({
   } else {
     title = (
       <span>
-        L&apos;objectif d&apos;inscription de votre région n&apos;a pas été atteint à 100%. Le dossier d&apos;inscription de {young.firstName} {young.lastName} va être{" "}
+        L&apos;objectif d&apos;inscription de votre département n&apos;a pas été atteint à 100%. Le dossier d&apos;inscription de {young.firstName} {young.lastName} va être{" "}
         <strong className="text-bold">validé sur liste principale</strong>.
       </span>
     );

--- a/api/src/services/inscription-goal.test.ts
+++ b/api/src/services/inscription-goal.test.ts
@@ -1,6 +1,37 @@
-import { FILLING_RATE_LIMIT, getCompletionObjectifDepartement, getCompletionObjectifs } from "./inscription-goal";
+import { FILLING_RATE_LIMIT, getCompletionObjectifDepartement, getCompletionObjectifRegion, getCompletionObjectifs } from "./inscription-goal";
 import { YoungModel, InscriptionGoalModel } from "../models";
 import { FUNCTIONAL_ERRORS } from "snu-lib";
+
+describe("getCompletionObjectifRegion", () => {
+  it("should return the completion objectif region", async () => {
+    const region = "region1";
+    const cohort = "cohort1";
+    const total = 100;
+    const jeunesCount = 50;
+
+    InscriptionGoalModel.aggregate = jest.fn().mockResolvedValue([{ _id: "region", total }]);
+    YoungModel.find = jest.fn().mockReturnThis();
+    YoungModel.countDocuments = jest.fn().mockResolvedValue(jeunesCount);
+
+    const result = await getCompletionObjectifRegion(region, cohort);
+
+    expect(result).toEqual({
+      jeunesCount,
+      objectif: total,
+      tauxRemplissage: 0.5,
+      isAtteint: false,
+    });
+  });
+
+  it("should throw an error if there is no total", async () => {
+    const region = "region1";
+    const cohort = "cohort1";
+
+    InscriptionGoalModel.aggregate = jest.fn().mockResolvedValue([]);
+
+    await expect(getCompletionObjectifRegion(region, cohort)).rejects.toThrow(FUNCTIONAL_ERRORS.INSCRIPTION_GOAL_NOT_DEFINED);
+  });
+});
 
 describe("getCompletionObjectifDepartement", () => {
   it("should return the correct filling rate", async () => {
@@ -52,20 +83,28 @@ describe("getCompletionObjectifs", () => {
     const department = "Test Department";
     const cohort = "Test Cohort";
     const count = 50;
-    const max = 100;
+    const maxDepartment = 100;
+    const maxRegion = 500;
 
     YoungModel.find = jest.fn().mockReturnValue({
       countDocuments: jest.fn().mockResolvedValue(count),
     });
 
-    InscriptionGoalModel.findOne = jest.fn().mockResolvedValue({ max });
-    InscriptionGoalModel.aggregate = jest.fn().mockResolvedValue([{ total: max }]);
+    InscriptionGoalModel.findOne = jest.fn().mockResolvedValue({ max: maxDepartment });
+    InscriptionGoalModel.aggregate = jest.fn().mockResolvedValue([{ total: maxRegion }]);
 
     const stats = await getCompletionObjectifs(department, cohort);
 
     expect(stats.department.jeunesCount).toBe(count);
-    expect(stats.department.objectif).toBe(max);
+    expect(stats.department.objectif).toBe(maxDepartment);
     expect(stats.department.tauxRemplissage).toBe(0.5);
+    expect(stats.department.isAtteint).toBe(false);
+    expect(stats.region.jeunesCount).toBe(count);
+    expect(stats.region.objectif).toBe(maxRegion);
+    expect(stats.region.isAtteint).toBe(false);
+    expect(stats.region.tauxRemplissage).toBe(0.1);
+    expect(stats.isAtteint).toBe(false);
+    expect(stats.tauxRemplissage).toBe(0.5);
     expect(stats.tauxLimiteRemplissage).toBe(FILLING_RATE_LIMIT);
   });
 

--- a/api/src/services/inscription-goal.ts
+++ b/api/src/services/inscription-goal.ts
@@ -37,7 +37,7 @@ export const getCompletionObjectifRegion = async (region: string, cohort: string
 };
 
 // Vérification des objectifs pour un département donné
-export const getCompletionObjectifDepartement = async (department: string, cohort: string) => {
+export const getCompletionObjectifDepartement = async (department: string, cohort: string): Promise<CompletionObjectif> => {
   const jeunesCount = (await YoungModel.find({ department, status: { $in: ["VALIDATED"] }, cohort }).countDocuments()) || 0;
   const objectif = await InscriptionGoalModel.findOne({ department, cohort });
   if (!objectif || !objectif.max) {
@@ -54,9 +54,9 @@ export const getCompletionObjectifs = async (department: string, cohort: string)
   return {
     department: completionObjectifDepartement,
     region: completionObjectifRegion,
-    // uniquement la région est utilisé pour la completion des objectifs
-    isAtteint: completionObjectifRegion.isAtteint,
-    tauxRemplissage: completionObjectifRegion.tauxRemplissage,
+    // completion des objectifs départemententaux et régionaux
+    isAtteint: completionObjectifRegion.isAtteint || completionObjectifDepartement.isAtteint,
+    tauxRemplissage: Math.max(completionObjectifRegion.tauxRemplissage, completionObjectifDepartement.tauxRemplissage),
     tauxLimiteRemplissage: FILLING_RATE_LIMIT,
   };
 };

--- a/api/src/services/inscription-goal.ts
+++ b/api/src/services/inscription-goal.ts
@@ -54,7 +54,7 @@ export const getCompletionObjectifs = async (department: string, cohort: string)
   return {
     department: completionObjectifDepartement,
     region: completionObjectifRegion,
-    // completion des objectifs départemententaux et régionaux
+    // completion des objectifs départementaux et régionaux
     isAtteint: completionObjectifRegion.isAtteint || completionObjectifDepartement.isAtteint,
     tauxRemplissage: Math.max(completionObjectifRegion.tauxRemplissage, completionObjectifDepartement.tauxRemplissage),
     tauxLimiteRemplissage: FILLING_RATE_LIMIT,


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->


**Ticket / Issue**

https://www.notion.so/jeveuxaider/HTS-2025-Bloquer-les-inscriptions-aux-objectifs-d-partementaux-et-non-r-gionaux-12e72a322d5080eb9031c96b46f4e354?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
