### PR TITLE
chore(api): cron coherence cohortId - ne pas check les young deleted

### DIFF
--- a/api/src/crons/checkCoherence.ts
+++ b/api/src/crons/checkCoherence.ts
@@ -1,3 +1,5 @@
+import { YOUNG_STATUS } from "snu-lib";
+
 import { YoungModel } from "../models";
 import { logger } from "../logger";
 import { capture } from "../sentry";
@@ -6,7 +8,7 @@ import slack from "../slack";
 export const handler = async () => {
   try {
     // get all young without cohortId
-    const youngs = await YoungModel.find({ cohort: { $exists: true }, cohortId: { $exists: false } }).select({ _id: 1, cohort: 1 });
+    const youngs = await YoungModel.find({ cohort: { $exists: true }, cohortId: { $exists: false }, status: { $ne: YOUNG_STATUS.DELETED } }).select({ _id: 1, cohort: 1 });
 
     if (youngs.length > 0) {
       const youngsCountByCohort = youngs.reduce((acc, cur) => {

--- a/api/src/crons/index.js
+++ b/api/src/crons/index.js
@@ -110,7 +110,7 @@ const CRONS = [
   cron("syncContactSupport", "15 1 * * *", syncContactSupport.handler),
   cron("mongoMonitoring", "*/5 * * * *", mongoMonitoring.handler),
   cron("classesStatusUpdate", "2 */1 * * *", classesStatusUpdate.handler),
-  cron("checkCoherence", "30 6,11,15 * * *", checkCoherence.handler),
+  cron("checkCoherence", "30 7,12,16 * * *", checkCoherence.handler),
 ];
 
 module.exports = CRONS;


### PR DESCRIPTION
**Description**

Le cron de vérification de la cohérence des cohortId des jeunes vérifie à tord les jeunes aux status "DELETED"

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->


**Ticket / Issue**

<!-- If you have a Notion Ticket / GitHub Issue -->
<!-- Fixes [Notion ticket #123](https://notion.so/abc) -->

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
