### PR TITLE
feat(api): 3567 - Automatiser le script de validation de la phase 1

### DIFF
--- a/admin/src/scenes/settings/tabs/GeneralTab.tsx
+++ b/admin/src/scenes/settings/tabs/GeneralTab.tsx
@@ -930,7 +930,7 @@ export default function GeneralTab({ cohort, onCohortChange, readOnly, getCohort
                   </ReactTooltip>
                 </div>
                 {/* @ts-ignore */}
-                <NumberInput days={cohort.daysToValidate ?? 8} label={"Nombre de jour pour validation"} onChange={(e) => onCohortChange({ ...cohort, daysToValidate: e })} />
+                <NumberInput days={cohort.daysToValidate} label={"Nombre de jour pour validation"} onChange={(e) => onCohortChange({ ...cohort, daysToValidate: e })} />
               </div>
             </div>
           </div>

--- a/admin/src/scenes/settings/tabs/GeneralTab.tsx
+++ b/admin/src/scenes/settings/tabs/GeneralTab.tsx
@@ -930,7 +930,7 @@ export default function GeneralTab({ cohort, onCohortChange, readOnly, getCohort
                   </ReactTooltip>
                 </div>
                 {/* @ts-ignore */}
-                <NumberInput days={cohort.daysToValidate} label={"Nombre de jour pour validation"} onChange={(e) => onCohortChange({ ...cohort, daysToValidate: e })} />
+                <NumberInput days={cohort.daysToValidate ?? 8} label={"Nombre de jour pour validation"} onChange={(e) => onCohortChange({ ...cohort, daysToValidate: e })} />
               </div>
             </div>
           </div>

--- a/api/migrations/20241120144707-add-daysToValidate-cohort.js
+++ b/api/migrations/20241120144707-add-daysToValidate-cohort.js
@@ -1,0 +1,7 @@
+const { CohortModel } = require("../src/models");
+
+module.exports = {
+  async up() {
+    await CohortModel.updateMany({ daysToValidate: null }, { $set: { daysToValidate: 8 } });
+  },
+};

--- a/api/src/crons/__tester__.ts
+++ b/api/src/crons/__tester__.ts
@@ -1,8 +1,7 @@
 // To test run:
 // ts-node ./src/crons/__tester__.ts patch/young
-
-// uncomment when running in local
-// process.env["NODE_CONFIG_DIR"] = "<RELATIVE PATH>/service-national-universel/api/config/";
+import path from "path";
+process.env["NODE_CONFIG_DIR"] = path.resolve(__dirname, "../../config");
 
 import config from "config";
 import { initDB } from "../mongo";
@@ -42,6 +41,9 @@ import { initDB } from "../mongo";
       break;
     case "check-coherence":
       await require("./checkCoherence").handler();
+      break;
+    case "autoValidatePhase1":
+      await require("./autoValidatePhase1").handler();
       break;
     default:
       console.log("No cron found for " + process.argv[2]);

--- a/api/src/crons/__tester__.ts
+++ b/api/src/crons/__tester__.ts
@@ -1,7 +1,7 @@
 // To test run:
 // ts-node ./src/crons/__tester__.ts patch/young
-// import path from "path";
-// process.env["NODE_CONFIG_DIR"] = path.resolve(__dirname, "../../config");
+import path from "path";
+process.env["NODE_CONFIG_DIR"] = path.resolve(__dirname, "../../config");
 
 import config from "config";
 import { initDB } from "../mongo";

--- a/api/src/crons/__tester__.ts
+++ b/api/src/crons/__tester__.ts
@@ -1,7 +1,7 @@
 // To test run:
 // ts-node ./src/crons/__tester__.ts patch/young
-import path from "path";
-process.env["NODE_CONFIG_DIR"] = path.resolve(__dirname, "../../config");
+// import path from "path";
+// process.env["NODE_CONFIG_DIR"] = path.resolve(__dirname, "../../config");
 
 import config from "config";
 import { initDB } from "../mongo";

--- a/api/src/crons/autoValidatePhase1.ts
+++ b/api/src/crons/autoValidatePhase1.ts
@@ -25,11 +25,6 @@ export const handler = async (): Promise<void> => {
         const sessionPhase1 = await CohortModel.findById(young.sessionPhase1Id);
         const dateStart = getDepartureDate(young, sessionPhase1, cohort, { bus });
 
-        let daysToValidate = cohort.daysToValidate;
-        if (!daysToValidate) {
-          console.warn(`Cohort ${cohort.name} has no daysToValidate`);
-          daysToValidate = 8;
-        }
         if (differenceInDays(now, dateStart) !== cohort.daysToValidate) continue;
 
         const validationDateWithDays = addDays(new Date(dateStart), cohort.daysToValidate).toISOString();

--- a/api/src/crons/autoValidatePhase1.ts
+++ b/api/src/crons/autoValidatePhase1.ts
@@ -17,7 +17,7 @@ export const handler = async (): Promise<void> => {
     if (!onGoingCohorts.length) return;
 
     for (const cohort of onGoingCohorts) {
-      const youngs = await YoungModel.find({ cohortId: cohort._id, status: "VALIDATED", statusPhase1: "AFFECTED" });
+      const youngs = await YoungModel.find({ cohortId: cohort._id, status: YOUNG_STATUS.VALIDATED, statusPhase1: YOUNG_STATUS_PHASE1.AFFECTED });
 
       let nbYoungs = 0;
       for (const young of youngs) {

--- a/api/src/crons/autoValidatePhase1.ts
+++ b/api/src/crons/autoValidatePhase1.ts
@@ -4,7 +4,7 @@ import { updateStatusPhase1 } from "../utils";
 import { capture } from "../sentry";
 import slack from "../slack";
 import { CohortModel, LigneBusModel, YoungModel } from "../models";
-import { getDepartureDate } from "snu-lib";
+import { getDepartureDate, YOUNG_STATUS, YOUNG_STATUS_PHASE1 } from "snu-lib";
 
 export const handler = async (): Promise<void> => {
   try {
@@ -17,22 +17,22 @@ export const handler = async (): Promise<void> => {
     if (!onGoingCohorts.length) return;
 
     for (const cohort of onGoingCohorts) {
-      const youngs = await YoungModel.find({ cohortId: cohort._id, status: YOUNG_STATUS.VALIDATED, statusPhase1: YOUNG_STATUS_PHASE1.AFFECTED });
+      const cursor = await YoungModel.find({ cohortId: cohort._id, status: YOUNG_STATUS.VALIDATED, statusPhase1: YOUNG_STATUS_PHASE1.AFFECTED }).cursor();
 
       let nbYoungs = 0;
-      for (const young of youngs) {
+      await cursor.eachAsync(async (young) => {
         const bus = await LigneBusModel.findById(young.ligneId);
         const sessionPhase1 = await CohortModel.findById(young.sessionPhase1Id);
         const dateStart = getDepartureDate(young, sessionPhase1, cohort, { bus });
 
-        if (differenceInDays(now, dateStart) !== cohort.daysToValidate) continue;
+        if (differenceInDays(now, dateStart) !== cohort.daysToValidate) return;
 
         const validationDateWithDays = addDays(new Date(dateStart), cohort.daysToValidate).toISOString();
         const modified = await updateStatusPhase1(young, validationDateWithDays, {
           firstName: `[CRON] Autovalidation de la phase 1 après ${cohort.daysToValidate} jours après le départ`,
         });
         if (modified) nbYoungs++;
-      }
+      });
 
       if (nbYoungs > 0) {
         slack.success({

--- a/api/src/crons/autoValidatePhase1.ts
+++ b/api/src/crons/autoValidatePhase1.ts
@@ -9,7 +9,6 @@ import { getDepartureDate } from "snu-lib";
 export const handler = async (): Promise<void> => {
   try {
     const now = new Date().toISOString();
-    console.log("🚀 ~ file: autoValidatePhase1.ts:11 ~ handler ~ now:", now);
 
     const onGoingCohorts = await CohortModel.find({
       $and: [{ dateStart: { $lte: now } }, { dateEnd: { $gte: now } }],
@@ -49,6 +48,7 @@ export const handler = async (): Promise<void> => {
     }
   } catch (e) {
     capture(e);
+    slack.error({ title: "CheckCoherence", text: JSON.stringify(e) });
     throw e;
   }
 };

--- a/api/src/crons/autoValidatePhase1.ts
+++ b/api/src/crons/autoValidatePhase1.ts
@@ -10,8 +10,10 @@ export const handler = async (): Promise<void> => {
   try {
     const now = new Date().toISOString();
 
+    const cohortsAVenir = ["CLE 23-24", "2025 CLE Globale"];
+
     const onGoingCohorts = await CohortModel.find({
-      $and: [{ dateStart: { $lte: now } }, { dateEnd: { $gte: now } }],
+      $and: [{ dateStart: { $lte: now } }, { dateEnd: { $gte: now } }, { name: { $nin: cohortsAVenir } }],
     });
 
     if (!onGoingCohorts.length) return;

--- a/api/src/crons/index.js
+++ b/api/src/crons/index.js
@@ -30,7 +30,7 @@ const mongoMonitoring = require("./mongoMonitoring");
 const classesStatusUpdate = require("./classesStatusUpdate");
 const monitorCertificats = require("./monitorCertificats");
 const checkCoherence = require("./checkCoherence");
-
+const autoValidatePhase1 = require("./autoValidatePhase1");
 
 // doubt ? -> https://crontab.guru/
 
@@ -115,6 +115,7 @@ const CRONS = [
   cron("classesStatusUpdate", "2 */1 * * *", classesStatusUpdate.handler),
   cron("monitorCertificats", "0 3 1 * *", monitorCertificats.handler),
   cron("checkCoherence", "30 7,12,16 * * *", checkCoherence.handler),
+  cron("autoValidatePhase1", "20 1 * * *", autoValidatePhase1.handler),
 ];
 
 module.exports = CRONS;

--- a/api/src/sentry.js
+++ b/api/src/sentry.js
@@ -92,7 +92,7 @@ function capture(err, contexte) {
     return sentryCaptureMessage(err.message, contexte);
   } else {
     const msg = "Error not defined well (Change to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#examples)";
-    logger.error(`capture: ${msg}`);
+    logger.error(`capture: ${msg} : Error ?= ${err}`);
     return sentryCaptureMessage(msg, { extra: { error: err, contexte: contexte } });
   }
 }

--- a/api/src/sentry.js
+++ b/api/src/sentry.js
@@ -69,6 +69,8 @@ function capture(err, contexte) {
     return sentryCaptureMessage(msg);
   }
 
+  if (typeof err === "string") return captureMessage(err, contexte);
+
   if (err instanceof Error) {
     // Capture the current error and recursively capture any nested causes
     const eventId = captureError(err, contexte);

--- a/api/src/sentry.js
+++ b/api/src/sentry.js
@@ -92,7 +92,7 @@ function capture(err, contexte) {
     return sentryCaptureMessage(err.message, contexte);
   } else {
     const msg = "Error not defined well (Change to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#examples)";
-    logger.error(`capture: ${msg} : Error ?= ${err}`);
+    logger.error(`capture: ${msg}: Error ${err}`);
     return sentryCaptureMessage(msg, { extra: { error: err, contexte: contexte } });
   }
 }

--- a/api/src/slack.js
+++ b/api/src/slack.js
@@ -2,7 +2,7 @@ const fetch = require("node-fetch");
 
 const config = require("config");
 const { logger } = require("./logger");
-const { capture } = require("./sentry");
+const { capture, captureMessage } = require("./sentry");
 
 const STATUS_PREFIX = {
   error: "❌",
@@ -16,7 +16,7 @@ const STATUS_COLOR = {
 };
 
 const postMessage = async ({ title, text, author_name, color }) => {
-  if (!config.SLACK_BOT_TOKEN || !config.SLACK_BOT_CHANNEL) return capture("NO SLACK CREDENTIALS");
+  if (!config.SLACK_BOT_TOKEN || !config.SLACK_BOT_CHANNEL) return captureMessage("NO SLACK CREDENTIALS");
   const payload = {
     channel: config.SLACK_BOT_CHANNEL,
     attachments: [

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -729,15 +729,12 @@ async function addingDayToDate(days, dateStart) {
   return formattedValidationDate;
 }
 
-async function autoValidationSessionPhase1Young({ young, sessionPhase1, cohort = null, user }) {
+async function autoValidationSessionPhase1Young({ young, sessionPhase1, user }) {
   let cohortWithOldRules = ["2021", "2022", "Février 2023 - C", "Avril 2023 - A", "Avril 2023 - B", "Juin 2023"];
-  let youngCohort = cohort;
-  if (!cohort) {
-    youngCohort = await CohortModel.findOne({ name: young.cohort });
-  }
+  const youngCohort = await CohortModel.findOne({ name: young.cohort });
 
   // ! Freeze validation for legacy cohort
-  if (cohortWithOldRules.includes(young.cohort) || cohortWithOldRules.includes(youngCohort.name)) return;
+  if (cohortWithOldRules.includes(youngCohort.name)) return;
 
   const { daysToValidate: daysToValidate, dateStart: dateStartCohort } = await getCohortDateInfo(sessionPhase1.cohort);
 
@@ -762,7 +759,7 @@ async function updateStatusPhase1(young, validationDateWithDays, user) {
     // Cette constante nous permet de vérifier si un jeune était présent au début du séjour (exception pour cette cohorte : pas besoin de JDM)(basé sur son grade)
     // ! Si null, on considère que le statut de pointage n'est pas encore connu (présent/absent)
     const isCohesionStayValid = young.cohesionStayPresence === "true";
-    // Cette constante nour permet de vérifier si la date de départ d'un jeune permet de valider sa phase 1 (basé sur son grade)
+    // Cette constante pour permet de vérifier si la date de départ d'un jeune permet de valider sa phase 1 (basé sur son grade)
     const isDepartureDateValid = now >= validationDate && (!young?.departSejourAt || young?.departSejourAt >= validationDate);
     // On valide la phase 1 si toutes les condition sont réunis. Une exception : le jeune a été exclu.
     if (isValidationDatePassed) {

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -738,7 +738,7 @@ async function autoValidationSessionPhase1Young({ young, sessionPhase1, user }) 
     daysToValidate: daysToValidate,
     validationDate: dateDeValidation,
     validationDateForTerminaleGrade: dateDeValidationTerminale,
-    dateStart: dateStartcohort,
+    dateStart: dateStartCohort,
   } = await getCohortDateInfo(sessionPhase1.cohort);
 
   // Ici on regarde si la session à des date spécifique sinon on garde la date de la cohort
@@ -756,7 +756,7 @@ async function autoValidationSessionPhase1Young({ young, sessionPhase1, user }) 
   } else {
     await updateStatusPhase1(young, validationDateWithDays, user);
   }
-  return { dateStart, daysToValidate, validationDateWithDays, dateStartcohort };
+  return { dateStart, daysToValidate, validationDateWithDays, dateStartCohort };
 }
 
 async function updateStatusPhase1(young, validationDateWithDays, user) {

--- a/api/src/utils/index.js
+++ b/api/src/utils/index.js
@@ -780,9 +780,7 @@ async function updateStatusPhase1(young, validationDateWithDays, user) {
       }
     }
     if (initialState !== young.statusPhase1) {
-      console.log("🚀 ~ file: index.js:839 ~ updateStatusPhase1 ~ initialState:", initialState);
-      console.log("🚀 ~ file: index.js:839 ~ updateStatusPhase1 ~ young.statusPhase1:", young.statusPhase1);
-      // await young.save({ fromUser: user });
+      await young.save({ fromUser: user });
       return true;
     }
   } catch (e) {

--- a/api/src/utils/old_cohorts_logic.js
+++ b/api/src/utils/old_cohorts_logic.js
@@ -1,6 +1,6 @@
 import { capture } from "../sentry";
 
-async function updateStatusPhase1WithSpecificCase(young, validationDate, user) {
+export async function updateStatusPhase1WithSpecificCase(young, validationDate, user) {
   try {
     const now = new Date();
     // Cette constante nous permet de vérifier si un jeune a passé sa date de validation (basé sur son grade)
@@ -37,7 +37,7 @@ async function updateStatusPhase1WithSpecificCase(young, validationDate, user) {
   }
 }
 
-async function updateStatusPhase1WithOldRules(young, validationDate, isTerminale, user) {
+export async function updateStatusPhase1WithOldRules(young, validationDate, isTerminale, user) {
   try {
     const now = new Date();
     // Cette constante nous permet de vérifier si un jeune a passé sa date de validation (basé sur son grade)
@@ -73,8 +73,3 @@ async function updateStatusPhase1WithOldRules(young, validationDate, isTerminale
     capture(e);
   }
 }
-
-module.exports = {
-  updateStatusPhase1WithOldRules,
-  updateStatusPhase1WithSpecificCase,
-};

--- a/api/src/utils/old_cohorts_logic.js
+++ b/api/src/utils/old_cohorts_logic.js
@@ -1,0 +1,80 @@
+import { capture } from "../sentry";
+
+async function updateStatusPhase1WithSpecificCase(young, validationDate, user) {
+  try {
+    const now = new Date();
+    // Cette constante nous permet de vérifier si un jeune a passé sa date de validation (basé sur son grade)
+    const isValidationDatePassed = now >= validationDate;
+    // Cette constante nous permet de vérifier si un jeune était présent au début du séjour (exception pour cette cohorte : pas besoin de JDM)(basé sur son grade)
+    const isCohesionStayValid = young.cohesionStayPresence === "true";
+    // Cette constante nour permet de vérifier si la date de départ d'un jeune permet de valider sa phase 1 (basé sur son grade)
+    const isDepartureDateValid = now >= validationDate && (!young?.departSejourAt || young?.departSejourAt > validationDate);
+
+    // On valide la phase 1 si toutes les condition sont réunis. Une exception : le jeune a été exclu.
+    if (isValidationDatePassed) {
+      if (isValidationDatePassed && isCohesionStayValid && isDepartureDateValid) {
+        if (young?.departSejourMotif && ["Exclusion"].includes(young.departSejourMotif)) {
+          young.set({ statusPhase1: "NOT_DONE" });
+        } else {
+          young.set({ statusPhase1: "DONE" });
+        }
+      } else {
+        // Sinon on ne valide pas sa phase 1. Exception : si le jeune a un cas de force majeur ou si urgence sanitaire, on valide sa phase 1
+        if (["Cas de force majeure pour le volontaire", "Annulation du séjour ou mesure d’éviction sanitaire"].includes(young?.departSejourMotif)) {
+          young.set({ statusPhase1: "DONE" });
+        } else if (young?.departSejourMotif && ["Exclusion", "Autre"].includes(young.departSejourMotif)) {
+          young.set({ statusPhase1: "NOT_DONE" });
+        } else if (young.cohesionStayPresence !== "false") {
+          young.set({ statusPhase1: "AFFECTED" });
+        } else {
+          young.set({ statusPhase1: "NOT_DONE", presenceJDM: "false" });
+        }
+      }
+    }
+    await young.save({ fromUser: user });
+  } catch (e) {
+    capture(e);
+  }
+}
+
+async function updateStatusPhase1WithOldRules(young, validationDate, isTerminale, user) {
+  try {
+    const now = new Date();
+    // Cette constante nous permet de vérifier si un jeune a passé sa date de validation (basé sur son grade)
+    const isValidationDatePassed = now >= validationDate;
+    // Cette constante nous permet de vérifier si un jeune était présent au début du séjour et à la JDM (basé sur son grade)
+    const isCohesionStayValid = young.cohesionStayPresence === "true" && (young.presenceJDM === "true" || isTerminale);
+    // Cette constante pour permet de vérifier si la date de départ d'un jeune permet de valider sa phase 1 (basé sur son grade)
+    const isDepartureDateValid = now >= validationDate && (!young?.departSejourAt || young?.departSejourAt > validationDate);
+
+    // On valide la phase 1 si toutes les condition sont réunis. Une exception : le jeune a été exclu.
+    if (isValidationDatePassed) {
+      if (isValidationDatePassed && isCohesionStayValid && isDepartureDateValid) {
+        if (young?.departSejourMotif && ["Exclusion"].includes(young.departSejourMotif)) {
+          young.set({ statusPhase1: "NOT_DONE" });
+        } else {
+          young.set({ statusPhase1: "DONE" });
+        }
+      } else {
+        // Sinon on ne valide pas sa phase 1. Exception : si le jeune a un cas de force majeur ou si urgence sanitaire, on valide sa phase 1
+        if (["Cas de force majeure pour le volontaire", "Annulation du séjour ou mesure d’éviction sanitaire"].includes(young?.departSejourMotif)) {
+          young.set({ statusPhase1: "DONE" });
+        } else if (young?.departSejourMotif && ["Exclusion", "Autre"].includes(young.departSejourMotif)) {
+          young.set({ statusPhase1: "NOT_DONE" });
+        } else if (young.cohesionStayPresence === "true" && !young.presenceJDM) {
+          young.set({ statusPhase1: "AFFECTED" });
+        } else {
+          young.set({ statusPhase1: "NOT_DONE", presenceJDM: "false" });
+        }
+      }
+    }
+    await young.save({ fromUser: user });
+  } catch (e) {
+    capture(e);
+  }
+}
+
+module.exports = {
+  updateStatusPhase1WithOldRules,
+  updateStatusPhase1WithSpecificCase,
+};

--- a/api/src/utils/old_cohorts_logic.js
+++ b/api/src/utils/old_cohorts_logic.js
@@ -1,6 +1,6 @@
-import { capture } from "../sentry";
+const { capture } = require("../sentry");
 
-export async function updateStatusPhase1WithSpecificCase(young, validationDate, user) {
+async function updateStatusPhase1WithSpecificCase(young, validationDate, user) {
   try {
     const now = new Date();
     // Cette constante nous permet de vérifier si un jeune a passé sa date de validation (basé sur son grade)
@@ -37,7 +37,7 @@ export async function updateStatusPhase1WithSpecificCase(young, validationDate, 
   }
 }
 
-export async function updateStatusPhase1WithOldRules(young, validationDate, isTerminale, user) {
+async function updateStatusPhase1WithOldRules(young, validationDate, isTerminale, user) {
   try {
     const now = new Date();
     // Cette constante nous permet de vérifier si un jeune a passé sa date de validation (basé sur son grade)
@@ -73,3 +73,8 @@ export async function updateStatusPhase1WithOldRules(young, validationDate, isTe
     capture(e);
   }
 }
+
+module.exports = {
+  updateStatusPhase1WithSpecificCase,
+  updateStatusPhase1WithOldRules,
+};

--- a/devops/analytics/src/index.js
+++ b/devops/analytics/src/index.js
@@ -1,4 +1,5 @@
 (async () => {
+  return;
   await require("./env-manager")();
 
   const helmet = require("helmet");

--- a/packages/lib/src/mongoSchema/cohort.ts
+++ b/packages/lib/src/mongoSchema/cohort.ts
@@ -329,6 +329,7 @@ export const CohortSchema = {
     documentation: {
       description: "Nombre de jours nécessaire pour valider le séjour",
     },
+    default: 8,
   },
 
   daysToValidateForTerminalGrade: {


### PR DESCRIPTION
Introduce a cron job that automatically validates phase 1 for ongoing cohorts based on specified parameters. Update validation logic to handle cases where days to validate are not set.
https://www.notion.so/jeveuxaider/Automatiser-le-script-de-validation-de-la-phase-1-12672a322d5080689852f080bc7dc5d1?pvs=4