### PR TITLE
fix(api,admin): 3677 - Inscription Goal utilisation du departemet de residence

### DIFF
--- a/admin/src/scenes/phase0/YoungFooterNoRequest.tsx
+++ b/admin/src/scenes/phase0/YoungFooterNoRequest.tsx
@@ -3,7 +3,7 @@ import { isBefore } from "date-fns";
 import { toastr } from "react-redux-toastr";
 import { HiInformationCircle } from "react-icons/hi";
 
-import { YOUNG_STATUS, YOUNG_SOURCE, YoungDto, getDepartmentForEligibility, translate, InscriptionGoalsRoutes } from "snu-lib";
+import { YOUNG_STATUS, YOUNG_SOURCE, YoungDto, getDepartmentForInscriptionGoal, translate } from "snu-lib";
 
 import { capture } from "@/sentry";
 import api from "@/services/api";
@@ -38,9 +38,7 @@ export function YoungFooterNoRequest({ processing, young, onProcess, footerClass
       const isDatePassed = young.latestCNIFileExpirationDate ? isBefore(new Date(young.latestCNIFileExpirationDate), new Date()) : false;
       let isGoalReached, isLCavailable;
       if (young.source !== YOUNG_SOURCE.CLE) {
-        // on vérifie la completion des objectifs pour la région (en fonction du département)
-        // schoolDepartment pour les scolarisés et HZR sinon department pour les non scolarisés
-        const departement = getDepartmentForEligibility(young);
+        const departement = getDepartmentForInscriptionGoal(young);
         const tauxRemplissage = await InscriptionGoalService.getTauxRemplissage({ cohort: young.cohort!, department: departement });
         isGoalReached = tauxRemplissage >= 1;
         // on vérifie qu'il n'y pas de jeunes en LC

--- a/admin/src/scenes/volontaires/create.tsx
+++ b/admin/src/scenes/volontaires/create.tsx
@@ -19,7 +19,7 @@ import {
   PHONE_ZONES,
   YOUNG_SOURCE,
   getSchoolYear,
-  getDepartmentForEligibility,
+  getDepartmentForInscriptionGoal,
   CohortType,
   EtablissementDto,
 } from "snu-lib";
@@ -422,8 +422,7 @@ export default function Create() {
       sendData();
     } else {
       // on vérifie la completion des objectifs pour le département
-      // schoolDepartment pour les scolarisés et HZR sinon department pour les non scolarisés
-      const departement = getDepartmentForEligibility(values);
+      const departement = getDepartmentForInscriptionGoal(values);
       const res = await api.get(`/inscription-goal/${values.cohort}/department/${departement}`);
       if (!res.ok) {
         toastr.error("Séjour non disponible: ", translate(res.code));

--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -55,7 +55,7 @@ import {
   translateFileStatusPhase1,
   REGLEMENT_INTERIEUR_VERSION,
   ReferentType,
-  getDepartmentForEligibility,
+  getDepartmentForInscriptionGoal,
   FUNCTIONAL_ERRORS,
   CohortDto,
 } from "snu-lib";
@@ -276,8 +276,7 @@ router.post("/invite", passport.authenticate("referent", { session: false, failW
     }
 
     if (obj.source !== YOUNG_SOURCE.CLE && value.status === YOUNG_STATUS.VALIDATED) {
-      // schoolDepartment pour les scolarisés et HZR sinon department pour les non scolarisés
-      const departement = getDepartmentForEligibility(obj);
+      const departement = getDepartmentForInscriptionGoal(obj);
       const completionObjectif = await getCompletionObjectifs(departement, cohort.name);
       if (completionObjectif.isAtteint) {
         return res.status(400).send({

--- a/api/src/controllers/young/phase1.ts
+++ b/api/src/controllers/young/phase1.ts
@@ -17,7 +17,7 @@ import {
   YOUNG_STATUS_PHASE1,
   REFERENT_DEPARTMENT_SUBROLE,
   getDepartmentByZip,
-  getDepartmentForEligibility,
+  getDepartmentForInscriptionGoal,
   FUNCTIONAL_ERRORS,
   DepartmentServiceType,
 } from "snu-lib";
@@ -88,8 +88,7 @@ router.post("/affectation", passport.authenticate("referent", { session: false, 
 
     // update youngs infos
     if (young.status === "WAITING_LIST") {
-      // schoolDepartment pour les scolarisés et HZR sinon department pour les non scolarisés
-      const departement = getDepartmentForEligibility(young);
+      const departement = getDepartmentForInscriptionGoal(young);
       const completionObjectif = await getCompletionObjectifs(departement, cohort.name);
       if (completionObjectif.isAtteint) {
         return res.status(400).send({

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -104,7 +104,7 @@ import {
   canUpdateInscriptionGoals,
   FUNCTIONAL_ERRORS,
   YoungType,
-  getDepartmentForEligibility,
+  getDepartmentForInscriptionGoal,
   isAdmin,
 } from "snu-lib";
 import { getFilteredSessions, getAllSessions } from "../utils/cohort";
@@ -557,8 +557,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       (!canUpdateInscriptionGoals(req.user) || !req.query.forceGoal)
     ) {
       if (!cohort) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
-      // schoolDepartment pour les scolarisés et HZR sinon department pour les non scolarisés
-      const departement = getDepartmentForEligibility(young);
+      const departement = getDepartmentForInscriptionGoal(young);
       const completionObjectif = await getCompletionObjectifs(departement, cohort.name);
       if (completionObjectif.isAtteint) {
         return res.status(400).send({

--- a/packages/lib/src/region-and-departments.spec.ts
+++ b/packages/lib/src/region-and-departments.spec.ts
@@ -1,5 +1,5 @@
 import { YoungType } from "src";
-import { getDepartmentForEligibility, getRegionForEligibility } from "./region-and-departments";
+import { getDepartmentForEligibility, getRegionForEligibility, getDepartmentForInscriptionGoal } from "./region-and-departments";
 
 describe("getDepartmentForEligibility", () => {
   it("when young is schooled should return the school department", () => {
@@ -45,6 +45,53 @@ describe("getDepartmentForEligibility", () => {
   it("when department corse with return good department", () => {
     const young: Partial<YoungType> = { _id: "123", department: "2A" };
     expect(getDepartmentForEligibility(young)).toBe("Corse-du-Sud");
+  });
+});
+
+describe("getDepartmentForInscriptionGoal", () => {
+  it("when young is schooled should return the department", () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "true", department: "department", schoolDepartment: "schoolDepartment" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("department");
+  });
+
+  it("when young is not schooled and doesn't have school department should returns the department", () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "false", department: "department" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("department");
+  });
+
+  it("when the both are available and the young is schooled should returns the department", () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "true", schoolDepartment: "schoolDepartment", department: "department" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("department");
+  });
+
+  it("when the both are available should return the school department", () => {
+    const young: Partial<YoungType> = { _id: "123", schoolDepartment: "SchoolDepartment", department: "Department" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("Department");
+  });
+
+  it("when school country is not FRANCE should department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "youngDepartment", schoolCountry: "ESPAGNE", schoolDepartment: "134" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("youngDepartment");
+  });
+
+  it("when school country is not FRANCE and schooled should department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "youngDepartment", schooled: "true", schoolCountry: "ESPAGNE", schoolDepartment: "134" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("youngDepartment");
+  });
+
+  it('when department not found should returns "Etranger"', () => {
+    const young: Partial<YoungType> = { _id: "123", schooled: "false" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("Etranger");
+  });
+
+  it("when department prepended with 0 should return good department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "044" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("Loire-Atlantique");
+  });
+
+  it("when department corse with return good department", () => {
+    const young: Partial<YoungType> = { _id: "123", department: "2A" };
+    expect(getDepartmentForInscriptionGoal(young)).toBe("Corse-du-Sud");
   });
 });
 

--- a/packages/lib/src/region-and-departments.ts
+++ b/packages/lib/src/region-and-departments.ts
@@ -122,7 +122,7 @@ function normalizeString(str) {
     .replace(/-/g, " ")
     .replace(/'/g, "")
     .replace(/\s+/g, " ")
-    .trim(); 
+    .trim();
 }
 
 const departmentNameMapping = {};
@@ -391,6 +391,18 @@ const getDepartmentForEligibility = (
   if (young._id && young.schooled === "false") dep = young.department;
 
   if (!dep) dep = schoolDepartment || young?.department || getDepartmentByZip(young?.zip);
+  if (dep && (!isNaN(dep) || ["2A", "2B", "02A", "02B"].includes(dep))) {
+    if (dep.substring(0, 1) === "0" && dep.length === 3) dep = departmentLookUp[dep.substring(1)];
+    else dep = departmentLookUp[dep];
+  }
+  if (!dep) dep = "Etranger";
+  return dep;
+};
+
+export const getDepartmentForInscriptionGoal = (
+  young: Pick<YoungType, "schooled" | "schoolRegion" | "region" | "department" | "schoolDepartment" | "schoolCountry" | "zip"> & { _id?: YoungType["_id"] },
+) => {
+  let dep = young?.department || getDepartmentByZip(young?.zip);
   if (dep && (!isNaN(dep) || ["2A", "2B", "02A", "02B"].includes(dep))) {
     if (dep.substring(0, 1) === "0" && dep.length === 3) dep = departmentLookUp[dep.substring(1)];
     else dep = departmentLookUp[dep];


### PR DESCRIPTION
**Description**

Modifie le contrôle pour prendre en compte la zone de résidence du jeune et non sa zone de scolarité pour le dépassement d’objectif.

**Todo**

- [x] Séparation du code d'éligibilité de celui d'inscription : nouvelle méthode `getDepartmentForInscriptionGoal` pour gérer les futures changements de règle.

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Modifier-le-contr-le-c-t-back-pour-prendre-en-compte-la-zone-de-r-sidence-du-jeune-et-non-sa-zone-d-14272a322d50803a9042ce820ec25afb#14272a322d5081f19b75e481561b5a9c

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
