### PR TITLE
chore(misc): set max_scale to 1

### DIFF
--- a/devops/terraform/environments/ci/generate_env_template.sh
+++ b/devops/terraform/environments/ci/generate_env_template.sh
@@ -24,7 +24,7 @@ fi
 
 set -e
 
-env_name=$(../../../.github/scripts/get_custom_env_name.sh $branch_name)
+env_name=$(../../../../.github/scripts/get_custom_env_name.sh $branch_name)
 
 cp -R custom $env_name
 cd $env_name

--- a/devops/terraform/environments/production/production.tf
+++ b/devops/terraform/environments/production/production.tf
@@ -30,7 +30,7 @@ resource "scaleway_container" "api" {
   cpu_limit       = 1024
   memory_limit    = 2048
   min_scale       = 0
-  max_scale       = 20
+  max_scale       = 1
   timeout         = 60
   max_concurrency = 25
   privacy         = "public"
@@ -57,7 +57,7 @@ resource "scaleway_container" "admin" {
   cpu_limit       = 256
   memory_limit    = 256
   min_scale       = 0
-  max_scale       = 20
+  max_scale       = 1
   timeout         = 60
   max_concurrency = 50
   privacy         = "public"
@@ -81,7 +81,7 @@ resource "scaleway_container" "app" {
   cpu_limit       = 256
   memory_limit    = 256
   min_scale       = 0
-  max_scale       = 20
+  max_scale       = 1
   timeout         = 60
   max_concurrency = 50
   privacy         = "public"
@@ -105,7 +105,7 @@ resource "scaleway_container" "antivirus" {
   cpu_limit       = 1024
   memory_limit    = 4096
   min_scale       = 0
-  max_scale       = 5
+  max_scale       = 1
   timeout         = 60
   max_concurrency = 50
   privacy         = "public"

--- a/devops/terraform/environments/production/staging/main.tf
+++ b/devops/terraform/environments/production/staging/main.tf
@@ -58,7 +58,7 @@ resource "scaleway_container" "api" {
   cpu_limit       = 768
   memory_limit    = 1024
   min_scale       = 1
-  max_scale       = 3
+  max_scale       = 1
   timeout         = 60
   max_concurrency = 50
   privacy         = "public"
@@ -156,7 +156,7 @@ resource "scaleway_container" "admin" {
   cpu_limit       = 256
   memory_limit    = 256
   min_scale       = 1
-  max_scale       = 2
+  max_scale       = 1
   timeout         = 60
   max_concurrency = 50
   privacy         = "public"
@@ -180,7 +180,7 @@ resource "scaleway_container" "app" {
   cpu_limit       = 256
   memory_limit    = 256
   min_scale       = 1
-  max_scale       = 2
+  max_scale       = 1
   timeout         = 60
   max_concurrency = 50
   privacy         = "public"


### PR DESCRIPTION
Fix `memory quotas: rpc error: code = ResourceExhausted desc = quota(s) exceeded for this resource` error by setting max_scale to 1.

from [Scaleway docs](https://www.scaleway.com/en/docs/identity-and-access-management/organizations-and-projects/additional-content/organization-quotas/#serverless-containers) : 

`The maximum RAM quota is obtained by multiplying the maximum scale factor of your container by the selected RAM quantity. For example, if you choose to create a container with 512 MB of memory and a maximum scale of 20, you will have 10 GB RAM.`