### PR TITLE
fix(admin): 3756 - Correction formattage dates CNI et birthdate

### DIFF
--- a/admin/src/scenes/phase0/components/CniModal.jsx
+++ b/admin/src/scenes/phase0/components/CniModal.jsx
@@ -11,6 +11,7 @@ import { capture } from "@/sentry";
 import Field from "./Field";
 import DatePickerInput from "@/components/ui/forms/dateForm/DatePickerInput";
 import { resizeImage } from "@/services/file.service";
+import dayjs from "@/utils/dayjs.utils";
 import Eye from "@/assets/icons/Eye";
 import { Spinner } from "reactstrap";
 import Download from "@/assets/icons/Download";
@@ -148,6 +149,11 @@ export function CniModal({ young, onClose, mode, blockUpload }) {
     setFilesToUpload(array);
   };
 
+  const handleChangeExpirationDate = (date) => {
+    const formattedDate = dayjs(date).toUtc().toDate();
+    setDate(formattedDate);
+  };
+
   const handlePreview = async (file) => {
     try {
       setLoadingPreviewStates((prevLoadingPreviewStates) => ({
@@ -265,7 +271,7 @@ export function CniModal({ young, onClose, mode, blockUpload }) {
                     )}
                   </div>
                   <div className="mt-4 w-full space-y-2">
-                    <DatePickerInput label="Date d'expiration" value={date} onChange={(date) => setDate(date)} />
+                    <DatePickerInput label="Date d'expiration" value={date} onChange={handleChangeExpirationDate} />
                     <Field
                       label="Catégorie"
                       value={category}

--- a/admin/src/scenes/phase0/components/sections/identite/SectionIdentite.tsx
+++ b/admin/src/scenes/phase0/components/sections/identite/SectionIdentite.tsx
@@ -71,7 +71,14 @@ export default function SectionIdentite({
   }
 
   function onLocalChange(field, value) {
-    setYoungFiltered({ ...youngFiltered, [field]: value });
+    // If field is a date, we need to format it
+    if (field === "birthdateAt") {
+      // @ts-expect-error toUtc
+      const formattedDate = dayjs(value).toUtc().toDate();
+      setYoungFiltered((prev) => ({ ...prev, [field]: formattedDate }));
+    } else {
+      setYoungFiltered((prev) => ({ ...prev, [field]: value }));
+    }
   }
 
   function onLocalAddressChange(field, value) {


### PR DESCRIPTION
**Description**

Il y a une regression suite à la suppression du formattage toUTC() dans le composant DatePickerInput qui est utilisé dans d'autre endroit comme l'application Admin.

**Todo**

- [x] Trouver les utilisations du DatePickerInput
- [x] Ajouter le formattage des dates utilisant ce DatePickerInput

**Checklist**

- [ ] **⚠️ My code can have side-effects on other part of the code-base**
- [ ] I have added the Plausible tags/events
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

[Notion ticket #3756](https://www.notion.so/jeveuxaider/Impossible-de-modifier-la-date-de-naissance-d-un-volontaire-15772a322d5080be9fb4c90911a264fd)
