### PR TITLE
feat(api,admin): 3830 - FF fermeture bascule manuelle sur LP pour les référents regionaux

### DIFF
--- a/admin/src/scenes/phase0/components/YoungHeader.jsx
+++ b/admin/src/scenes/phase0/components/YoungHeader.jsx
@@ -4,10 +4,10 @@ import { toastr } from "react-redux-toastr";
 import { useHistory } from "react-router-dom";
 import {
   canManageMig,
+  canValidateYoungToLP,
   canViewEmailHistory,
   canViewNotes,
   isCle,
-  isReferentDep,
   ROLES,
   SENDINBLUE_TEMPLATES,
   translate,
@@ -46,7 +46,6 @@ import downloadPDF from "@/utils/download-pdf";
 import ModalConfirm from "@/components/modals/ModalConfirm";
 import { capture } from "@/sentry";
 import { signinAs } from "@/utils/signinAs";
-import { isAfter } from "date-fns";
 
 const blueBadge = { color: "#66A7F4", backgroundColor: "#F9FCFF" };
 const greyBadge = { color: "#9A9A9A", backgroundColor: "#F6F6F6" };
@@ -70,10 +69,10 @@ export default function YoungHeader({ young, tab, onChange, phase = YOUNG_PHASE.
       } else {
         switch (young.status) {
           case YOUNG_STATUS.WAITING_LIST:
-            if (isReferentDep(user.role) && cohortYoung?.instructionEndDate && isAfter(new Date(), new Date(cohortYoung.instructionEndDate))) {
-              options = [YOUNG_STATUS.WITHDRAWN];
-            } else {
+            if (canValidateYoungToLP(user, cohortYoung)) {
               options = [YOUNG_STATUS.VALIDATED, YOUNG_STATUS.WITHDRAWN];
+            } else {
+              options = [YOUNG_STATUS.WITHDRAWN];
             }
             break;
           case YOUNG_STATUS.WITHDRAWN:

--- a/admin/src/scenes/settings/general/GeneralTab.tsx
+++ b/admin/src/scenes/settings/general/GeneralTab.tsx
@@ -401,6 +401,14 @@ export default function GeneralTab({ cohort, onCohortChange, readOnly, getCohort
                     error={error.instructionEndDate}
                   />
                 </div>
+                {cohort.type !== COHORT_TYPE.CLE && (
+                  <SimpleToggle
+                    label="Bascule manuelle de LC vers LP pour les référents regionaux après fermeture de l'instruction"
+                    disabled={isLoading || readOnly}
+                    value={!cohort.youngHTSBasculeLPDisabled}
+                    onChange={() => onCohortChange({ ...cohort, youngHTSBasculeLPDisabled: !cohort.youngHTSBasculeLPDisabled })}
+                  />
+                )}
               </div>
               {cohort.type !== COHORT_TYPE.CLE && (
                 <div className="flex flex-col gap-3">

--- a/admin/src/scenes/volontaires/view/index.tsx
+++ b/admin/src/scenes/volontaires/view/index.tsx
@@ -3,7 +3,7 @@ import { Switch } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { useQuery } from "@tanstack/react-query";
 
-import { YoungDto, isReferentReg, isAdmin } from "snu-lib";
+import { YoungDto, isAdmin } from "snu-lib";
 import { AuthState } from "@/redux/auth/reducer";
 import useDocumentTitle from "@/hooks/useDocumentTitle";
 import { SentryRoute } from "@/sentry";
@@ -44,7 +44,8 @@ export default function Index({ ...props }) {
       ? "correction"
       : "readonly";
     const cohort = cohorts.find(({ _id, name }) => _id === young?.cohortId || name === young?.cohort);
-    if (!isAdmin(user) && !isReferentReg(user) && cohort?.instructionEndDate && isAfter(new Date(), new Date(cohort.instructionEndDate))) {
+    const isInstructionOpen = cohort && isAfter(new Date(), new Date(cohort.instructionEndDate));
+    if (!isInstructionOpen && !isAdmin(user)) {
       mode = "readonly";
     }
 

--- a/api/src/cohort/cohortValidator.ts
+++ b/api/src/cohort/cohortValidator.ts
@@ -82,6 +82,7 @@ export const validateCohortDto = (dto: UpdateCohortDto): Joi.ValidationResult<Up
     cleUpdateCentersForReferentDepartment: Joi.boolean().default(false),
     cleDisplayCohortsForAdminCLEDate: ToFromDateValidator,
     cleDisplayCohortsForReferentClasseDate: ToFromDateValidator,
+    youngHTSBasculeLPDisabled: Joi.boolean().default(false),
   }).validate(dto, { stripUnknown: true });
 };
 

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -108,6 +108,7 @@ import {
   isAdmin,
   isReferentReg,
   isReferentDep,
+  canValidateYoungToLP,
 } from "snu-lib";
 import { getFilteredSessions, getAllSessions, getFilteredSessionsForCLE } from "../utils/cohort";
 import scanFile from "../utils/virusScanner";
@@ -652,7 +653,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
     }
 
     // verification des dates de fin d'instruction si jeune est VALIDATED
-    if (newYoung.status === YOUNG_STATUS.VALIDATED) {
+    if (newYoung.status === YOUNG_STATUS.VALIDATED && young.status !== YOUNG_STATUS.VALIDATED) {
       if (!cohort) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
       if (young.source === YOUNG_SOURCE.CLE) {
         const classe = await ClasseModel.findById(young.classeId);
@@ -667,9 +668,8 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
           return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
         }
       } else {
-        const now = new Date();
-        const isInstructionOpen = now < cohort.instructionEndDate;
-        if (!isInstructionOpen && !isAdmin(req.user) && !isReferentReg(req.user)) {
+        // HTS
+        if (!canValidateYoungToLP(req.user, cohort)) {
           return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
         }
       }

--- a/packages/lib/src/dto/cohortDto.ts
+++ b/packages/lib/src/dto/cohortDto.ts
@@ -67,6 +67,7 @@ export type CohortDto = {
   youngCheckinForDepartmentReferent?: boolean;
   daysToValidate?: number | null;
   objectifLevel?: "departemental" | "regional";
+  youngHTSBasculeLPDisabled?: boolean;
   uselessInformation?: Record<string, any> | null;
   validationDate?: Date | null;
   validationDateForTerminaleGrade?: Date | null;

--- a/packages/lib/src/mongoSchema/cohort.ts
+++ b/packages/lib/src/mongoSchema/cohort.ts
@@ -394,6 +394,13 @@ export const CohortSchema = {
       description: "Niveau des objectifs (départemental ou régional)",
     },
   },
+
+  youngHTSBasculeLPDisabled: {
+    type: Boolean,
+    documentation: {
+      description: "Fermeture de la validation sur Liste Principale",
+    },
+  },
 };
 
 const schema = new Schema(CohortSchema);

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -2,7 +2,8 @@ import { CohortDto, ReferentDto, UserDto } from "./dto";
 import { region2department } from "./region-and-departments";
 import { isNowBetweenDates } from "./utils/date";
 import { LIMIT_DATE_ESTIMATED_SEATS, LIMIT_DATE_TOTAL_SEATS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, YOUNG_STATUS_PHASE3 } from "./constants/constants";
-import { PointDeRassemblementType, ReferentType, SessionPhase1Type, YoungType } from "./mongoSchema";
+import { CohortType, PointDeRassemblementType, ReferentType, SessionPhase1Type, YoungType } from "./mongoSchema";
+import { isBefore } from "date-fns";
 
 const DURATION_BEFORE_EXPIRATION_2FA_MONCOMPTE_MS = 1000 * 60 * 15; // 15 minutes
 const DURATION_BEFORE_EXPIRATION_2FA_ADMIN_MS = 1000 * 60 * 10; // 10 minutes
@@ -1082,6 +1083,23 @@ const phaseStatusOptionsByRole = {
 
 function getPhaseStatusOptions(actor: UserDto, phase: number) {
   return phaseStatusOptionsByRole[phase][actor.role] || phaseStatusOptionsByRole[phase].DEFAULT || [];
+}
+
+export function canValidateYoungToLP(actor: UserDto, cohort?: Pick<CohortType, "instructionEndDate" | "youngHTSBasculeLPDisabled">) {
+  if (!cohort) return false;
+
+  const isInstructionOpen = isBefore(new Date(), new Date(cohort.instructionEndDate));
+  if (isAdmin(actor) || isInstructionOpen) {
+    return true;
+  }
+  if (isReferentDep(actor)) {
+    return false;
+  }
+  if (cohort.youngHTSBasculeLPDisabled) {
+    return false;
+  }
+  // referent regional
+  return true;
 }
 
 export {


### PR DESCRIPTION
**Description**

<img width="964" alt="image" src="https://github.com/user-attachments/assets/61159cdb-5dbf-4491-8604-d106fd7f4922" />

**Todo**

- [x] Corriger la validation en LP (impossible quand instruction fermée et non admin)
- [x] Empecher la bascule de LC -> LP (front menu en haut à droite)
- [x] Ajout contrôle côté API 

**Ticket / Issue**

- https://www.notion.so/jeveuxaider/Param-tre-dynamique-Bascule-LC-LP-17572a322d50804a95b7c4b614c9b6d6
- https://www.notion.so/jeveuxaider/BUG-Admin-les-r-f-rents-ne-peuvent-plus-modifier-le-dossier-des-volontaires-17672a322d5080e798fae510c55ad12b

**Testing instructions**

https://snufeatffdisableyoun8vcmtpvz-admin.functions.fnc.fr-par.scw.cloud