### PR TITLE
feat(api): 3751 - import PDT: type transport autocar

### DIFF
--- a/api/src/controllers/planDeTransport/import.ts
+++ b/api/src/controllers/planDeTransport/import.ts
@@ -32,7 +32,7 @@ import scanFile from "../../utils/virusScanner";
 import { getMimeFromFile } from "../../utils/file";
 import { validateId } from "../../utils/validator";
 import { validatePdtFile, computeImportSummary, getLinePdrCount } from "../../planDeTransport/planDeTransport/import/pdtImportService";
-import { formatTime } from "../../planDeTransport/planDeTransport/import/pdtImportUtils";
+import { formatTime, mapTransportType } from "../../planDeTransport/planDeTransport/import/pdtImportUtils";
 import { startSession, withTransaction, endSession } from "../../mongo";
 import { UserRequest } from "../request";
 
@@ -251,7 +251,7 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
             acc.push({
               lineId: busLine._id.toString(),
               meetingPointId: pdrMatriculeIdMap.get(line[pdrKey] as string),
-              transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`]?.toString().toLowerCase() || "",
+              transportType: mapTransportType(line[`TYPE DE TRANSPORT PDR ${pdrNumber}`] as string),
               busArrivalHour: formatTime(line[`HEURE ALLER ARRIVÉE AU PDR ${pdrNumber}`] as string),
               departureHour: formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`] as string),
               meetingHour: getPDRMeetingHour(
@@ -270,14 +270,14 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
                 address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`] as string,
                 departureHour: formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`] as string),
                 returnHour: "",
-                transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`]?.toString().toLowerCase() || "",
+                transportType: mapTransportType(line[`TYPE DE TRANSPORT PDR ${pdrNumber}`] as string),
               });
               acc[acc.length - 1].stepPoints.push({
                 type: "retour",
                 address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`] as string,
                 departureHour: "",
                 returnHour: formatTime(line[`HEURE DE RETOUR ARRIVÉE AU PDR ${pdrNumber}`] as string),
-                transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`]?.toString().toLowerCase() || "",
+                transportType: mapTransportType(line[`TYPE DE TRANSPORT PDR ${pdrNumber}`] as string),
               });
             } else {
               const isAller = pdrValue === "correspondance aller";
@@ -286,7 +286,7 @@ router.post("/:importId/execute", passport.authenticate("referent", { session: f
                 address: line[`NOM + ADRESSE DU PDR ${pdrNumber}`] as string,
                 departureHour: isAller ? formatTime(line[`HEURE DEPART DU PDR ${pdrNumber}`] as string) : "",
                 returnHour: isAller ? "" : formatTime(line[`HEURE DE RETOUR ARRIVÉE AU PDR ${pdrNumber}`] as string),
-                transportType: line[`TYPE DE TRANSPORT PDR ${pdrNumber}`]?.toString().toLowerCase() || "",
+                transportType: mapTransportType(line[`TYPE DE TRANSPORT PDR ${pdrNumber}`] as string),
               });
             }
           }

--- a/api/src/planDeTransport/planDeTransport/import/pdtImportService.ts
+++ b/api/src/planDeTransport/planDeTransport/import/pdtImportService.ts
@@ -158,7 +158,7 @@ export const validatePdtFile = async (
       if (!line[`TYPE DE TRANSPORT PDR ${i}`]) {
         errors[`TYPE DE TRANSPORT PDR ${i}`].push({ line: index, error: PDT_IMPORT_ERRORS.MISSING_DATA });
       }
-      if (line[`TYPE DE TRANSPORT PDR ${i}`] && !["bus", "train", "avion"].includes(line[`TYPE DE TRANSPORT PDR ${i}`].toLowerCase())) {
+      if (line[`TYPE DE TRANSPORT PDR ${i}`] && !["bus", "autocar", "train", "avion"].includes(line[`TYPE DE TRANSPORT PDR ${i}`].toLowerCase())) {
         errors[`TYPE DE TRANSPORT PDR ${i}`].push({ line: index, error: PDT_IMPORT_ERRORS.UNKNOWN_TRANSPORT_TYPE, extra: line[`TYPE DE TRANSPORT PDR ${i}`] });
       }
       if (!line[`NOM + ADRESSE DU PDR ${i}`]) {

--- a/api/src/planDeTransport/planDeTransport/import/pdtImportUtils.ts
+++ b/api/src/planDeTransport/planDeTransport/import/pdtImportUtils.ts
@@ -26,7 +26,15 @@ export function isValidBoolean(b) {
     .match(/^(oui|non)$/);
 }
 
-export function isValidDepartment(department) {
+export function isValidDepartment(department?: string) {
   const ids = Object.keys(departmentLookUp);
   return ids.includes((department || "").toUpperCase());
+}
+
+export function mapTransportType(transportType?: string) {
+  const result = transportType?.toString()?.toLowerCase() || "";
+  if (result === "autocar") {
+    return "bus";
+  }
+  return result;
 }


### PR DESCRIPTION
**Description**

Ajoute le type autocar dans les types de transport autorisé lors de l'import d'un PDT

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Ajouter-le-type-autocar-dans-les-types-de-transport-15772a322d5080f9a7f2f90ca64a17c9?pvs=23

**Testing instructions**

https://snufeatpdtimportautosudanlte-admin.functions.fnc.fr-par.scw.cloud
