### PR TITLE
fix(api): 3840 - les référents ne peuvent plus modifier le dossier des volontaires après l'instruction

### DIFF
--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -563,7 +563,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
     ) {
       if (!cohort) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
 
-      if (isReferentDep(req.user) && cohort?.instructionEndDate && isAfter(new Date(), new Date(cohort.instructionEndDate))) {
+      if (!canValidateYoungToLP(req.user, cohort)) {
         return res.status(403).send({ ok: false, code: ERRORS.OPERATION_NOT_ALLOWED });
       }
 

--- a/api/src/young/edition/youngEditionController.ts
+++ b/api/src/young/edition/youngEditionController.ts
@@ -118,10 +118,6 @@ router.put("/:id/identite", passport.authenticate("referent", { session: false, 
       return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     }
 
-    const cohort = await CohortModel.findById(young.cohortId);
-    if (!isAdmin(req.user) && !isReferentReg(req.user) && cohort?.instructionEndDate && isAfter(new Date(), new Date(cohort.instructionEndDate)))
-      return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
-
     if (value.zip && value.city && value.address) {
       const qpv = await getQPV(value.zip, value.city, value.address);
       if (qpv === true) value.qpv = "true";
@@ -265,10 +261,6 @@ router.put("/:id/situationparents", passport.authenticate("referent", { session:
     if (!canEditYoung(req.user, young)) {
       return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     }
-
-    const cohort = await CohortModel.findById(young.cohortId);
-    if (!isAdmin(req.user) && !isReferentReg(req.user) && cohort?.instructionEndDate && isAfter(new Date(), new Date(cohort.instructionEndDate)))
-      return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
 
     young.set(value);
     young.set({


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

- [x] Permettre la modification des données d'un jeune, même si l'instruction est fermée (Identité et RL)

**Ticket / Issue**

https://www.notion.so/jeveuxaider/BUG-Admin-les-r-f-rents-ne-peuvent-plus-modifier-le-dossier-des-volontaires-17672a322d5080e798fae510c55ad12b

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
