### PR TITLE
fix(api): 3867 - Deletion du champ situation et grade pour des young pour qui il etait égale à "".

### DIFF
--- a/admin/src/scenes/phase0/components/sections/SectionParents.jsx
+++ b/admin/src/scenes/phase0/components/sections/SectionParents.jsx
@@ -424,7 +424,15 @@ export default function SectionParents({ young, onStartRequest, currentRequest, 
                     young={young}
                     transformer={translateEtablissementSector}
                   />
-                  <Field name="classeGrade" label="Classe" value={young?.grade} mode="readonly" className="mb-[24px]" young={young} transformer={translateGrade} />
+                  <Field
+                    name="classeGrade"
+                    label="Niveau Scolaire"
+                    value={young?.grade || "Non renseigné"}
+                    mode="readonly"
+                    className="mb-[24px]"
+                    young={young}
+                    transformer={translateGrade}
+                  />
                   <MiniTitle>Établissement</MiniTitle>
                   <div className="flex items-center gap-4 mb-[16px]">
                     <Field name="etablissementZone" label="Zone" value={region2zone[youngFiltered?.etablissement?.region]} mode="readonly" className="w-1/2" young={young} />

--- a/admin/src/scenes/phase0/components/sections/SectionParents.jsx
+++ b/admin/src/scenes/phase0/components/sections/SectionParents.jsx
@@ -424,15 +424,7 @@ export default function SectionParents({ young, onStartRequest, currentRequest, 
                     young={young}
                     transformer={translateEtablissementSector}
                   />
-                  <Field
-                    name="classeGrade"
-                    label="Niveau Scolaire"
-                    value={young?.grade || "Non renseigné"}
-                    mode="readonly"
-                    className="mb-[24px]"
-                    young={young}
-                    transformer={translateGrade}
-                  />
+                  <Field name="classeGrade" label="Niveau Scolaire" value={young?.grade} mode="readonly" className="mb-[24px]" young={young} transformer={translateGrade} />
                   <MiniTitle>Établissement</MiniTitle>
                   <div className="flex items-center gap-4 mb-[16px]">
                     <Field name="etablissementZone" label="Zone" value={region2zone[youngFiltered?.etablissement?.region]} mode="readonly" className="w-1/2" young={young} />

--- a/api/migrations/20250116144902-Rattrapage_young_with_empty_situation.js
+++ b/api/migrations/20250116144902-Rattrapage_young_with_empty_situation.js
@@ -2,10 +2,16 @@ const { logger } = require("../src/logger");
 const { YoungModel } = require("../src/models");
 module.exports = {
   async up() {
-    const youngs = await YoungModel.find({ situation: "" });
-    logger.info(`Found ${youngs.length} youngs with empty situation...`);
-    for (const young of youngs) {
+    const youngsWithWrongSituation = await YoungModel.find({ situation: "" });
+    logger.info(`Found ${youngsWithWrongSituation.length} youngs with empty situation...`);
+    for (const young of youngsWithWrongSituation) {
       await YoungModel.updateOne({ _id: young._id }, { $unset: { situation: "" } });
+    }
+
+    const youngsWithWrongGrade = await YoungModel.find({ grade: "" });
+    logger.info(`Found ${youngsWithWrongGrade.length} youngs with empty grade...`);
+    for (const young of youngsWithWrongGrade) {
+      await YoungModel.updateOne({ _id: young._id }, { $unset: { grade: "" } });
     }
   },
 };

--- a/api/migrations/20250116144902-Rattrapage_young_with_empty_situation.js
+++ b/api/migrations/20250116144902-Rattrapage_young_with_empty_situation.js
@@ -1,0 +1,11 @@
+const { logger } = require("../src/logger");
+const { YoungModel } = require("../src/models");
+module.exports = {
+  async up() {
+    const youngs = await YoungModel.find({ situation: "" });
+    logger.info(`Found ${youngs.length} youngs with empty situation...`);
+    for (const young of youngs) {
+      await YoungModel.updateOne({ _id: young._id }, { $unset: { situation: "" } });
+    }
+  },
+};

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -325,7 +325,6 @@ class Auth {
         classeId: classe._id,
         etablissementId: etablissement._id,
         cohort: classe.cohort,
-        //TODO ajouter le grade de la classe selectionné par le jeune
         cohesionCenterId: classe.cohesionCenterId,
         sessionPhase1Id: classe.sessionId,
         meetingPointId: classe.pointDeRassemblementId,

--- a/api/src/controllers/young/inscription2023.js
+++ b/api/src/controllers/young/inscription2023.js
@@ -92,7 +92,6 @@ router.put("/eligibilite", passport.authenticate("young", { session: false, fail
       schoolRegion: "",
       schoolCountry: "",
       schoolId: "",
-      grade: "",
       zip: "",
       ...value,
       ...(value.livesInFrance === "true"

--- a/api/src/young/edition/youngEditionController.ts
+++ b/api/src/young/edition/youngEditionController.ts
@@ -184,6 +184,7 @@ router.put("/:id/situationparents", passport.authenticate("referent", { session:
 
     // --- validate data
     const bodySchema = Joi.object().keys({
+      situation: Joi.string().valid(...Object.keys(YOUNG_SITUATIONS)),
       schoolId: Joi.string().trim().allow(""),
       schoolName: Joi.string().trim().allow(""),
       schoolCity: Joi.string().trim().allow(""),
@@ -194,6 +195,7 @@ router.put("/:id/situationparents", passport.authenticate("referent", { session:
       schoolZip: Joi.string().trim().allow(""),
       schoolDepartment: Joi.string().trim().allow(""),
       schoolRegion: Joi.string().trim().allow(""),
+      grade: Joi.string().valid(...Object.keys(GRADES)),
       sameSchoolCLE: Joi.string().trim(),
 
       parent1Status: Joi.string().trim().allow(""),

--- a/api/src/young/edition/youngEditionController.ts
+++ b/api/src/young/edition/youngEditionController.ts
@@ -184,7 +184,6 @@ router.put("/:id/situationparents", passport.authenticate("referent", { session:
 
     // --- validate data
     const bodySchema = Joi.object().keys({
-      situation: Joi.string().valid(...Object.keys(YOUNG_SITUATIONS)),
       schoolId: Joi.string().trim().allow(""),
       schoolName: Joi.string().trim().allow(""),
       schoolCity: Joi.string().trim().allow(""),
@@ -195,7 +194,6 @@ router.put("/:id/situationparents", passport.authenticate("referent", { session:
       schoolZip: Joi.string().trim().allow(""),
       schoolDepartment: Joi.string().trim().allow(""),
       schoolRegion: Joi.string().trim().allow(""),
-      grade: Joi.string().valid(...Object.keys(GRADES)),
       sameSchoolCLE: Joi.string().trim(),
 
       parent1Status: Joi.string().trim().allow(""),


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Impossible-de-modifier-les-d-tails-d-un-dossier-d-l-ve-CLE-17c72a322d5080b181baf996a9af85b0?pvs=4

Lors du down de la migration de ce commit : 
https://github.com/betagouv/service-national-universel/pull/4380/files
On settait la stuation du jeune a "". Cela posait des probleme pour le JOI de la route /situationParent, il faut donc supprimer ce champ