### PR TITLE
fix(api): 212 - import centre des sessions - ajout champ sejourSnuIds

### DIFF
--- a/api/migrations/20250212084123-sp1-sejourSnuIds.js
+++ b/api/migrations/20250212084123-sp1-sejourSnuIds.js
@@ -1,0 +1,23 @@
+const { SessionPhase1Model } = require("../src/models");
+
+module.exports = {
+  async up(db, client) {
+    // await SessionPhase1Model.find({ sejourSnuId: { $exists: true } })
+    //   .cursor()
+    //   .eachAsync(async (session) => {
+    //     session.sejourSnuIds = [session.sejourSnuId];
+    //     await session.save();
+    //   });
+    // await SessionPhase1Model.updateMany({ sejourSnuId: { $exists: true } }, { $unset: { sejourSnuId: 1 } });
+  },
+
+  async down(db, client) {
+    // await SessionPhase1Model.find({ sejourSnuIds: { $exists: true } })
+    //   .cursor()
+    //   .eachAsync(async (session) => {
+    //     session.sejourSnuId = session.sejourSnuIds?.[0];
+    //     await session.save();
+    //   });
+    // await SessionPhase1Model.updateMany({ sejourSnuIds: { $exists: true } }, { $unset: { sejourSnuIds: 1 } });
+  },
+};

--- a/api/migrations/20250212084123-sp1-sejourSnuIds.js
+++ b/api/migrations/20250212084123-sp1-sejourSnuIds.js
@@ -2,22 +2,22 @@ const { SessionPhase1Model } = require("../src/models");
 
 module.exports = {
   async up(db, client) {
-    // await SessionPhase1Model.find({ sejourSnuId: { $exists: true } })
-    //   .cursor()
-    //   .eachAsync(async (session) => {
-    //     session.sejourSnuIds = [session.sejourSnuId];
-    //     await session.save();
-    //   });
-    // await SessionPhase1Model.updateMany({ sejourSnuId: { $exists: true } }, { $unset: { sejourSnuId: 1 } });
+    await SessionPhase1Model.find({ sejourSnuId: { $exists: true } })
+      .cursor()
+      .eachAsync(async (session) => {
+        session.sejourSnuIds = [session.sejourSnuId];
+        await session.save();
+      });
+    await SessionPhase1Model.updateMany({ sejourSnuId: { $exists: true } }, { $unset: { sejourSnuId: 1 } });
   },
 
   async down(db, client) {
-    // await SessionPhase1Model.find({ sejourSnuIds: { $exists: true } })
-    //   .cursor()
-    //   .eachAsync(async (session) => {
-    //     session.sejourSnuId = session.sejourSnuIds?.[0];
-    //     await session.save();
-    //   });
-    // await SessionPhase1Model.updateMany({ sejourSnuIds: { $exists: true } }, { $unset: { sejourSnuIds: 1 } });
+    await SessionPhase1Model.find({ sejourSnuIds: { $exists: true } })
+      .cursor()
+      .eachAsync(async (session) => {
+        session.sejourSnuId = session.sejourSnuIds?.[0];
+        await session.save();
+      });
+    await SessionPhase1Model.updateMany({ sejourSnuIds: { $exists: true } }, { $unset: { sejourSnuIds: 1 } });
   },
 };

--- a/api/src/cle/classe/importAuto/classeImportAutoService.ts
+++ b/api/src/cle/classe/importAuto/classeImportAutoService.ts
@@ -84,7 +84,7 @@ export const updateClasse = async (classeToUpdateMapped: ClasseMapped): Promise<
 
   try {
     if (classeToUpdateMapped.sessionCode) {
-      const session = await SessionPhase1Model.findOne({ sejourSnuId: classeToUpdateMapped.sessionCode });
+      const session = await SessionPhase1Model.findOne({ sejourSnuIds: classeToUpdateMapped.sessionCode });
       if (!session) {
         error.push(ERRORS.SESSION_NOT_FOUND);
       } else {

--- a/api/src/sessionPhase1/import/sessionPhase1ImportService.ts
+++ b/api/src/sessionPhase1/import/sessionPhase1ImportService.ts
@@ -104,7 +104,7 @@ const createSession = async (
     // on met à jour les places disponibles si la session existe déjà
     logger.warn(`Session already exists for cohesion center ${foundCenter.matricule} and cohort ${foundCohort.snuId}`);
     foundSession.placesTotal = sessionCenter.sessionPlaces;
-    if (!foundSession.sejourSnuIds.includes(sessionCenter.sejourSnuId)) {
+    if (sessionCenter.sejourSnuId && !foundSession.sejourSnuIds.includes(sessionCenter.sejourSnuId)) {
       logger.warn(`Add missing sejourSnuId ${sessionCenter.sejourSnuId}`);
       foundSession.sejourSnuIds.push(sessionCenter.sejourSnuId);
     }

--- a/api/src/sessionPhase1/import/sessionPhase1ImportService.ts
+++ b/api/src/sessionPhase1/import/sessionPhase1ImportService.ts
@@ -104,11 +104,15 @@ const createSession = async (
     // on met à jour les places disponibles si la session existe déjà
     logger.warn(`Session already exists for cohesion center ${foundCenter.matricule} and cohort ${foundCohort.snuId}`);
     foundSession.placesTotal = sessionCenter.sessionPlaces;
+    if (!foundSession.sejourSnuIds.includes(sessionCenter.sejourSnuId)) {
+      logger.warn(`Add missing sejourSnuId ${sessionCenter.sejourSnuId}`);
+      foundSession.sejourSnuIds.push(sessionCenter.sejourSnuId);
+    }
     await foundSession.save({ fromUser: { firstName: "IMPORT_SESSION_COHESION_CENTER" } });
     return {
       sessionId: foundSession._id,
       sessionFormule: sessionCenter.sessionFormule,
-      sessionSnuId: foundSession.sejourSnuId,
+      sessionSnuId: foundSession.sejourSnuIds.join(","),
       cohesionCenterId: foundCenter._id,
       cohesionCenterMatricule: sessionCenter.cohesionCenterMatricule,
       placesTotal: sessionCenter.sessionPlaces,
@@ -130,7 +134,7 @@ const createSession = async (
     nameCentre: foundCenter.name,
     zipCentre: foundCenter.zip,
     cityCentre: foundCenter.city,
-    sejourSnuId: sessionCenter.sejourSnuId,
+    sejourSnuIds: [sessionCenter.sejourSnuId],
   };
 
   const createdSessionPhase1 = await SessionPhase1Model.create(sessionPhase1);

--- a/apiv2/src/admin/core/sejours/phase1/sejour/Sejour.model.ts
+++ b/apiv2/src/admin/core/sejours/phase1/sejour/Sejour.model.ts
@@ -22,7 +22,7 @@ export type SejourModel = {
     //     email?: string;
     //     phone?: string;
     // }[];
-    sejourSnuId?: string;
+    sejourSnuIds: string[];
     dateStart?: string;
     dateEnd?: string;
     sanitaryContactEmail?: string;

--- a/apiv2/src/admin/infra/sejours/phase1/sejour/repository/Sejour.mapper.ts
+++ b/apiv2/src/admin/infra/sejours/phase1/sejour/repository/Sejour.mapper.ts
@@ -30,6 +30,7 @@ export class SejourMapper {
             departement: sejourDocument.department,
             centreCode: sejourDocument.codeCentre,
             centreNom: sejourDocument.nameCentre,
+            sejourSnuIds: sejourDocument.sejourSnuIds,
         };
     }
 
@@ -47,6 +48,7 @@ export class SejourMapper {
             hasPedagoProject: sejourModel.hasPedagoProject,
             cohort: sejourModel.sessionNom,
             cohortId: sejourModel.sessionId,
+            sejourSnuIds: sejourModel.sejourSnuIds,
         };
     }
 }

--- a/apiv2/src/admin/infra/sejours/phase1/sejour/repository/mongo/SejourMongo.repository.ts
+++ b/apiv2/src/admin/infra/sejours/phase1/sejour/repository/mongo/SejourMongo.repository.ts
@@ -23,7 +23,7 @@ export class SejourRepository implements SejourGateway {
         private readonly cls: ClsService,
     ) {}
     async findBySejourSnuId(sejourSnuId: string): Promise<SejourModel | null> {
-        const sejour = await this.sejourMongooseEntity.findOne({ sejourSnuId });
+        const sejour = await this.sejourMongooseEntity.findOne({ sejourSnuIds: sejourSnuId });
         if (!sejour) {
             return null;
         }

--- a/apiv2/test/admin/sejour/phase1/helper/SejourHelper.ts
+++ b/apiv2/test/admin/sejour/phase1/helper/SejourHelper.ts
@@ -15,6 +15,7 @@ export const createSejour = async (sejour?: Partial<SejourModel>) => {
         placesTotal: 15,
         placesRestantes: 15,
         status: "VALIDATED",
+        sejourSnuIds: [],
         ...sejour,
     });
 };

--- a/packages/lib/src/mongoSchema/sessionPhase1.ts
+++ b/packages/lib/src/mongoSchema/sessionPhase1.ts
@@ -178,10 +178,10 @@ export const SessionPhase1Schema = {
     },
   },
 
-  sejourSnuId: {
-    type: String,
+  sejourSnuIds: {
+    type: [String],
     documentation: {
-      description: "Code du centre pour la session - séjour SI-SNU",
+      description: "Codes des centres en session - séjour SI-SNU",
     },
   },
 


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

- [x] Remplacement du champ `sejourSnuId` par un tableau : `sejourSnuIds`
- [x] Lors de l'import des "centres en session" mettre à jour le champ `sejourSnuIds` si nécessaire
- [x] Migration de reprise des données pour transférer l'ancien champ vers le nouveau (à décommenter avant de merge)

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Import-Centres-des-sessions-lacune-l-import-18b72a322d50806b9c49d1f38165e500?pvs=23

**Testing instructions**

- Importer les "centres en session"
- Vérifier que au moins une "session phase 1" a plus de une valeur dans le champ `sejourSnuIds`
- Importer le fichier des classes pour s'assurer que la session phase 1 est bien trouvé pour chaque `sejourSnuId`
