### PR TITLE
fix(api): 262 - correction envoie email sans modification PDR

### DIFF
--- a/api/src/services/LigneDeBusService.ts
+++ b/api/src/services/LigneDeBusService.ts
@@ -82,7 +82,7 @@ export const updatePDRForLine = async (
     { fromUser: user },
   );
 
-  if (shouldSendEmailCampaign && youngUpdateResult.modifiedCount > 0) {
+  if (shouldSendEmailCampaign) {
     await sendEmailCampaign(ligneBusId, newMeetingPointId, cohort);
   }
 


### PR DESCRIPTION
**Description**

Envoyer la campagne de mail même si l'on ne change pas de PDR  pour une ligne de bus.

**Checklist**

- [ ] **⚠️ My code can have side-effects on other part of the code-base**
- [ ] I have added the Plausible tags/events
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

Fixes [Notion ticket #123](https://www.notion.so/jeveuxaider/Bug-Changement-d-horaire-PDR-Notification-non-envoy-e-19972a322d50801f8452eb7bf92d3647)

**Testing instructions**

- Modifier les heures sans changer de PDR
- Vérifier les emails reçus dans le mailcatcher