### PR TITLE
feat(apiv2): 203 - Prise en compte du département de scolarité dans la simulation d’affectation HTS 

### DIFF
--- a/apiv2/src/admin/core/sejours/jeune/Jeune.gateway.ts
+++ b/apiv2/src/admin/core/sejours/jeune/Jeune.gateway.ts
@@ -4,7 +4,7 @@ export interface JeuneGateway {
     findAll(): Promise<JeuneModel[]>;
     findById(id: string): Promise<JeuneModel>;
     findByIds(ids: string[]): Promise<JeuneModel[]>;
-    findBySessionIdStatusNiveauScolairesAndDepartements(
+    findBySessionIdStatusNiveauScolairesAndDepartementsCible(
         sessionId: string,
         status: string,
         niveauScolaires: string[],

--- a/apiv2/src/admin/core/sejours/jeune/Jeune.gateway.ts
+++ b/apiv2/src/admin/core/sejours/jeune/Jeune.gateway.ts
@@ -4,7 +4,7 @@ export interface JeuneGateway {
     findAll(): Promise<JeuneModel[]>;
     findById(id: string): Promise<JeuneModel>;
     findByIds(ids: string[]): Promise<JeuneModel[]>;
-    findBySessionIdStatusNiveauScolairesAndDepartementsCible(
+    findBySessionIdStatutNiveauScolairesAndDepartementsCible(
         sessionId: string,
         status: string,
         niveauScolaires: string[],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
@@ -71,7 +71,7 @@ describe("SimulationAffectationHTS", () => {
                 {
                     provide: JeuneGateway,
                     useValue: {
-                        findBySessionIdStatusNiveauScolairesAndDepartementsCible: jest
+                        findBySessionIdStatutNiveauScolairesAndDepartementsCible: jest
                             .fn()
                             .mockResolvedValue(mockJeunes),
                     },

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
@@ -71,7 +71,9 @@ describe("SimulationAffectationHTS", () => {
                 {
                     provide: JeuneGateway,
                     useValue: {
-                        findBySessionIdStatusNiveauScolairesAndDepartements: jest.fn().mockResolvedValue(mockJeunes),
+                        findBySessionIdStatusNiveauScolairesAndDepartementsCible: jest
+                            .fn()
+                            .mockResolvedValue(mockJeunes),
                     },
                 },
                 {

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
@@ -65,7 +65,7 @@ export class SimulationAffectationHTS implements UseCase<SimulationAffectationHT
         if (centreList.length === 0) {
             throw new FunctionalException(FunctionalExceptionCode.AFFECTATION_NOT_ENOUGH_DATA, "Aucun centres !");
         }
-        let allJeunes = await this.jeuneGateway.findBySessionIdStatusNiveauScolairesAndDepartementsCible(
+        let allJeunes = await this.jeuneGateway.findBySessionIdStatutNiveauScolairesAndDepartementsCible(
             sessionId,
             YOUNG_STATUS.VALIDATED,
             niveauScolaires,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
@@ -65,7 +65,7 @@ export class SimulationAffectationHTS implements UseCase<SimulationAffectationHT
         if (centreList.length === 0) {
             throw new FunctionalException(FunctionalExceptionCode.AFFECTATION_NOT_ENOUGH_DATA, "Aucun centres !");
         }
-        let allJeunes = await this.jeuneGateway.findBySessionIdStatusNiveauScolairesAndDepartements(
+        let allJeunes = await this.jeuneGateway.findBySessionIdStatusNiveauScolairesAndDepartementsCible(
             sessionId,
             YOUNG_STATUS.VALIDATED,
             niveauScolaires,

--- a/apiv2/src/admin/infra/sejours/jeune/repository/mongo/JeuneMongo.repository.ts
+++ b/apiv2/src/admin/infra/sejours/jeune/repository/mongo/JeuneMongo.repository.ts
@@ -52,7 +52,7 @@ export class JeuneRepository implements JeuneGateway {
         return JeuneMapper.toModel(jeune);
     }
 
-    async findBySessionIdStatusNiveauScolairesAndDepartements(
+    async findBySessionIdStatusNiveauScolairesAndDepartementsCible(
         sessionId: string,
         status: string,
         niveauScolaires: string[],
@@ -62,7 +62,12 @@ export class JeuneRepository implements JeuneGateway {
             cohortId: sessionId,
             status,
             grade: { $in: niveauScolaires },
-            department: { $in: departements },
+            $or: [
+                { department: { $in: departements }, schoolDepartment: { $in: departements } }, // scolarisé dans sa zone de résidence
+                { department: { $in: departements }, schoolDepartment: { $exists: false } }, // non scolarisé
+                { department: { $nin: departements }, schoolDepartment: { $in: departements } }, // HZR
+                { department: { $in: departements }, schoolCountry: { $not: /^FRANCE$i/ } }, // etranger
+            ],
         });
         return JeuneMapper.toModels(jeunes);
     }

--- a/apiv2/src/admin/infra/sejours/jeune/repository/mongo/JeuneMongo.repository.ts
+++ b/apiv2/src/admin/infra/sejours/jeune/repository/mongo/JeuneMongo.repository.ts
@@ -52,7 +52,7 @@ export class JeuneRepository implements JeuneGateway {
         return JeuneMapper.toModel(jeune);
     }
 
-    async findBySessionIdStatusNiveauScolairesAndDepartementsCible(
+    async findBySessionIdStatutNiveauScolairesAndDepartementsCible(
         sessionId: string,
         status: string,
         niveauScolaires: string[],

--- a/apiv2/test/admin/sejour/phase1/JeuneMongo.repository.spec.ts
+++ b/apiv2/test/admin/sejour/phase1/JeuneMongo.repository.spec.ts
@@ -28,7 +28,7 @@ describe("JeuneGateway", () => {
         expect(jeuneGateway).toBeDefined();
     });
 
-    describe("findBySessionIdStatusNiveauScolairesAndDepartementsCible", () => {
+    describe("findBySessionIdStatutNiveauScolairesAndDepartementsCible", () => {
         it("prise en compte des département cible des jeunes", async () => {
             const session = await createSession();
             // scolarisé dans sa zone de résidence
@@ -74,7 +74,7 @@ describe("JeuneGateway", () => {
                 paysScolarite: "FRANCE",
             });
 
-            const result = await jeuneGateway.findBySessionIdStatusNiveauScolairesAndDepartementsCible(
+            const result = await jeuneGateway.findBySessionIdStatutNiveauScolairesAndDepartementsCible(
                 session.id,
                 YOUNG_STATUS.VALIDATED,
                 Object.values(GRADES),

--- a/apiv2/test/admin/sejour/phase1/JeuneMongo.repository.spec.ts
+++ b/apiv2/test/admin/sejour/phase1/JeuneMongo.repository.spec.ts
@@ -1,0 +1,87 @@
+import mongoose from "mongoose";
+
+import { createJeune } from "./helper/JeuneHelper";
+import { setupAdminTest } from "../../setUpAdminTest";
+import { INestApplication } from "@nestjs/common";
+import { JeuneGateway } from "@admin/core/sejours/jeune/Jeune.gateway";
+import { GRADES, YOUNG_STATUS } from "snu-lib";
+import { createSession } from "./helper/SessionHelper";
+
+describe("JeuneGateway", () => {
+    let jeuneGateway: JeuneGateway;
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        const appSetup = await setupAdminTest();
+        app = appSetup.app;
+        const module = appSetup.adminTestModule;
+        jeuneGateway = module.get<JeuneGateway>(JeuneGateway);
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app.close();
+        mongoose.disconnect();
+    });
+
+    it("should be defined", () => {
+        expect(jeuneGateway).toBeDefined();
+    });
+
+    describe("findBySessionIdStatusNiveauScolairesAndDepartementsCible", () => {
+        it("prise en compte des département cible des jeunes", async () => {
+            const session = await createSession();
+            // scolarisé dans sa zone de résidence
+            await createJeune({
+                statut: YOUNG_STATUS.VALIDATED,
+                sessionId: session.id,
+                sessionNom: session.nom,
+                departement: "Loire-Atlantique",
+                departementScolarite: "Loire-Atlantique",
+            });
+            // non scolarisé
+            await createJeune({
+                statut: YOUNG_STATUS.VALIDATED,
+                sessionId: session.id,
+                sessionNom: session.nom,
+                departement: "Loire-Atlantique",
+                departementScolarite: undefined,
+            });
+            // HZR
+            await createJeune({
+                statut: YOUNG_STATUS.VALIDATED,
+                sessionId: session.id,
+                sessionNom: session.nom,
+                departement: "Maine-et-Loire",
+                departementScolarite: "Loire-Atlantique",
+            });
+            // etranger
+            await createJeune({
+                statut: YOUNG_STATUS.VALIDATED,
+                sessionId: session.id,
+                sessionNom: session.nom,
+                departement: "Loire-Atlantique",
+                departementScolarite: "N/A",
+                paysScolarite: "ESPAGNE",
+            });
+            // jeune hors departement
+            await createJeune({
+                statut: YOUNG_STATUS.VALIDATED,
+                sessionId: session.id,
+                sessionNom: session.nom,
+                departement: "Alpes-Maritimes",
+                departementScolarite: "Alpes-Maritimes",
+                paysScolarite: "FRANCE",
+            });
+
+            const result = await jeuneGateway.findBySessionIdStatusNiveauScolairesAndDepartementsCible(
+                session.id,
+                YOUNG_STATUS.VALIDATED,
+                Object.values(GRADES),
+                ["Loire-Atlantique"],
+            );
+
+            expect(result.length).toBe(4);
+        });
+    });
+});

--- a/apiv2/test/admin/sejour/phase1/helper/JeuneHelper.ts
+++ b/apiv2/test/admin/sejour/phase1/helper/JeuneHelper.ts
@@ -90,7 +90,7 @@ export const createJeune = async (jeune?: Partial<JeuneModel>) => {
         // populationDensity: "DENSE",
         qpv: "false",
         // situation: "Etudiant",
-        // grade: "2ndeGT",
+        niveauScolaire: "2ndeGT",
         // schoolCertification: "false",
         // schooled: "true",
         // schoolName: faker.location.city(),


### PR DESCRIPTION
**Description**

- La sélection des jeunes pour la simulation se fait sur le département de scolarité. 
- Pour les jeunes non scolarisés et les étrangers, la sélection des jeunes se fait sur le département de résidence
- La simulation des jeunes reste uniquement sur le département de résidence

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Prendre-en-compte-dans-la-simulation-d-affectation-HTS-le-d-partement-de-scolarit-des-jeunes-18a72a322d5080ef8a3fc0bd07fe1a08?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
