### PR TITLE
feat(apiv2): 201 - Ajuster l’onglet résumé du rapport de simulation d'affectation HTS

### DIFF
--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
@@ -1167,19 +1167,7 @@ export class SimulationAffectationHTSService {
             ...infoNonAffecetes.stats,
             "Taux d'erreur pour l'iteration : " + analytics.selectedCost,
             ...(changementDepartements.length > 0
-                ? [
-                      "Changement de département : " +
-                          changementDepartements
-                              .map(
-                                  ({ origine, destination }) =>
-                                      `${formatDepartement(origine)} -> ${[
-                                          ...new Set(destination.map((dest) => dest.departement)),
-                                      ]
-                                          .map(formatDepartement)
-                                          .join("-")}`,
-                              )
-                              .join("; \n"),
-                  ]
+                ? ["Changement de département : " + this.formatChangementDepartements(changementDepartements)]
                 : []),
             ...(changementDepartementsErreur.length > 0
                 ? ["Erreurs changement de département : " + changementDepartementsErreur.join(".\n")]
@@ -1386,5 +1374,16 @@ export class SimulationAffectationHTSService {
             [result[currentIndex], result[randomIndex]] = [result[randomIndex], result[currentIndex]];
         }
         return result;
+    }
+
+    formatChangementDepartements(changementDepartements: ChangementDepartement[]) {
+        return changementDepartements
+            .map(
+                ({ origine, destination }) =>
+                    `${formatDepartement(origine)} -> ${[...new Set(destination.map((dest) => dest.departement))]
+                        .map(formatDepartement)
+                        .join("-")}`,
+            )
+            .join("; \n");
     }
 }

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
@@ -944,12 +944,18 @@ export class SimulationAffectationHTSService {
         return {
             jeunes,
             stats: [
-                "jeunes probablement hors zones : " + probHorsZone,
-                "          -> Liste des départements hors zones : " +
+                "          dont jeunes probablement hors zones : " + probHorsZone,
+                "             -> Liste des départements hors zones : " +
                     departmentHortZone.map(formatDepartement).join(", "),
-                "jeunes pas de ligne disponible pour centre(s) " + centresNames.join(", ") + " : " + pasDeligne,
-                "jeunes pas de centre disponible pour ligne(s) " + lignesNames.join(", ") + " : " + pasDecentre,
-                "jeunes non affectés pour problèmes de places : " + limite,
+                "          dont jeunes pas de ligne disponible pour centre(s) " +
+                    centresNames.join(", ") +
+                    " : " +
+                    pasDeligne,
+                "          dont jeunes pas de centre disponible pour ligne(s) " +
+                    lignesNames.join(", ") +
+                    " : " +
+                    pasDecentre,
+                "          dont jeunes non affectés pour problèmes de places : " + limite,
             ],
         };
     }
@@ -1153,21 +1159,28 @@ export class SimulationAffectationHTSService {
         }));
 
         const summary = [
+            "Nombre de jeunes à affecter : " + jeunesList.length,
             "Nombre de jeunes affectés : " + jeunesNouvellementAffectedList.length,
-            "En attente d'affectation : " + jeuneAttenteAffectationList.length,
-            "Taux d'erreur pour l'iteration : " + analytics.selectedCost,
+            "          dont affectés en amont : " + jeunesDejaAffectedList.length,
+            "En attente d'affectation : " + jeuneAttenteAffectationList.length + jeuneIntraDepartementList.length,
+            "          dont intradep : " + jeuneIntraDepartementList.length,
             ...infoNonAffecetes.stats,
-            "Changement de département : " +
-                changementDepartements
-                    .map(
-                        ({ origine, destination }) =>
-                            `${formatDepartement(origine)} -> ${[
-                                ...new Set(destination.map((dest) => dest.departement)),
-                            ]
-                                .map(formatDepartement)
-                                .join("-")}`,
-                    )
-                    .join("; \n"),
+            "Taux d'erreur pour l'iteration : " + analytics.selectedCost,
+            ...(changementDepartements.length > 0
+                ? [
+                      "Changement de département : " +
+                          changementDepartements
+                              .map(
+                                  ({ origine, destination }) =>
+                                      `${formatDepartement(origine)} -> ${[
+                                          ...new Set(destination.map((dest) => dest.departement)),
+                                      ]
+                                          .map(formatDepartement)
+                                          .join("-")}`,
+                              )
+                              .join("; \n"),
+                  ]
+                : []),
             ...(changementDepartementsErreur.length > 0
                 ? ["Erreurs changement de département : " + changementDepartementsErreur.join(".\n")]
                 : []),

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
@@ -1159,7 +1159,7 @@ export class SimulationAffectationHTSService {
         }));
 
         const summary = [
-            "Nombre de jeunes à affecter : " + jeunesList.length,
+            "Nombre de jeunes à affecter : " + (jeunesList.length + jeuneIntraDepartementList.length),
             "Nombre de jeunes affectés : " + jeunesNouvellementAffectedList.length,
             "          dont affectés en amont : " + jeunesDejaAffectedList.length,
             "En attente d'affectation : " + (jeuneAttenteAffectationList.length + jeuneIntraDepartementList.length),

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.service.ts
@@ -1162,7 +1162,7 @@ export class SimulationAffectationHTSService {
             "Nombre de jeunes à affecter : " + jeunesList.length,
             "Nombre de jeunes affectés : " + jeunesNouvellementAffectedList.length,
             "          dont affectés en amont : " + jeunesDejaAffectedList.length,
-            "En attente d'affectation : " + jeuneAttenteAffectationList.length + jeuneIntraDepartementList.length,
+            "En attente d'affectation : " + (jeuneAttenteAffectationList.length + jeuneIntraDepartementList.length),
             "          dont intradep : " + jeuneIntraDepartementList.length,
             ...infoNonAffecetes.stats,
             "Taux d'erreur pour l'iteration : " + analytics.selectedCost,


### PR DESCRIPTION
**Description**

![image](https://github.com/user-attachments/assets/44927c9c-0c8f-4033-9ca9-e74f99b1972f)

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Ajuster-l-onglet-r-sum-du-rapport-de-simulation-d-affectation-HTS-18a72a322d508008a9fec50c1255ecdc?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
