### PR TITLE
fix(misc): Apply patch-package patches in Dockerfile build for CI

### DIFF
--- a/devops/ci/Dockerfile
+++ b/devops/ci/Dockerfile
@@ -15,6 +15,7 @@ RUN --mount=type=bind,src=api,target=/tmp/api \
     --mount=type=bind,src=apiv2,target=/tmp/apiv2 \
     --mount=type=bind,src=admin,target=/tmp/admin \
     --mount=type=bind,src=app,target=/tmp/app \
+    --mount=type=bind,src=patches,target=/tmp/patches \
     --mount=type=bind,src=packages,target=/tmp/packages \
     --mount=type=bind,src=package.json,target=/tmp/package.json \
     --mount=type=bind,src=package-lock.json,target=/tmp/package-lock.json \
@@ -75,6 +76,7 @@ COPY --from=builder /build/api/node_modules/ api/node_modules/
 COPY --from=builder /build/api/package.json api/
 
 COPY --from=builder /build/package.json ./
+COPY --from=builder /build/patches/ patches/
 COPY --from=builder /build/node_modules/ node_modules/
 
 

--- a/devops/ci/Dockerfile
+++ b/devops/ci/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=bind,src=api,target=/tmp/api \
     --mount=type=bind,src=package.json,target=/tmp/package.json \
     --mount=type=bind,src=package-lock.json,target=/tmp/package-lock.json \
     --mount=type=bind,src=turbo.json,target=/tmp/turbo.json \
-    turbo prune --docker --cwd /tmp --out-dir /build app admin api apiv2
+    turbo prune --docker --cwd /tmp --out-dir /build app admin api apiv2 && cp -fr /tmp/patches /build/full/
 
 
 FROM base AS builder


### PR DESCRIPTION
**Description**

Sur CI l'api V2 ne fonctionne pas bien lors de l'utilsiation des patches :

```
"(0 , mongoose_patch_history_1.createPatch) is not a function"
```

 cela est du au fait que l'image docker pour la ci n'utilise pas les même docker file que les autres environnements et qu'il ne copy pas le dossier `patches` avant de lancer un `npm install`


problème : `https://github.com/vercel/turborepo/issues/4289`
Autre solution envisagé : `https://github.com/vercel/turborepo/pull/4318`

on voit le problème dans le build de l'image : 
```
#14 53.83 > postinstall
#14 53.83 > patch-package
#14 53.83 
#14 54.00 patch-package 8.0.0
#14 54.01 Applying patches...
#14 54.01 No patch files found
```

il faut avoir : 
```
#14 53.49 > postinstall
#14 53.49 > patch-package
#14 53.49 
#14 53.67 patch-package 8.0.0
#14 53.67 Applying patches...
#14 53.67 mongoose-patch-history@2.0.0 ✔
```