### PR TITLE
feat(api): 259 - Notification pour les référents régionaux lorsque les jeunes se désistent après affectations

### DIFF
--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -940,6 +940,7 @@ router.put("/withdraw", passport.authenticate("young", { session: false, failWit
     if (!young) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
     if (!youngCanWithdraw(young)) return res.status(403).send({ ok: false, code: ERRORS.OPERATION_UNAUTHORIZED });
     const cohort = await CohortModel.findOne({ name: young.cohort });
+    if (!cohort) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
     const mandatoryPhasesDone = young.statusPhase1 === YOUNG_STATUS_PHASE1.DONE && young.statusPhase2 === YOUNG_STATUS_PHASE2.VALIDATED;
     const inscriptionStatus = ([YOUNG_STATUS.IN_PROGRESS, YOUNG_STATUS.WAITING_VALIDATION, YOUNG_STATUS.WAITING_CORRECTION] as string[]).includes(young.status!);
 

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -675,6 +675,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
     }
 
     if (newYoung.status === YOUNG_STATUS.WITHDRAWN && young.status !== YOUNG_STATUS.WITHDRAWN) {
+      if (!cohort) return res.status(404).send({ ok: false, code: ERRORS.NOT_FOUND });
       const { withdrawnReason } = newYoung;
       await handleNotifForYoungWithdrawn(young, cohort, withdrawnReason, req.user);
       newYoung.statusPhase1 = young.statusPhase1 === YOUNG_STATUS_PHASE1.AFFECTED ? YOUNG_STATUS_PHASE1.WAITING_AFFECTATION : young.statusPhase1;

--- a/api/src/young/youngService.ts
+++ b/api/src/young/youngService.ts
@@ -330,7 +330,7 @@ export async function handleNotifForYoungWithdrawn(young: YoungType, cohort: Coh
       }
 
       const referentsRegion = await ReferentModel.find({
-        role: ROLES.REFERENT_DEPARTMENT,
+        role: ROLES.REFERENT_REGION,
         subRole: SUB_ROLES.coordinator,
         region: young.region,
       });

--- a/api/src/young/youngService.ts
+++ b/api/src/young/youngService.ts
@@ -31,6 +31,7 @@ import {
   EtablissementModel,
   ReferentDocument,
   SessionPhase1Model,
+  LigneBusModel,
 } from "../models";
 
 import { sendTemplate } from "../brevo";
@@ -309,10 +310,12 @@ export async function handleNotifForYoungWithdrawn(young: YoungType, cohort: Coh
 
     // If young affected, we notify the head center and refs region
     if (oldStatusPhase1 === YOUNG_STATUS_PHASE1.AFFECTED && young.sessionPhase1Id != null) {
+      const ligneDeBus = await LigneBusModel.findOne({ _id: young.ligneId });
       const params = {
         contact_name: youngFullName,
         date_cohorte: getCohortPeriod(cohort),
         contact_departement: formatDepartement(young.department!),
+        contact_ligne: ligneDeBus?.busId || "",
         message: WITHRAWN_REASONS.find((r) => r.value === withdrawnReason)?.label || "",
       };
 

--- a/api/src/young/youngService.ts
+++ b/api/src/young/youngService.ts
@@ -16,6 +16,9 @@ import {
   SUB_ROLES,
   WITHRAWN_REASONS,
   formatDateFRTimezoneUTC,
+  CohortType,
+  formatDepartement,
+  getCohortPeriod,
 } from "snu-lib";
 
 import {
@@ -268,7 +271,7 @@ async function getContactsCLE(classeId: string) {
   return await ReferentModel.find({ _id: { $in: contactCLEId } });
 }
 
-export async function handleNotifForYoungWithdrawn(young, cohort, withdrawnReason, actor) {
+export async function handleNotifForYoungWithdrawn(young: YoungType, cohort: CohortType, withdrawnReason: string, actor: UserDto) {
   const oldStatusPhase1 = young.statusPhase1;
 
   // We notify the ref dep and the young
@@ -304,15 +307,34 @@ export async function handleNotifForYoungWithdrawn(young, cohort, withdrawnReaso
       }
     }
 
-    // If young affected, we notify the head center
+    // If young affected, we notify the head center and refs region
     if (oldStatusPhase1 === YOUNG_STATUS_PHASE1.AFFECTED && young.sessionPhase1Id != null) {
+      const params = {
+        contact_name: youngFullName,
+        date_cohorte: getCohortPeriod(cohort),
+        contact_departement: formatDepartement(young.department!),
+        message: WITHRAWN_REASONS.find((r) => r.value === withdrawnReason)?.label || "",
+      };
+
       const session = await SessionPhase1Model.findById(young.sessionPhase1Id);
       const headCenter = await ReferentModel.findById(session?.headCenterId);
 
       if (headCenter) {
         await sendTemplate(SENDINBLUE_TEMPLATES.headCenter.YOUNG_WITHDRAWN, {
           emailTo: [{ name: `${headCenter.firstName} ${headCenter.lastName}`, email: headCenter.email }],
-          params: { contact_name: youngFullName, message: WITHRAWN_REASONS.find((r) => r.value === withdrawnReason)?.label || "" },
+          params,
+        });
+      }
+
+      const referentsRegion = await ReferentModel.find({
+        role: ROLES.REFERENT_DEPARTMENT,
+        subRole: SUB_ROLES.coordinator,
+        region: young.region,
+      });
+      for (const referentRegional of referentsRegion) {
+        await sendTemplate(SENDINBLUE_TEMPLATES.headCenter.YOUNG_WITHDRAWN, {
+          emailTo: [{ name: `${referentRegional.firstName} ${referentRegional.lastName}`, email: referentRegional.email }],
+          params,
         });
       }
     }


### PR DESCRIPTION

**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Notification-pour-les-r-f-rents-r-gionaux-lorsque-les-jeunes-se-d-sistent-apr-s-affectations-19872a322d508079b4f9fbab653b8913

**Testing instructions**

désister un jeune qui est au status affecté, vérifier que le référent régional reçoit la notification dans le mail catcher
