### PR TITLE
fix(api): 312 - migration nettoyage sessionphase1 (sejourSnuId) pour l'import des centres en sessions

### DIFF
--- a/api/migrations/20250219100910-sp1-sejourSnuIds-clean.js
+++ b/api/migrations/20250219100910-sp1-sejourSnuIds-clean.js
@@ -1,0 +1,20 @@
+const { SessionPhase1Model } = require("../src/models");
+
+module.exports = {
+  async up(db, client) {
+    // on supprime le champ obsolète
+    await db.collection("sessionphase1").updateMany({ sejourSnuId: { $exists: true } }, { $unset: { sejourSnuId: 1 } });
+
+    // on nettoie les valeurs null
+    const sejourList = await SessionPhase1Model.find({ sejourSnuIds: { $exists: true } });
+    console.log(`Updating ${sejourList.length} sejours`);
+    for (const sejour of sejourList) {
+      sejour.sejourSnuIds = sejour.sejourSnuIds.filter((id) => !!id);
+      await sejour.save();
+    }
+  },
+
+  async down(db, client) {
+    // Cannot revert
+  },
+};


### PR DESCRIPTION
**Description**


Nettoyage de la base de données suite au correctif de l’import des centres en sessions.
la suppression du champ sejourSnuId n’avait pas fonctionner et le champ sejourSnuIds comprend des valeurs à null.

Clean suite à https://github.com/betagouv/service-national-universel/pull/4726


**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Migration-nettoyage-sessionphase1-sejourSnuId-pour-l-import-des-centres-en-sessions-1a072a322d50802cb49fd4a4e0c48f54?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
