### PR TITLE
fix(api): phase1 agreement template params cta

### DIFF
--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -1075,6 +1075,7 @@ router.put("/phase1/:document", passport.authenticate("young", { session: false,
       await sendTemplate(SENDINBLUE_TEMPLATES.young.PHASE1_AGREEMENT, {
         emailTo: [{ name: `${young.firstName} ${young.lastName}`, email: young.email }],
         params: {
+          cta: `${config.APP_URL}`,
           youngFirstName: young.firstName,
           youngLastName: young.lastName,
         },

--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -72,6 +72,7 @@ import {
   ContractType,
   CohortType,
   ReferentType,
+  getCohortPeriod,
 } from "snu-lib";
 import { getFilteredSessionsForChangementSejour } from "../../cohort/cohortService";
 import { anonymizeApplicationsFromYoungId } from "../../application/applicationService";
@@ -1072,10 +1073,12 @@ router.put("/phase1/:document", passport.authenticate("young", { session: false,
       // youngPhase1Agreement est forcément true ici
       let template = SENDINBLUE_TEMPLATES.young.PHASE1_AGREEMENT;
       let cc = getCcOfYoung({ template, young });
-      await sendTemplate(SENDINBLUE_TEMPLATES.young.PHASE1_AGREEMENT, {
+      const cohort = await CohortModel.findOne({ name: young.cohort });
+      await sendTemplate(template, {
         emailTo: [{ name: `${young.firstName} ${young.lastName}`, email: young.email }],
         params: {
           cta: `${config.APP_URL}`,
+          date_cohorte: cohort ? getCohortPeriod(cohort) : "",
           youngFirstName: young.firstName,
           youngLastName: young.lastName,
         },

--- a/api/src/controllers/young/phase1.ts
+++ b/api/src/controllers/young/phase1.ts
@@ -320,10 +320,12 @@ router.post("/:key", passport.authenticate("referent", { session: false, failWit
     if (key === "youngPhase1Agreement" && newValue === "true") {
       let template = SENDINBLUE_TEMPLATES.young.PHASE1_AGREEMENT;
       let cc = getCcOfYoung({ template, young });
-      await sendTemplate(SENDINBLUE_TEMPLATES.young.PHASE1_AGREEMENT, {
+      const cohort = await CohortModel.findOne({ name: young.cohort });
+      await sendTemplate(template, {
         emailTo: [{ name: `${young.firstName} ${young.lastName}`, email: young.email }],
         params: {
           cta: `${config.APP_URL}`,
+          date_cohorte: cohort ? getCohortPeriod(cohort) : "",
           youngFirstName: young.firstName,
           youngLastName: young.lastName,
         },

--- a/api/src/controllers/young/phase1.ts
+++ b/api/src/controllers/young/phase1.ts
@@ -20,6 +20,8 @@ import {
   LigneBusType,
   getCohortPeriod,
 } from "snu-lib";
+
+import { config } from "../../config";
 import { capture } from "../../sentry";
 import { sendTemplate } from "../../brevo";
 import { YoungModel, SessionPhase1Model, PointDeRassemblementModel, LigneBusModel, CohortModel } from "../../models";
@@ -321,6 +323,7 @@ router.post("/:key", passport.authenticate("referent", { session: false, failWit
       await sendTemplate(SENDINBLUE_TEMPLATES.young.PHASE1_AGREEMENT, {
         emailTo: [{ name: `${young.firstName} ${young.lastName}`, email: young.email }],
         params: {
+          cta: `${config.APP_URL}`,
           youngFirstName: young.firstName,
           youngLastName: young.lastName,
         },


### PR DESCRIPTION
**Description**

dans le mailcatcher, le bouton "J'accède à mon compte" pointe vers :
https://app-6394fbac-6fee-401c-8bc3-3840737e171e.cleverapps.io/messages/%7B%7B%20params.cta%20%7D%7D

`params.cta` aurait du être remplacé

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

<!-- If you have a Notion Ticket / GitHub Issue -->
<!-- Fixes [Notion ticket #123](https://notion.so/abc) -->

**Testing instructions**


