### PR TITLE
chore(apiv2): 417 - Utilisation de dates zoné dans le Clock.provider

### DIFF
--- a/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.spec.ts
+++ b/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.spec.ts
@@ -23,7 +23,8 @@ describe("ReferentielImportTaskService", () => {
                 {
                     provide: ClockGateway,
                     useValue: {
-                        getNowSafeIsoDate: jest.fn().mockReturnValue("2024-07-31T00:00:00.000Z"),
+                        now: jest.fn().mockReturnValue(new Date("2024-07-31T00:00:00.000Z")),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2024-07-31T00:00:00.000Z"),
                     },
                 },
                 {
@@ -46,9 +47,8 @@ describe("ReferentielImportTaskService", () => {
         [REGION_ACADEMIQUE_COLUMN_NAMES[0]]: "BRE",
         [REGION_ACADEMIQUE_COLUMN_NAMES[1]]: "BRETAGNE",
         [REGION_ACADEMIQUE_COLUMN_NAMES[2]]: "A",
-        [REGION_ACADEMIQUE_COLUMN_NAMES[3]]: "31/07/2024"
+        [REGION_ACADEMIQUE_COLUMN_NAMES[3]]: "31/07/2024",
     };
-    
 
     describe("import", () => {
         const mockAuteur = {
@@ -90,10 +90,10 @@ describe("ReferentielImportTaskService", () => {
                     "Session : Désignation de la session": "",
                     "Session : Date de début de la session": "",
                     "Session : Date de fin de la session": "",
-                   // Route: "",
+                    // Route: "",
                     "Code point de rassemblement initial": "",
                     "Point de rassemblement initial": "",
-                }
+                },
             ]);
             await expect(
                 referentielImportTaskService.import({
@@ -112,11 +112,9 @@ describe("ReferentielImportTaskService", () => {
             ).rejects.toThrow(new FunctionalException(FunctionalExceptionCode.IMPORT_MISSING_COLUMN));
         });
 
-        
-
         it("should import file with valid columns", async () => {
             jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecord]);
-            
+
             await referentielImportTaskService.import({
                 importType: ReferentielTaskType.IMPORT_REGIONS_ACADEMIQUES,
                 fileName: "fileName",
@@ -163,9 +161,12 @@ describe("ReferentielImportTaskService", () => {
 
             jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([partialData]);
 
-            await expect(referentielImportTaskService.import(mockImportParams))
-                .rejects
-                .toThrow(new FunctionalException(FunctionalExceptionCode.IMPORT_MISSING_COLUMN, "Zone région académique édition"));
+            await expect(referentielImportTaskService.import(mockImportParams)).rejects.toThrow(
+                new FunctionalException(
+                    FunctionalExceptionCode.IMPORT_MISSING_COLUMN,
+                    "Zone région académique édition",
+                ),
+            );
         });
     });
 });

--- a/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.spec.ts
+++ b/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.spec.ts
@@ -24,7 +24,7 @@ describe("ReferentielImportTaskService", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn().mockReturnValue(new Date("2024-07-31T00:00:00.000Z")),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2024-07-31T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2024-07-31T00:00:00.000Z"),
                     },
                 },
                 {

--- a/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.ts
+++ b/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.ts
@@ -24,7 +24,7 @@ export class ReferentielImportTaskService {
         mimetype,
         auteur,
     }: {
-        importType: typeof ReferentielTaskType[keyof typeof ReferentielTaskType];
+        importType: (typeof ReferentielTaskType)[keyof typeof ReferentielTaskType];
         fileName: string;
         buffer: Buffer;
         mimetype: string;
@@ -34,7 +34,7 @@ export class ReferentielImportTaskService {
             sheetName: IMPORT_TAB_NAMES[importType],
             defval: "",
         });
-        
+
         if (dataToImport.length === 0) {
             throw new FunctionalException(FunctionalExceptionCode.IMPORT_EMPTY_FILE);
         }
@@ -44,7 +44,7 @@ export class ReferentielImportTaskService {
             }
         }
 
-        const timestamp = this.clockGateway.getNowSafeIsoDate();
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const folderPath = `${FilePath[importType]}/export-${timestamp}`;
         const s3File = await this.fileGateway.uploadFile(`${folderPath}/${fileName}`, {
             data: buffer,
@@ -63,7 +63,7 @@ export class ReferentielImportTaskService {
                     fileLineCount: dataToImport.length,
                     auteur,
                 },
-            },  
+            },
         });
 
         return task;

--- a/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.ts
+++ b/apiv2/src/admin/core/referentiel/ReferentielImportTask.service.ts
@@ -44,7 +44,7 @@ export class ReferentielImportTaskService {
             }
         }
 
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const folderPath = `${FilePath[importType]}/export-${timestamp}`;
         const s3File = await this.fileGateway.uploadFile(`${folderPath}/${fileName}`, {
             data: buffer,

--- a/apiv2/src/admin/core/referentiel/academie/AcademieImport.service.ts
+++ b/apiv2/src/admin/core/referentiel/academie/AcademieImport.service.ts
@@ -40,7 +40,7 @@ export class AcademieImportService {
     ): Promise<string> {
         const sheetsReports = Object.fromEntries(reports.map((report, index) => [`rapport-${index + 1}`, report]));
         const fileBuffer = await this.fileGateway.generateExcel(sheetsReports);
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const reportName = `rapport-import-${parameters.type}-${timestamp}.xlsx`;
         const s3File = await this.fileGateway.uploadFile(`${parameters.folderPath}/${reportName}`, {
             data: fileBuffer,

--- a/apiv2/src/admin/core/referentiel/academie/AcademieImport.service.ts
+++ b/apiv2/src/admin/core/referentiel/academie/AcademieImport.service.ts
@@ -15,11 +15,11 @@ export class AcademieImportService {
         @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         @Inject(NotificationGateway) private readonly notificationGateway: NotificationGateway,
         @Inject(AcademieGateway) private readonly academieGateway: AcademieGateway,
-    ) { }
+    ) {}
 
     async import(academie: ImportAcademieModel): Promise<AcademieModel> {
         const academieDB = await this.academieGateway.findByCode(academie.code);
-        
+
         if (!academieDB) {
             return this.academieGateway.create(academie);
         }
@@ -27,17 +27,20 @@ export class AcademieImportService {
         if (this.canBeUpdated(academie, academieDB)) {
             return this.academieGateway.update({
                 ...academie,
-                id: academieDB.id
+                id: academieDB.id,
             } as AcademieModel);
         }
 
         return academieDB;
     }
 
-    async processReport(parameters: ReferentielImportTaskParameters, ...reports: AcademieImportRapport[][]): Promise<string> {
+    async processReport(
+        parameters: ReferentielImportTaskParameters,
+        ...reports: AcademieImportRapport[][]
+    ): Promise<string> {
         const sheetsReports = Object.fromEntries(reports.map((report, index) => [`rapport-${index + 1}`, report]));
         const fileBuffer = await this.fileGateway.generateExcel(sheetsReports);
-        const timestamp = this.clockGateway.getNowSafeIsoDate();
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const reportName = `rapport-import-${parameters.type}-${timestamp}.xlsx`;
         const s3File = await this.fileGateway.uploadFile(`${parameters.folderPath}/${reportName}`, {
             data: fileBuffer,

--- a/apiv2/src/admin/core/referentiel/academie/useCase/ImporterAcademies/ImporterAcademies.spec.ts
+++ b/apiv2/src/admin/core/referentiel/academie/useCase/ImporterAcademies/ImporterAcademies.spec.ts
@@ -61,7 +61,7 @@ describe("ImporterAcademies", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn().mockReturnValue(new Date(mockDate)),
-                        formatSafeIsoDate: jest.fn().mockReturnValue(mockDate),
+                        formatSafeDateTime: jest.fn().mockReturnValue(mockDate),
                         isValidDate: jest.fn().mockReturnValue(true),
                     },
                 },

--- a/apiv2/src/admin/core/referentiel/academie/useCase/ImporterAcademies/ImporterAcademies.spec.ts
+++ b/apiv2/src/admin/core/referentiel/academie/useCase/ImporterAcademies/ImporterAcademies.spec.ts
@@ -1,302 +1,321 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { FileGateway } from '@shared/core/File.gateway';
-import { ReferentielTaskType } from 'snu-lib';
-import { ReferentielImportTaskParameters } from '@admin/core/referentiel/ReferentielImportTask.model';
-import { Logger } from '@nestjs/common';
-import { ClockGateway } from '@shared/core/Clock.gateway';
-import { NotificationGateway } from '@notification/core/Notification.gateway';
-import { AcademieImportService } from '../../AcademieImport.service';
-import { ImporterAcademies } from './ImporterAcademies';
-import { AcademieGateway } from '../../Academie.gateway';
-import { ACADEMIE_COLUMN_NAMES } from '../../Academie.model';
-import { AcademieImportMapper } from '../../AcademieMapper';
+import { Test, TestingModule } from "@nestjs/testing";
+import { FileGateway } from "@shared/core/File.gateway";
+import { ReferentielTaskType } from "snu-lib";
+import { ReferentielImportTaskParameters } from "@admin/core/referentiel/ReferentielImportTask.model";
+import { Logger } from "@nestjs/common";
+import { ClockGateway } from "@shared/core/Clock.gateway";
+import { NotificationGateway } from "@notification/core/Notification.gateway";
+import { AcademieImportService } from "../../AcademieImport.service";
+import { ImporterAcademies } from "./ImporterAcademies";
+import { AcademieGateway } from "../../Academie.gateway";
+import { ACADEMIE_COLUMN_NAMES } from "../../Academie.model";
+import { AcademieImportMapper } from "../../AcademieMapper";
 
-describe('ImporterAcademies', () => {
-  let useCase: ImporterAcademies;
-  let academieImportService: AcademieImportService;
-  let academieGateway: AcademieGateway;
-  let fileGateway: FileGateway;
-  let clockGateway: ClockGateway;
+describe("ImporterAcademies", () => {
+    let useCase: ImporterAcademies;
+    let academieImportService: AcademieImportService;
+    let academieGateway: AcademieGateway;
+    let fileGateway: FileGateway;
+    let clockGateway: ClockGateway;
 
-  const mockDate = "31/07/2024";
-  const mockDatePlus1 = "01/08/2024";
+    const mockDate = "31/07/2024";
+    const mockDatePlus1 = "01/08/2024";
 
-  let academieRecord = {
-    [ACADEMIE_COLUMN_NAMES.code]: "001",
-    [ACADEMIE_COLUMN_NAMES.libelle]: "LYON",
-    [ACADEMIE_COLUMN_NAMES.regionAcademique]: "AUVERGNE-RHONE-ALPES",
-    [ACADEMIE_COLUMN_NAMES.dateCreationSI]: mockDate,
-    [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: mockDate
-  }
+    let academieRecord = {
+        [ACADEMIE_COLUMN_NAMES.code]: "001",
+        [ACADEMIE_COLUMN_NAMES.libelle]: "LYON",
+        [ACADEMIE_COLUMN_NAMES.regionAcademique]: "AUVERGNE-RHONE-ALPES",
+        [ACADEMIE_COLUMN_NAMES.dateCreationSI]: mockDate,
+        [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: mockDate,
+    };
 
-  const importAcademieModel = AcademieImportMapper.fromRecord(academieRecord);
+    const importAcademieModel = AcademieImportMapper.fromRecord(academieRecord);
 
-  let mockAcademieDb = {
-    ...importAcademieModel,
-    id: "1"
-  }
+    let mockAcademieDb = {
+        ...importAcademieModel,
+        id: "1",
+    };
 
-  const mockParams: ReferentielImportTaskParameters = {
-    type: ReferentielTaskType.IMPORT_ACADEMIES,
-    fileName: "test",
-    fileKey: "test",
-    fileLineCount: 1,
-    auteur: {
-      id: "test",
-      prenom: "test",
-      nom: "test",
-      role: "test",
-      sousRole: "test"
-    },
-    folderPath: ''
-  };
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ImporterAcademies,
-        AcademieImportService,
-        Logger,
-        {
-          provide: ClockGateway,
-          useValue: {
-            getNowSafeIsoDate: jest.fn().mockReturnValue(mockDate),
-            isValidDate: jest.fn().mockReturnValue(true)
-          }
-        },  
-        {
-          provide: NotificationGateway,
-          useValue: {
-            sendEmail: jest.fn()
-          }
+    const mockParams: ReferentielImportTaskParameters = {
+        type: ReferentielTaskType.IMPORT_ACADEMIES,
+        fileName: "test",
+        fileKey: "test",
+        fileLineCount: 1,
+        auteur: {
+            id: "test",
+            prenom: "test",
+            nom: "test",
+            role: "test",
+            sousRole: "test",
         },
-        {
-          provide: FileGateway,
-          useValue: {
-            downloadFile: jest.fn().mockResolvedValue({ Body: 'mocked file content' }),
-            parseXLS: jest.fn()
-          }
-        },
-        {
-          provide: AcademieGateway,
-          useValue: {
-            findByCode: jest.fn(),
-            create: jest.fn(() => mockAcademieDb),
-            update: jest.fn(() => mockAcademieDb),
-          }
-        }
-      ],
-    }).compile();
+        folderPath: "",
+    };
 
-    useCase = module.get<ImporterAcademies>(ImporterAcademies);
-    academieImportService = module.get<AcademieImportService>(AcademieImportService);
-    academieGateway = module.get<AcademieGateway>(AcademieGateway);
-    fileGateway = module.get<FileGateway>(FileGateway);
-    clockGateway = module.get<ClockGateway>(ClockGateway);
-  });
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ImporterAcademies,
+                AcademieImportService,
+                Logger,
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn().mockReturnValue(new Date(mockDate)),
+                        formatSafeIsoDate: jest.fn().mockReturnValue(mockDate),
+                        isValidDate: jest.fn().mockReturnValue(true),
+                    },
+                },
+                {
+                    provide: NotificationGateway,
+                    useValue: {
+                        sendEmail: jest.fn(),
+                    },
+                },
+                {
+                    provide: FileGateway,
+                    useValue: {
+                        downloadFile: jest.fn().mockResolvedValue({ Body: "mocked file content" }),
+                        parseXLS: jest.fn(),
+                    },
+                },
+                {
+                    provide: AcademieGateway,
+                    useValue: {
+                        findByCode: jest.fn(),
+                        create: jest.fn(() => mockAcademieDb),
+                        update: jest.fn(() => mockAcademieDb),
+                    },
+                },
+            ],
+        }).compile();
 
-  describe('execute', () => {
-    describe('Create academie', () => {
-      it('Not existing row', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([academieRecord]);
-        jest.spyOn(academieGateway, 'findByCode').mockResolvedValue(undefined);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(academieGateway.create).toHaveBeenCalledTimes(1);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "LYON",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: expect.any(Date),
-          dateDerniereModificationSI: expect.any(Date),
-          result: "success",
-        }));
-      });
+        useCase = module.get<ImporterAcademies>(ImporterAcademies);
+        academieImportService = module.get<AcademieImportService>(AcademieImportService);
+        academieGateway = module.get<AcademieGateway>(AcademieGateway);
+        fileGateway = module.get<FileGateway>(FileGateway);
+        clockGateway = module.get<ClockGateway>(ClockGateway);
     });
 
-    describe('Update academie', () => {
-      it('Existing row ET siEntity.dateDerniereModificationSI is greater than internalEntity.dateDerniereModificationSI', async () => {
-        let academieRecordPlus1 = {
-          ...academieRecord,
-          [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: mockDatePlus1
-        };
+    describe("execute", () => {
+        describe("Create academie", () => {
+            it("Not existing row", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([academieRecord]);
+                jest.spyOn(academieGateway, "findByCode").mockResolvedValue(undefined);
 
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([academieRecordPlus1]);
-        jest.spyOn(academieGateway, 'findByCode').mockResolvedValue(mockAcademieDb);
+                const result = await useCase.execute(mockParams);
 
-        const result = await useCase.execute(mockParams);
+                expect(academieGateway.create).toHaveBeenCalledTimes(1);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
 
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(1);
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "LYON",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: expect.any(Date),
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "success",
+                    }),
+                );
+            });
+        });
 
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "LYON",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: expect.any(Date),
-          dateDerniereModificationSI: expect.any(Date),
-          result: "success",
-        }));
-      });
+        describe("Update academie", () => {
+            it("Existing row ET siEntity.dateDerniereModificationSI is greater than internalEntity.dateDerniereModificationSI", async () => {
+                let academieRecordPlus1 = {
+                    ...academieRecord,
+                    [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: mockDatePlus1,
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([academieRecordPlus1]);
+                jest.spyOn(academieGateway, "findByCode").mockResolvedValue(mockAcademieDb);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(1);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "LYON",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: expect.any(Date),
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "success",
+                    }),
+                );
+            });
+        });
+
+        describe("no creation, No update", () => {
+            it("Empty buffer", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
+
+                expect(result).toEqual([]);
+            });
+
+            it("Data Validation - Code - Empty", async () => {
+                let academieRecordEmpty = {
+                    ...academieRecord,
+                    [ACADEMIE_COLUMN_NAMES.code]: "",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([academieRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "",
+                        libelle: "LYON",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: expect.any(Date),
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - code",
+                    }),
+                );
+
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Code - Invalid format - less than 3 letters", async () => {
+                let academieRecordLessThan3Letters = {
+                    ...academieRecord,
+                    [ACADEMIE_COLUMN_NAMES.code]: "01",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([academieRecordLessThan3Letters]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "01",
+                        libelle: "LYON",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: expect.any(Date),
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - code",
+                    }),
+                );
+
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - libelle - Invalid format - Empty", async () => {
+                let academieRecordEmpty = {
+                    ...academieRecord,
+                    [ACADEMIE_COLUMN_NAMES.libelle]: "",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([academieRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: expect.any(Date),
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - libelle",
+                    }),
+                );
+
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Date modification SI - Invalid format - Empty", async () => {
+                let academieRecordEmpty = {
+                    ...academieRecord,
+                    [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: "",
+                };
+                jest.spyOn(clockGateway, "isValidDate").mockRestore();
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([academieRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "LYON",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: expect.any(Date),
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - dateDerniereModificationSI",
+                    }),
+                );
+
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Date modification SI - Invalid format - Invalid date format", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([
+                    {
+                        ...academieRecord,
+                        [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: "jeudi dernier",
+                    },
+                ]);
+                jest.spyOn(clockGateway, "isValidDate").mockRestore();
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "LYON",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: expect.any(Date),
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - dateDerniereModificationSI",
+                    }),
+                );
+
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Existing row ET date_derniere_modification_si is less or equal than date_derniere_modification_si_db", async () => {
+                let academieRecordLessThanMockDate = {
+                    ...academieRecord,
+                    [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: mockDate,
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([academieRecordLessThanMockDate]);
+
+                jest.spyOn(academieGateway, "findByCode").mockResolvedValue(mockAcademieDb);
+
+                const result = await useCase.execute(mockParams);
+                expect(academieGateway.create).toHaveBeenCalledTimes(0);
+                expect(academieGateway.update).toHaveBeenCalledTimes(0);
+
+                expect(result).toEqual([
+                    {
+                        code: "001",
+                        libelle: "LYON",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        dateCreationSI: new Date("2024-07-31"),
+                        dateDerniereModificationSI: new Date("2024-07-31"),
+                        result: "success",
+                    },
+                ]);
+            });
+        });
     });
-
-    describe('no creation, No update', () => {
-      it('Empty buffer', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toEqual([]);
-      });
-
-      it('Data Validation - Code - Empty', async () => {
-        let academieRecordEmpty = {
-          ...academieRecord,
-          [ACADEMIE_COLUMN_NAMES.code]: ""
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([academieRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "",
-          libelle: "LYON",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: expect.any(Date),
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - code"
-        }));
-
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Code - Invalid format - less than 3 letters', async () => {
-        let academieRecordLessThan3Letters = {
-          ...academieRecord,
-          [ACADEMIE_COLUMN_NAMES.code]: "01"
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([academieRecordLessThan3Letters]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "01",
-          libelle: "LYON",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: expect.any(Date),
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - code"
-        }));
-
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - libelle - Invalid format - Empty', async () => {
-        let academieRecordEmpty = {
-          ...academieRecord,
-          [ACADEMIE_COLUMN_NAMES.libelle]: ""
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([academieRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: expect.any(Date),
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - libelle"
-        }));
-
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Date modification SI - Invalid format - Empty', async () => {
-        let academieRecordEmpty = {
-          ...academieRecord,
-          [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: ""
-        };
-        jest.spyOn(clockGateway, 'isValidDate').mockRestore();
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([academieRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "LYON",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: expect.any(Date),
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - dateDerniereModificationSI"
-        }));
-
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Date modification SI - Invalid format - Invalid date format', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([{
-          ...academieRecord,
-          [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: "jeudi dernier",
-        }]);
-        jest.spyOn(clockGateway, 'isValidDate').mockRestore();
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "LYON",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: expect.any(Date),
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - dateDerniereModificationSI"
-        }));
-
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Existing row ET date_derniere_modification_si is less or equal than date_derniere_modification_si_db', async () => {
-        let academieRecordLessThanMockDate = {
-          ...academieRecord,
-          [ACADEMIE_COLUMN_NAMES.dateDerniereModificationSI]: mockDate,
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([academieRecordLessThanMockDate]);        
-        
-        jest.spyOn(academieGateway, 'findByCode').mockResolvedValue(mockAcademieDb);
-
-        const result = await useCase.execute(mockParams);
-        expect(academieGateway.create).toHaveBeenCalledTimes(0);
-        expect(academieGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toEqual([{
-          code: "001",
-          libelle: "LYON",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          dateCreationSI: new Date("2024-07-31"),
-          dateDerniereModificationSI: new Date("2024-07-31"),
-          result: "success"
-        }]);
-      });
-    });
-  });
 });

--- a/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.spec.ts
+++ b/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.spec.ts
@@ -29,7 +29,8 @@ describe("ReferentielClasseService", () => {
             getMissingColumns: jest.fn(),
         };
         const mockClockGateway = {
-            getNowSafeIsoDate: jest.fn(),
+            now: jest.fn(),
+            formatSafeIsoDate: jest.fn(),
         };
         const mockNotificationGateway = {
             sendEmail: jest.fn(),

--- a/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.spec.ts
+++ b/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.spec.ts
@@ -81,7 +81,7 @@ describe("ReferentielClasseService", () => {
 
             fileGateway.parseXLS.mockResolvedValueOnce([{ someData: "test" }]).mockResolvedValueOnce([]);
             referentielService.getMissingColumns.mockReturnValueOnce([]);
-            clockGateway.getNowSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
             taskGateway.create.mockResolvedValueOnce({ id: "task-id" } as any);
 
@@ -106,7 +106,7 @@ describe("ReferentielClasseService", () => {
 
             fileGateway.parseXLS.mockResolvedValueOnce([]).mockResolvedValueOnce([{ someData: "test" }]);
             referentielService.getMissingColumns.mockReturnValueOnce([]);
-            clockGateway.getNowSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
             taskGateway.create.mockResolvedValueOnce({ id: "task-id" } as any);
 
@@ -135,7 +135,7 @@ describe("ReferentielClasseService", () => {
 
             referentielService.getMissingColumns.mockReturnValueOnce([]).mockReturnValueOnce([]);
 
-            clockGateway.getNowSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
             taskGateway.create.mockResolvedValueOnce({ id: "task-id" } as any);
 
@@ -179,7 +179,7 @@ describe("ReferentielClasseService", () => {
             const mockS3Response = { Key: "report-key" };
 
             fileGateway.generateExcel.mockResolvedValueOnce(Buffer.from("test"));
-            clockGateway.getNowSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
 
             const result = await service.processReport(mockParams, mockReport);

--- a/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.spec.ts
+++ b/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.spec.ts
@@ -30,7 +30,7 @@ describe("ReferentielClasseService", () => {
         };
         const mockClockGateway = {
             now: jest.fn(),
-            formatSafeIsoDate: jest.fn(),
+            formatSafeDateTime: jest.fn(),
         };
         const mockNotificationGateway = {
             sendEmail: jest.fn(),
@@ -81,7 +81,7 @@ describe("ReferentielClasseService", () => {
 
             fileGateway.parseXLS.mockResolvedValueOnce([{ someData: "test" }]).mockResolvedValueOnce([]);
             referentielService.getMissingColumns.mockReturnValueOnce([]);
-            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeDateTime.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
             taskGateway.create.mockResolvedValueOnce({ id: "task-id" } as any);
 
@@ -106,7 +106,7 @@ describe("ReferentielClasseService", () => {
 
             fileGateway.parseXLS.mockResolvedValueOnce([]).mockResolvedValueOnce([{ someData: "test" }]);
             referentielService.getMissingColumns.mockReturnValueOnce([]);
-            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeDateTime.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
             taskGateway.create.mockResolvedValueOnce({ id: "task-id" } as any);
 
@@ -135,7 +135,7 @@ describe("ReferentielClasseService", () => {
 
             referentielService.getMissingColumns.mockReturnValueOnce([]).mockReturnValueOnce([]);
 
-            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeDateTime.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
             taskGateway.create.mockResolvedValueOnce({ id: "task-id" } as any);
 
@@ -179,7 +179,7 @@ describe("ReferentielClasseService", () => {
             const mockS3Response = { Key: "report-key" };
 
             fileGateway.generateExcel.mockResolvedValueOnce(Buffer.from("test"));
-            clockGateway.formatSafeIsoDate.mockReturnValueOnce(mockTimestamp);
+            clockGateway.formatSafeDateTime.mockReturnValueOnce(mockTimestamp);
             fileGateway.uploadFile.mockResolvedValueOnce(mockS3Response as any);
 
             const result = await service.processReport(mockParams, mockReport);

--- a/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.ts
+++ b/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.ts
@@ -92,7 +92,7 @@ export class ReferentielClasseService {
             throw new FunctionalException(FunctionalExceptionCode.NOT_IMPLEMENTED_YET);
         }
 
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const folderPath = `${FilePath[ReferentielTaskType.IMPORT_CLASSES]}/export-${timestamp}`;
         const s3File = await this.fileGateway.uploadFile(`${folderPath}/${fileName}`, {
             data: buffer,
@@ -120,7 +120,7 @@ export class ReferentielClasseService {
     async processReport(parameters: ReferentielImportTaskParameters, ...reports: ClasseRapport[][]): Promise<string> {
         const sheetsReports = Object.fromEntries(reports.map((report, index) => [`rapport-${index + 1}`, report]));
         const fileBuffer = await this.fileGateway.generateExcel(sheetsReports);
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const reportName = `rapport-import-${parameters.type}-${timestamp}.xlsx`;
         const s3File = await this.fileGateway.uploadFile(`${parameters.folderPath}/${reportName}`, {
             data: fileBuffer,

--- a/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.ts
+++ b/apiv2/src/admin/core/referentiel/classe/ReferentielClasse.service.ts
@@ -92,7 +92,7 @@ export class ReferentielClasseService {
             throw new FunctionalException(FunctionalExceptionCode.NOT_IMPLEMENTED_YET);
         }
 
-        const timestamp = this.clockGateway.getNowSafeIsoDate();
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const folderPath = `${FilePath[ReferentielTaskType.IMPORT_CLASSES]}/export-${timestamp}`;
         const s3File = await this.fileGateway.uploadFile(`${folderPath}/${fileName}`, {
             data: buffer,
@@ -120,7 +120,7 @@ export class ReferentielClasseService {
     async processReport(parameters: ReferentielImportTaskParameters, ...reports: ClasseRapport[][]): Promise<string> {
         const sheetsReports = Object.fromEntries(reports.map((report, index) => [`rapport-${index + 1}`, report]));
         const fileBuffer = await this.fileGateway.generateExcel(sheetsReports);
-        const timestamp = this.clockGateway.getNowSafeIsoDate();
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const reportName = `rapport-import-${parameters.type}-${timestamp}.xlsx`;
         const s3File = await this.fileGateway.uploadFile(`${parameters.folderPath}/${reportName}`, {
             data: fileBuffer,

--- a/apiv2/src/admin/core/referentiel/departement/DepartementImport.service.ts
+++ b/apiv2/src/admin/core/referentiel/departement/DepartementImport.service.ts
@@ -15,11 +15,11 @@ export class DepartementImportService {
         @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         @Inject(NotificationGateway) private readonly notificationGateway: NotificationGateway,
         @Inject(DepartementGateway) private readonly departementGateway: DepartementGateway,
-    ) { }
+    ) {}
 
     async import(departement: ImportDepartementModel): Promise<DepartementModel> {
         const departementDB = await this.departementGateway.findByCode(departement.code);
-        
+
         if (!departementDB) {
             return this.departementGateway.create(departement);
         }
@@ -27,17 +27,20 @@ export class DepartementImportService {
         if (this.canBeUpdated(departement, departementDB)) {
             return this.departementGateway.update({
                 ...departement,
-                id: departementDB.id
+                id: departementDB.id,
             } as DepartementModel);
         }
 
         return departementDB;
     }
 
-    async processReport(parameters: ReferentielImportTaskParameters, ...reports: DepartementImportRapport[][]): Promise<string> {
+    async processReport(
+        parameters: ReferentielImportTaskParameters,
+        ...reports: DepartementImportRapport[][]
+    ): Promise<string> {
         const sheetsReports = Object.fromEntries(reports.map((report, index) => [`rapport-${index + 1}`, report]));
         const fileBuffer = await this.fileGateway.generateExcel(sheetsReports);
-        const timestamp = this.clockGateway.getNowSafeIsoDate();
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const reportName = `rapport-import-${parameters.type}-${timestamp}.xlsx`;
         const s3File = await this.fileGateway.uploadFile(`${parameters.folderPath}/${reportName}`, {
             data: fileBuffer,

--- a/apiv2/src/admin/core/referentiel/departement/DepartementImport.service.ts
+++ b/apiv2/src/admin/core/referentiel/departement/DepartementImport.service.ts
@@ -40,7 +40,7 @@ export class DepartementImportService {
     ): Promise<string> {
         const sheetsReports = Object.fromEntries(reports.map((report, index) => [`rapport-${index + 1}`, report]));
         const fileBuffer = await this.fileGateway.generateExcel(sheetsReports);
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const reportName = `rapport-import-${parameters.type}-${timestamp}.xlsx`;
         const s3File = await this.fileGateway.uploadFile(`${parameters.folderPath}/${reportName}`, {
             data: fileBuffer,

--- a/apiv2/src/admin/core/referentiel/departement/useCase/ImporterDepartements/ImporterDepartements.spec.ts
+++ b/apiv2/src/admin/core/referentiel/departement/useCase/ImporterDepartements/ImporterDepartements.spec.ts
@@ -63,7 +63,7 @@ describe("ImporterDepartements", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue(mockDate),
+                        formatSafeDateTime: jest.fn().mockReturnValue(mockDate),
                         isValidDate: jest.fn().mockReturnValue(true),
                     },
                 },

--- a/apiv2/src/admin/core/referentiel/departement/useCase/ImporterDepartements/ImporterDepartements.spec.ts
+++ b/apiv2/src/admin/core/referentiel/departement/useCase/ImporterDepartements/ImporterDepartements.spec.ts
@@ -1,313 +1,332 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { FileGateway } from '@shared/core/File.gateway';
-import { ReferentielTaskType } from 'snu-lib';
-import { ReferentielImportTaskParameters } from '@admin/core/referentiel/ReferentielImportTask.model';
-import { Logger } from '@nestjs/common';
-import { ClockGateway } from '@shared/core/Clock.gateway';
-import { NotificationGateway } from '@notification/core/Notification.gateway';
-import { DepartementImportService } from '../../DepartementImport.service';
-import { ImporterDepartements } from './ImporterDepartements';
-import { DepartementGateway } from '../../Departement.gateway';
-import { DEPARTEMENT_COLUMN_NAMES } from '../../Departement.model';
-import { DepartementImportMapper } from '../../DepartementMapper';
+import { Test, TestingModule } from "@nestjs/testing";
+import { FileGateway } from "@shared/core/File.gateway";
+import { ReferentielTaskType } from "snu-lib";
+import { ReferentielImportTaskParameters } from "@admin/core/referentiel/ReferentielImportTask.model";
+import { Logger } from "@nestjs/common";
+import { ClockGateway } from "@shared/core/Clock.gateway";
+import { NotificationGateway } from "@notification/core/Notification.gateway";
+import { DepartementImportService } from "../../DepartementImport.service";
+import { ImporterDepartements } from "./ImporterDepartements";
+import { DepartementGateway } from "../../Departement.gateway";
+import { DEPARTEMENT_COLUMN_NAMES } from "../../Departement.model";
+import { DepartementImportMapper } from "../../DepartementMapper";
 
-describe('ImporterDepartements', () => {
-  let useCase: ImporterDepartements;
-  let departementImportService: DepartementImportService;
-  let departementGateway: DepartementGateway;
-  let fileGateway: FileGateway;
-  let clockGateway: ClockGateway;
+describe("ImporterDepartements", () => {
+    let useCase: ImporterDepartements;
+    let departementImportService: DepartementImportService;
+    let departementGateway: DepartementGateway;
+    let fileGateway: FileGateway;
+    let clockGateway: ClockGateway;
 
-  const mockDate = "31/07/2024";
-  const mockDatePlus1 = "01/08/2024";
+    const mockDate = "31/07/2024";
+    const mockDatePlus1 = "01/08/2024";
 
-  let departementRecord = {
-    [DEPARTEMENT_COLUMN_NAMES.code]: "001",
-    [DEPARTEMENT_COLUMN_NAMES.libelle]: "AIN",
-    [DEPARTEMENT_COLUMN_NAMES.chefLieu]: "Bourg en Bresse",
-    [DEPARTEMENT_COLUMN_NAMES.regionAcademique]: "AUVERGNE-RHONE-ALPES",
-    [DEPARTEMENT_COLUMN_NAMES.academie]: "LYON",
-    [DEPARTEMENT_COLUMN_NAMES.dateCreationSI]: mockDate,
-    [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: mockDate
-  }
+    let departementRecord = {
+        [DEPARTEMENT_COLUMN_NAMES.code]: "001",
+        [DEPARTEMENT_COLUMN_NAMES.libelle]: "AIN",
+        [DEPARTEMENT_COLUMN_NAMES.chefLieu]: "Bourg en Bresse",
+        [DEPARTEMENT_COLUMN_NAMES.regionAcademique]: "AUVERGNE-RHONE-ALPES",
+        [DEPARTEMENT_COLUMN_NAMES.academie]: "LYON",
+        [DEPARTEMENT_COLUMN_NAMES.dateCreationSI]: mockDate,
+        [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: mockDate,
+    };
 
-  const importDepartementModel = DepartementImportMapper.fromRecord(departementRecord);
+    const importDepartementModel = DepartementImportMapper.fromRecord(departementRecord);
 
-  let mockDepartementDb = {
-    ...importDepartementModel,
-    id: "1"
-  }
+    let mockDepartementDb = {
+        ...importDepartementModel,
+        id: "1",
+    };
 
-  const mockParams: ReferentielImportTaskParameters = {
-    type: ReferentielTaskType.IMPORT_DEPARTEMENTS,
-    fileName: "test",
-    fileKey: "test",
-    fileLineCount: 1,
-    auteur: {
-      id: "test",
-      prenom: "test",
-      nom: "test",
-      role: "test",
-      sousRole: "test"
-    },
-    folderPath: ''
-  };
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ImporterDepartements,
-        DepartementImportService,
-        Logger,
-        {
-          provide: ClockGateway,
-          useValue: {
-            getNowSafeIsoDate: jest.fn().mockReturnValue(mockDate),
-            isValidDate: jest.fn().mockReturnValue(true)
-          }
+    const mockParams: ReferentielImportTaskParameters = {
+        type: ReferentielTaskType.IMPORT_DEPARTEMENTS,
+        fileName: "test",
+        fileKey: "test",
+        fileLineCount: 1,
+        auteur: {
+            id: "test",
+            prenom: "test",
+            nom: "test",
+            role: "test",
+            sousRole: "test",
         },
-        {
-          provide: NotificationGateway,
-          useValue: {
-            sendEmail: jest.fn()
-          }
-        },
-        {
-          provide: FileGateway,
-          useValue: {
-            downloadFile: jest.fn().mockResolvedValue({ Body: 'mocked file content' }),
-            parseXLS: jest.fn()
-          }
-        },
-        {
-          provide: DepartementGateway,
-          useValue: {
-            findByCode: jest.fn(),
-            create: jest.fn(() => mockDepartementDb),
-            update: jest.fn(() => mockDepartementDb),
-          }
-        }
-      ],
-    }).compile();
+        folderPath: "",
+    };
 
-    useCase = module.get<ImporterDepartements>(ImporterDepartements);
-    departementImportService = module.get<DepartementImportService>(DepartementImportService);
-    departementGateway = module.get<DepartementGateway>(DepartementGateway);
-    fileGateway = module.get<FileGateway>(FileGateway);
-    clockGateway = module.get<ClockGateway>(ClockGateway);
-  });
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ImporterDepartements,
+                DepartementImportService,
+                Logger,
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue(mockDate),
+                        isValidDate: jest.fn().mockReturnValue(true),
+                    },
+                },
+                {
+                    provide: NotificationGateway,
+                    useValue: {
+                        sendEmail: jest.fn(),
+                    },
+                },
+                {
+                    provide: FileGateway,
+                    useValue: {
+                        downloadFile: jest.fn().mockResolvedValue({ Body: "mocked file content" }),
+                        parseXLS: jest.fn(),
+                    },
+                },
+                {
+                    provide: DepartementGateway,
+                    useValue: {
+                        findByCode: jest.fn(),
+                        create: jest.fn(() => mockDepartementDb),
+                        update: jest.fn(() => mockDepartementDb),
+                    },
+                },
+            ],
+        }).compile();
 
-  describe('execute', () => {
-    describe('Create departement', () => {
-      it('Not existing row', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([departementRecord]);
-        jest.spyOn(departementGateway, 'findByCode').mockResolvedValue(undefined);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(departementGateway.create).toHaveBeenCalledTimes(1);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "AIN",
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          result: "success",
-        }));
-      });
+        useCase = module.get<ImporterDepartements>(ImporterDepartements);
+        departementImportService = module.get<DepartementImportService>(DepartementImportService);
+        departementGateway = module.get<DepartementGateway>(DepartementGateway);
+        fileGateway = module.get<FileGateway>(FileGateway);
+        clockGateway = module.get<ClockGateway>(ClockGateway);
     });
 
-    describe('Update departement', () => {
-      it('Existing row ET siEntity.dateDerniereModificationSI is greater than internalEntity.dateDerniereModificationSI', async () => {
-        let departementRecordPlus1 = {
-          ...departementRecord,
-          [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: mockDatePlus1
-        };
+    describe("execute", () => {
+        describe("Create departement", () => {
+            it("Not existing row", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([departementRecord]);
+                jest.spyOn(departementGateway, "findByCode").mockResolvedValue(undefined);
 
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([departementRecordPlus1]);
-        jest.spyOn(departementGateway, 'findByCode').mockResolvedValue(mockDepartementDb);
+                const result = await useCase.execute(mockParams);
 
-        const result = await useCase.execute(mockParams);
+                expect(departementGateway.create).toHaveBeenCalledTimes(1);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
 
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(1);
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "AIN",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        result: "success",
+                    }),
+                );
+            });
+        });
 
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "AIN", 
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "success",
-        }));
-      });
+        describe("Update departement", () => {
+            it("Existing row ET siEntity.dateDerniereModificationSI is greater than internalEntity.dateDerniereModificationSI", async () => {
+                let departementRecordPlus1 = {
+                    ...departementRecord,
+                    [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: mockDatePlus1,
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([departementRecordPlus1]);
+                jest.spyOn(departementGateway, "findByCode").mockResolvedValue(mockDepartementDb);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(1);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "AIN",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "success",
+                    }),
+                );
+            });
+        });
+
+        describe("no creation, No update", () => {
+            it("Empty buffer", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
+
+                expect(result).toEqual([]);
+            });
+
+            it("Data Validation - Code - Empty", async () => {
+                let departementRecordEmpty = {
+                    ...departementRecord,
+                    [DEPARTEMENT_COLUMN_NAMES.code]: "",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([departementRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "",
+                        libelle: "AIN",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - code",
+                    }),
+                );
+
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Code - Invalid format - less than 3 letters", async () => {
+                let departementRecordLessThan3Letters = {
+                    ...departementRecord,
+                    [DEPARTEMENT_COLUMN_NAMES.code]: "01",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([departementRecordLessThan3Letters]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "01",
+                        libelle: "AIN",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - code",
+                    }),
+                );
+
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - libelle - Invalid format - Empty", async () => {
+                let departementRecordEmpty = {
+                    ...departementRecord,
+                    [DEPARTEMENT_COLUMN_NAMES.libelle]: "",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([departementRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - libelle",
+                    }),
+                );
+
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Date modification SI - Invalid format - Empty", async () => {
+                let departementRecordEmpty = {
+                    ...departementRecord,
+                    [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: "",
+                };
+
+                jest.spyOn(clockGateway, "isValidDate").mockRestore();
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([departementRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "AIN",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - dateDerniereModificationSI",
+                    }),
+                );
+
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Date creation SI - Invalid format - Invalid date format", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([
+                    {
+                        ...departementRecord,
+                        [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: "jeudi dernier",
+                    },
+                ]);
+                jest.spyOn(clockGateway, "isValidDate").mockRestore();
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "001",
+                        libelle: "AIN",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - dateDerniereModificationSI",
+                    }),
+                );
+
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Existing row ET date_derniere_modification_si is less or equal than date_derniere_modification_si_db", async () => {
+                let departementRecordLessThanMockDate = {
+                    ...departementRecord,
+                    [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: mockDate,
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([departementRecordLessThanMockDate]);
+
+                jest.spyOn(departementGateway, "findByCode").mockResolvedValue(mockDepartementDb);
+
+                const result = await useCase.execute(mockParams);
+                expect(departementGateway.create).toHaveBeenCalledTimes(0);
+                expect(departementGateway.update).toHaveBeenCalledTimes(0);
+
+                expect(result).toEqual([
+                    {
+                        code: "001",
+                        libelle: "AIN",
+                        chefLieu: "Bourg en Bresse",
+                        regionAcademique: "AUVERGNE-RHONE-ALPES",
+                        academie: "LYON",
+                        dateCreationSI: new Date("2024-07-31"),
+                        dateDerniereModificationSI: new Date("2024-07-31"),
+                        result: "success",
+                    },
+                ]);
+            });
+        });
     });
-
-    describe('no creation, No update', () => {
-      it('Empty buffer', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toEqual([]);
-      });
-
-      it('Data Validation - Code - Empty', async () => {
-        let departementRecordEmpty = {
-          ...departementRecord,
-          [DEPARTEMENT_COLUMN_NAMES.code]: ""
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([departementRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "",
-          libelle: "AIN",
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          dateDerniereModificationSI: expect.any(Date), 
-          result: "error",
-          error: "Invalid format - code"
-        }));
-
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Code - Invalid format - less than 3 letters', async () => {
-        let departementRecordLessThan3Letters = {
-          ...departementRecord,
-          [DEPARTEMENT_COLUMN_NAMES.code]: "01"
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([departementRecordLessThan3Letters]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "01",
-          libelle: "AIN",
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - code"
-        }));
-
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - libelle - Invalid format - Empty', async () => {
-        let departementRecordEmpty = {
-          ...departementRecord,
-          [DEPARTEMENT_COLUMN_NAMES.libelle]: ""
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([departementRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "",
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - libelle"
-        }));
-
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Date modification SI - Invalid format - Empty', async () => {
-        let departementRecordEmpty = {
-          ...departementRecord,
-          [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: ""
-        };
-
-        jest.spyOn(clockGateway, 'isValidDate').mockRestore();
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([departementRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "AIN",
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - dateDerniereModificationSI"
-        }));
-
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Date creation SI - Invalid format - Invalid date format', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([{
-          ...departementRecord,
-          [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: "jeudi dernier",
-        }]);
-        jest.spyOn(clockGateway, 'isValidDate').mockRestore();
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "001",
-          libelle: "AIN",
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - dateDerniereModificationSI"
-        }));
-
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Existing row ET date_derniere_modification_si is less or equal than date_derniere_modification_si_db', async () => {
-        let departementRecordLessThanMockDate = {
-          ...departementRecord,
-          [DEPARTEMENT_COLUMN_NAMES.dateDerniereModificationSI]: mockDate,
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([departementRecordLessThanMockDate]);        
-        
-        jest.spyOn(departementGateway, 'findByCode').mockResolvedValue(mockDepartementDb);
-
-        const result = await useCase.execute(mockParams);
-        expect(departementGateway.create).toHaveBeenCalledTimes(0);
-        expect(departementGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toEqual([{
-          code: "001",
-          libelle: "AIN",
-          chefLieu: "Bourg en Bresse",
-          regionAcademique: "AUVERGNE-RHONE-ALPES",
-          academie: "LYON",
-          dateCreationSI: new Date("2024-07-31"),
-          dateDerniereModificationSI: new Date("2024-07-31"),
-          result: "success"
-        }]);
-      });
-    });
-  });
 });

--- a/apiv2/src/admin/core/referentiel/regionAcademique/RegionAcademiqueImport.service.ts
+++ b/apiv2/src/admin/core/referentiel/regionAcademique/RegionAcademiqueImport.service.ts
@@ -44,7 +44,7 @@ export class RegionAcademiqueImportService {
     ): Promise<string> {
         const sheetsReports = Object.fromEntries(reports.map((report, index) => [`rapport-${index + 1}`, report]));
         const fileBuffer = await this.fileGateway.generateExcel(sheetsReports);
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const reportName = `rapport-import-${parameters.type}-${timestamp}.xlsx`;
         const s3File = await this.fileGateway.uploadFile(`${parameters.folderPath}/${reportName}`, {
             data: fileBuffer,

--- a/apiv2/src/admin/core/referentiel/regionAcademique/useCase/ImporterRegionsAcademiques/ImporterRegionsAcademiques.spec.ts
+++ b/apiv2/src/admin/core/referentiel/regionAcademique/useCase/ImporterRegionsAcademiques/ImporterRegionsAcademiques.spec.ts
@@ -60,7 +60,7 @@ describe("ImporterRegionsAcademiques", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue(mockDate),
+                        formatSafeDateTime: jest.fn().mockReturnValue(mockDate),
                         isValidDate: jest.fn().mockReturnValue(true),
                     },
                 },

--- a/apiv2/src/admin/core/referentiel/regionAcademique/useCase/ImporterRegionsAcademiques/ImporterRegionsAcademiques.spec.ts
+++ b/apiv2/src/admin/core/referentiel/regionAcademique/useCase/ImporterRegionsAcademiques/ImporterRegionsAcademiques.spec.ts
@@ -1,337 +1,353 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { RegionAcademiqueImportService } from '../../RegionAcademiqueImport.service';
-import { FileGateway } from '@shared/core/File.gateway';
-import { ReferentielTaskType } from 'snu-lib';
-import { RegionAcademiqueGateway } from '../../RegionAcademique.gateway';
-import { ImporterRegionsAcademiques } from './ImporterRegionsAcademiques';
-import { ReferentielImportTaskParameters } from '@admin/core/referentiel/ReferentielImportTask.model';
-import { Logger } from '@nestjs/common';
-import { ClockGateway } from '@shared/core/Clock.gateway';
-import { NotificationGateway } from '@notification/core/Notification.gateway';
-import { REGION_ACADEMIQUE_COLUMN_NAMES } from '../../RegionAcademique.model';
-import { RegionAcademiqueImportMapper } from '../../RegionAcademiqueMapper';
+import { Test, TestingModule } from "@nestjs/testing";
+import { RegionAcademiqueImportService } from "../../RegionAcademiqueImport.service";
+import { FileGateway } from "@shared/core/File.gateway";
+import { ReferentielTaskType } from "snu-lib";
+import { RegionAcademiqueGateway } from "../../RegionAcademique.gateway";
+import { ImporterRegionsAcademiques } from "./ImporterRegionsAcademiques";
+import { ReferentielImportTaskParameters } from "@admin/core/referentiel/ReferentielImportTask.model";
+import { Logger } from "@nestjs/common";
+import { ClockGateway } from "@shared/core/Clock.gateway";
+import { NotificationGateway } from "@notification/core/Notification.gateway";
+import { REGION_ACADEMIQUE_COLUMN_NAMES } from "../../RegionAcademique.model";
+import { RegionAcademiqueImportMapper } from "../../RegionAcademiqueMapper";
 
-describe('ImporterRegionsAcademiques', () => {
-  let useCase: ImporterRegionsAcademiques;
-  let regionAcademiqueImportService: RegionAcademiqueImportService;
-  let regionAcademiqueGateway: RegionAcademiqueGateway;
-  let fileGateway: FileGateway;
-  let clockGateway: ClockGateway;
+describe("ImporterRegionsAcademiques", () => {
+    let useCase: ImporterRegionsAcademiques;
+    let regionAcademiqueImportService: RegionAcademiqueImportService;
+    let regionAcademiqueGateway: RegionAcademiqueGateway;
+    let fileGateway: FileGateway;
+    let clockGateway: ClockGateway;
 
-  const mockDate = "31/07/2024";
-  const mockDatePlus1 = "01/08/2024";
+    const mockDate = "31/07/2024";
+    const mockDatePlus1 = "01/08/2024";
 
-  let regionAcademiqueRecord = {
-    [REGION_ACADEMIQUE_COLUMN_NAMES.code]: "BRE",
-    [REGION_ACADEMIQUE_COLUMN_NAMES.libelle]: "BRETAGNE",
-    [REGION_ACADEMIQUE_COLUMN_NAMES.zone]: "A",
-    [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: mockDate
-  }
+    let regionAcademiqueRecord = {
+        [REGION_ACADEMIQUE_COLUMN_NAMES.code]: "BRE",
+        [REGION_ACADEMIQUE_COLUMN_NAMES.libelle]: "BRETAGNE",
+        [REGION_ACADEMIQUE_COLUMN_NAMES.zone]: "A",
+        [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: mockDate,
+    };
 
-  const importRegionAcademiqueModel = RegionAcademiqueImportMapper.fromRecord(regionAcademiqueRecord);
+    const importRegionAcademiqueModel = RegionAcademiqueImportMapper.fromRecord(regionAcademiqueRecord);
 
-  let mockRegionAcademiqueDb = {
-    ...importRegionAcademiqueModel,
-    id: "1"
-  }
+    let mockRegionAcademiqueDb = {
+        ...importRegionAcademiqueModel,
+        id: "1",
+    };
 
-  const mockParams: ReferentielImportTaskParameters = {
-    type: ReferentielTaskType.IMPORT_REGIONS_ACADEMIQUES,
-    fileName: "test",
-    fileKey: "test",
-    fileLineCount: 1,
-    auteur: {
-      id: "test",
-      prenom: "test",
-      nom: "test",
-      role: "test",
-      sousRole: "test"
-    },
-    folderPath: ''
-  };
-
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ImporterRegionsAcademiques,
-        RegionAcademiqueImportService,
-        Logger,
-        {
-          provide: ClockGateway,
-          useValue: {
-            getNowSafeIsoDate: jest.fn().mockReturnValue(mockDate),
-            isValidDate: jest.fn().mockReturnValue(true)
-          }
-        },
-        {
-          provide: NotificationGateway,
-          useValue: {
-            sendEmail: jest.fn()
-          }
-        },
-        {
-          provide: FileGateway,
-          useValue: {
-            downloadFile: jest.fn().mockResolvedValue({ Body: 'mocked file content' }),
-            parseXLS: jest.fn()
-          }
-        },
-        {
-          provide: RegionAcademiqueGateway,
-          useValue: {
-            findByCode: jest.fn(),
-            create: jest.fn(() => mockRegionAcademiqueDb),
-            update: jest.fn(() => mockRegionAcademiqueDb),
-          }
-        }
-      ],
-    }).compile();
-
-    useCase = module.get<ImporterRegionsAcademiques>(ImporterRegionsAcademiques);
-    regionAcademiqueImportService = module.get<RegionAcademiqueImportService>(RegionAcademiqueImportService);
-    regionAcademiqueGateway = module.get<RegionAcademiqueGateway>(RegionAcademiqueGateway);
-
-    fileGateway = module.get<FileGateway>(FileGateway);
-    clockGateway = module.get<ClockGateway>(ClockGateway);
-  });
-
-  describe('execute', () => {
-    describe('Create région academique', () => {
-      it('Not existing row', async () => {
-        const params: ReferentielImportTaskParameters = {
-          type: ReferentielTaskType.IMPORT_REGIONS_ACADEMIQUES,
-          fileName: "test",
-          fileKey: "test",
-          fileLineCount: 1,
-          auteur: {
+    const mockParams: ReferentielImportTaskParameters = {
+        type: ReferentielTaskType.IMPORT_REGIONS_ACADEMIQUES,
+        fileName: "test",
+        fileKey: "test",
+        fileLineCount: 1,
+        auteur: {
             id: "test",
             prenom: "test",
             nom: "test",
             role: "test",
-            sousRole: "test"
-          },
-          folderPath: ''
-        };
+            sousRole: "test",
+        },
+        folderPath: "",
+    };
 
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecord]);
-        jest.spyOn(regionAcademiqueGateway, 'findByCode').mockResolvedValue(undefined);
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ImporterRegionsAcademiques,
+                RegionAcademiqueImportService,
+                Logger,
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue(mockDate),
+                        isValidDate: jest.fn().mockReturnValue(true),
+                    },
+                },
+                {
+                    provide: NotificationGateway,
+                    useValue: {
+                        sendEmail: jest.fn(),
+                    },
+                },
+                {
+                    provide: FileGateway,
+                    useValue: {
+                        downloadFile: jest.fn().mockResolvedValue({ Body: "mocked file content" }),
+                        parseXLS: jest.fn(),
+                    },
+                },
+                {
+                    provide: RegionAcademiqueGateway,
+                    useValue: {
+                        findByCode: jest.fn(),
+                        create: jest.fn(() => mockRegionAcademiqueDb),
+                        update: jest.fn(() => mockRegionAcademiqueDb),
+                    },
+                },
+            ],
+        }).compile();
 
-        const result = await useCase.execute(params);
+        useCase = module.get<ImporterRegionsAcademiques>(ImporterRegionsAcademiques);
+        regionAcademiqueImportService = module.get<RegionAcademiqueImportService>(RegionAcademiqueImportService);
+        regionAcademiqueGateway = module.get<RegionAcademiqueGateway>(RegionAcademiqueGateway);
 
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(1);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
-          libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
-          zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
-          dateDerniereModificationSI: expect.any(Date),
-          result: "success",
-        }));
-      });
+        fileGateway = module.get<FileGateway>(FileGateway);
+        clockGateway = module.get<ClockGateway>(ClockGateway);
     });
 
-    describe('Update région académique', () => {
-      it('Existing row ET siEntity.dateDerniereModificationSI is greater than internalEntity.dateDerniereModificationSI', async () => {
+    describe("execute", () => {
+        describe("Create région academique", () => {
+            it("Not existing row", async () => {
+                const params: ReferentielImportTaskParameters = {
+                    type: ReferentielTaskType.IMPORT_REGIONS_ACADEMIQUES,
+                    fileName: "test",
+                    fileKey: "test",
+                    fileLineCount: 1,
+                    auteur: {
+                        id: "test",
+                        prenom: "test",
+                        nom: "test",
+                        role: "test",
+                        sousRole: "test",
+                    },
+                    folderPath: "",
+                };
 
-        let regionAcademiqueRecordPlus1 = {
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: mockDatePlus1
-        };
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecord]);
+                jest.spyOn(regionAcademiqueGateway, "findByCode").mockResolvedValue(undefined);
 
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecordPlus1]);
-        jest.spyOn(regionAcademiqueGateway, 'findByCode').mockResolvedValue(mockRegionAcademiqueDb);
+                const result = await useCase.execute(params);
 
-        const result = await useCase.execute(mockParams);
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(1);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
 
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(1);
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
+                        libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
+                        zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "success",
+                    }),
+                );
+            });
+        });
 
-        expect(result).toContainEqual(expect.objectContaining({
-          code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
-          libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
-          zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
-          dateDerniereModificationSI: expect.any(Date),
-          result: "success",
-        }));
-      });
+        describe("Update région académique", () => {
+            it("Existing row ET siEntity.dateDerniereModificationSI is greater than internalEntity.dateDerniereModificationSI", async () => {
+                let regionAcademiqueRecordPlus1 = {
+                    ...regionAcademiqueRecord,
+                    [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: mockDatePlus1,
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecordPlus1]);
+                jest.spyOn(regionAcademiqueGateway, "findByCode").mockResolvedValue(mockRegionAcademiqueDb);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(1);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
+                        libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
+                        zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "success",
+                    }),
+                );
+            });
+        });
+
+        describe("no creation, No update", () => {
+            it("Empty buffer", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+
+                expect(result).toEqual([]);
+            });
+
+            it("Data Validation - Code - Empty", async () => {
+                let regionAcademiqueRecordEmpty = {
+                    ...regionAcademiqueRecord,
+                    [REGION_ACADEMIQUE_COLUMN_NAMES.code]: "",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "",
+                        libelle: "BRETAGNE",
+                        zone: "A",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - code",
+                    }),
+                );
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Code - Invalid format - less than 3 letters", async () => {
+                let regionAcademiqueRecordLessThan3Letters = {
+                    ...regionAcademiqueRecord,
+                    [REGION_ACADEMIQUE_COLUMN_NAMES.code]: "AB",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecordLessThan3Letters]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: "AB",
+                        libelle: "BRETAGNE",
+                        zone: "A",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - code",
+                    }),
+                );
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - libelle - Invalid format - Empty", async () => {
+                let regionAcademiqueRecordEmpty = {
+                    ...regionAcademiqueRecord,
+                    [REGION_ACADEMIQUE_COLUMN_NAMES.libelle]: "",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecordEmpty]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
+                        libelle: "",
+                        zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - libelle",
+                    }),
+                );
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Zone - Invalid format - Must be empty, A, B or C", async () => {
+                let regionAcademiqueRecordInvalidZone = {
+                    ...regionAcademiqueRecord,
+                    [REGION_ACADEMIQUE_COLUMN_NAMES.zone]: "D",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecordInvalidZone]);
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
+                        libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
+                        zone: "D",
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - zone",
+                    }),
+                );
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Date modification SI - Invalid format - Empty", async () => {
+                let regionAcademiqueRecordEmpty = {
+                    ...regionAcademiqueRecord,
+                    [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: "",
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecordEmpty]);
+                jest.spyOn(clockGateway, "isValidDate").mockRestore();
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
+                        libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
+                        zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - dateDerniereModificationSI",
+                    }),
+                );
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Data Validation - Date creation SI - Invalid format - Invalid date format", async () => {
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([
+                    {
+                        ...regionAcademiqueRecord,
+                        [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: "jeudi dernier",
+                    },
+                ]);
+                jest.spyOn(clockGateway, "isValidDate").mockRestore();
+
+                const result = await useCase.execute(mockParams);
+
+                expect(result).toContainEqual(
+                    expect.objectContaining({
+                        code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
+                        libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
+                        zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
+                        dateDerniereModificationSI: expect.any(Date),
+                        result: "error",
+                        error: "Invalid format - dateDerniereModificationSI",
+                    }),
+                );
+
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+            });
+
+            it("Existing row ET date_derniere_modification_si is less or equal than date_derniere_modification_si_db", async () => {
+                let regionAcademiqueRecordLessThanMockDate = {
+                    ...regionAcademiqueRecord,
+                    [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: mockDate,
+                };
+
+                jest.spyOn(fileGateway, "parseXLS").mockResolvedValue([regionAcademiqueRecordLessThanMockDate]);
+                jest.spyOn(regionAcademiqueGateway, "findByCode").mockResolvedValue(mockRegionAcademiqueDb);
+
+                const result = await useCase.execute(mockParams);
+                expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
+                expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
+
+                expect(result).toEqual([
+                    {
+                        code: "BRE",
+                        dateDerniereModificationSI: new Date("2024-07-31"),
+                        libelle: "BRETAGNE",
+                        result: "success",
+                        zone: "A",
+                    },
+                ]);
+            });
+        });
     });
-
-    describe('no creation, No update', () => {
-      it('Empty buffer', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toEqual([]);
-      });
-
-      it('Data Validation - Code - Empty', async () => {
-        let regionAcademiqueRecordEmpty = {
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.code]: ""
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "",
-          libelle: "BRETAGNE",
-          zone: "A",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - code"
-        }));
-
-
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Code - Invalid format - less than 3 letters', async () => {
-        let regionAcademiqueRecordLessThan3Letters = {
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.code]: "AB"
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecordLessThan3Letters]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: "AB",
-          libelle: "BRETAGNE",
-          zone: "A",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - code"
-        }));
-
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - libelle - Invalid format - Empty', async () => {
-        let regionAcademiqueRecordEmpty = {
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.libelle]: ""
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecordEmpty]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
-          libelle: "",
-          zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - libelle"
-        }));
-
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Zone - Invalid format - Must be empty, A, B or C', async () => {
-        let regionAcademiqueRecordInvalidZone = {
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.zone]: "D"
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecordInvalidZone]);
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
-          libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
-          zone: "D",
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - zone"
-        }));
-
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-      });
-
-      it('Data Validation - Date modification SI - Invalid format - Empty', async () => {
-        let regionAcademiqueRecordEmpty = {
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: ""
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecordEmpty]);
-        jest.spyOn(clockGateway, 'isValidDate').mockRestore();
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
-          libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
-          zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - dateDerniereModificationSI"
-        }));
-
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-      }); 
-
-      it('Data Validation - Date creation SI - Invalid format - Invalid date format', async () => {
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([{
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: "jeudi dernier",
-        }]);
-        jest.spyOn(clockGateway, 'isValidDate').mockRestore();
-
-        const result = await useCase.execute(mockParams);
-
-        expect(result).toContainEqual(expect.objectContaining({
-          code: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.code],
-          libelle: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.libelle],
-          zone: regionAcademiqueRecord[REGION_ACADEMIQUE_COLUMN_NAMES.zone],
-          dateDerniereModificationSI: expect.any(Date),
-          result: "error",
-          error: "Invalid format - dateDerniereModificationSI"
-        }));
-
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-
-      }); 
-
-
-      it('Existing row ET date_derniere_modification_si is less or equal than date_derniere_modification_si_db', async () => {
-    
-        let regionAcademiqueRecordLessThanMockDate = {
-          ...regionAcademiqueRecord,
-          [REGION_ACADEMIQUE_COLUMN_NAMES.date_derniere_modification_si]: mockDate,
-        };
-
-        jest.spyOn(fileGateway, 'parseXLS').mockResolvedValue([regionAcademiqueRecordLessThanMockDate]);        
-        jest.spyOn(regionAcademiqueGateway, 'findByCode').mockResolvedValue(mockRegionAcademiqueDb);
-
-        const result = await useCase.execute(mockParams);
-        expect(regionAcademiqueGateway.create).toHaveBeenCalledTimes(0);
-        expect(regionAcademiqueGateway.update).toHaveBeenCalledTimes(0);
-
-        expect(result).toEqual([{
-          code: "BRE",
-          dateDerniereModificationSI: new Date("2024-07-31"),
-          libelle: "BRETAGNE", 
-          result: "success",
-          zone: "A"
-        }]);
-      });
-    });
-  });
 });

--- a/apiv2/src/admin/core/referentiel/routes/ReferentielRoutes.service.ts
+++ b/apiv2/src/admin/core/referentiel/routes/ReferentielRoutes.service.ts
@@ -55,7 +55,7 @@ export class ReferentielRoutesService {
         }
 
         // save file to s3
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const s3File = await this.fileGateway.uploadFile(`file/admin/referentiel/routes/${timestamp}_${fileName}`, {
             data: buffer,
             mimetype,

--- a/apiv2/src/admin/core/referentiel/routes/ReferentielRoutes.service.ts
+++ b/apiv2/src/admin/core/referentiel/routes/ReferentielRoutes.service.ts
@@ -6,6 +6,7 @@ import { TaskGateway } from "@task/core/Task.gateway";
 import { ReferentielTaskType, TaskName, TaskStatus } from "snu-lib";
 import { TaskModel } from "@task/core/Task.model";
 import { ReferentielImportTaskAuthor } from "./ReferentielImportTask.model";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const REQUIRED_COLUMN_NAMES = [
     "Session formule",
@@ -24,6 +25,7 @@ export class ReferentielRoutesService {
     constructor(
         @Inject(TaskGateway) private readonly taskGateway: TaskGateway,
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
     ) {}
 
     async import({
@@ -53,7 +55,7 @@ export class ReferentielRoutesService {
         }
 
         // save file to s3
-        const timestamp = `${new Date().toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const s3File = await this.fileGateway.uploadFile(`file/admin/referentiel/routes/${timestamp}_${fileName}`, {
             data: buffer,
             mimetype,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.spec.ts
@@ -173,7 +173,7 @@ describe("SimulationAffectationCLE", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.spec.ts
@@ -28,6 +28,7 @@ import { PlanDeTransportGateway } from "../PlanDeTransport/PlanDeTransport.gatew
 import { ClasseGateway } from "../../cle/classe/Classe.gateway";
 import { EtablissementGateway } from "../../cle/etablissement/Etablissement.gateway";
 import { ReferentGateway } from "@admin/core/iam/Referent.gateway";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const sessionName = "2025 CLE 03 Fevrier";
 
@@ -167,6 +168,13 @@ describe("SimulationAffectationCLE", () => {
                 {
                     provide: PlanDeTransportGateway,
                     useValue: {},
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                    },
                 },
             ],
         }).compile();

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.ts
@@ -12,6 +12,7 @@ import { SimulationAffectationCLETaskParameters } from "./SimulationAffectationC
 import { LigneDeBusGateway } from "../ligneDeBus/LigneDeBus.gateway";
 import { PointDeRassemblementModel } from "../pointDeRassemblement/PointDeRassemblement.model";
 import { PointDeRassemblementGateway } from "../pointDeRassemblement/PointDeRassemblement.gateway";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export type SimulationAffectationCLEResult = {
     rapportData: RapportData;
@@ -35,6 +36,7 @@ export class SimulationAffectationCLE implements UseCase<SimulationAffectationCL
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
         @Inject(LigneDeBusGateway) private readonly ligneDeBusGateway: LigneDeBusGateway,
         @Inject(PointDeRassemblementGateway) private readonly pointDeRassemblementGateway: PointDeRassemblementGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly logger: Logger,
     ) {}
     async execute({
@@ -163,7 +165,7 @@ export class SimulationAffectationCLE implements UseCase<SimulationAffectationCL
 
         const fileBuffer = await this.simulationAffectationCLEService.generateRapportExcel(rapportData, "CLE");
 
-        const timestamp = `${new Date().toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const fileName = `simulation-affectation-cle/affectation_simulation_cle_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLE.ts
@@ -165,7 +165,7 @@ export class SimulationAffectationCLE implements UseCase<SimulationAffectationCL
 
         const fileBuffer = await this.simulationAffectationCLEService.generateRapportExcel(rapportData, "CLE");
 
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const fileName = `simulation-affectation-cle/affectation_simulation_cle_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.spec.ts
@@ -27,6 +27,7 @@ import { ClasseGateway } from "../../cle/classe/Classe.gateway";
 import { EtablissementGateway } from "../../cle/etablissement/Etablissement.gateway";
 import { ReferentGateway } from "@admin/core/iam/Referent.gateway";
 import { SimulationAffectationCLEDromCom } from "./SimulationAffectationCLEDromCom";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const sessionName = "2025 CLE 03 Fevrier";
 
@@ -159,6 +160,13 @@ describe("SimulationAffectationCLEDromCom", () => {
                 {
                     provide: PlanDeTransportGateway,
                     useValue: {},
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                    },
                 },
             ],
         }).compile();

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.spec.ts
@@ -165,7 +165,7 @@ describe("SimulationAffectationCLEDromCom", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.ts
@@ -9,6 +9,7 @@ import { RapportData, SimulationAffectationCLEService, SimulationResultats } fro
 
 import { FileGateway } from "@shared/core/File.gateway";
 import { SimulationAffectationCLEDromComTaskParameters } from "./SimulationAffectationCLEDromComTask.model";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export type SimulationAffectationCLEDromComResult = {
     rapportData: RapportData;
@@ -30,6 +31,7 @@ export class SimulationAffectationCLEDromCom implements UseCase<SimulationAffect
         @Inject(SimulationAffectationCLEService)
         private readonly simulationAffectationCLEService: SimulationAffectationCLEService,
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly logger: Logger,
     ) {}
     async execute({
@@ -112,7 +114,7 @@ export class SimulationAffectationCLEDromCom implements UseCase<SimulationAffect
 
         const fileBuffer = await this.simulationAffectationCLEService.generateRapportExcel(rapportData, "CLE_DROMCOM");
 
-        const timestamp = `${new Date().toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const fileName = `simulation-affectation-cle-dromcom/affectation_simulation_cle-dromcom_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/simulation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationCLEDromCom.ts
@@ -114,7 +114,7 @@ export class SimulationAffectationCLEDromCom implements UseCase<SimulationAffect
 
         const fileBuffer = await this.simulationAffectationCLEService.generateRapportExcel(rapportData, "CLE_DROMCOM");
 
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const fileName = `simulation-affectation-cle-dromcom/affectation_simulation_cle-dromcom_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/simulation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
@@ -26,6 +26,7 @@ import * as mockSejours from "./__tests__/sejours.json";
 import * as mockCentres from "./__tests__/centres.json";
 import { AffectationService } from "./Affectation.service";
 import { PlanDeTransportGateway } from "../PlanDeTransport/PlanDeTransport.gateway";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const cohortName = "Avril 2024 - C";
 
@@ -108,6 +109,13 @@ describe("SimulationAffectationHTS", () => {
                     useValue: {
                         findById: jest.fn().mockResolvedValue({ id: "pdt1" }),
                         update: jest.fn(),
+                    },
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.spec.ts
@@ -115,7 +115,7 @@ describe("SimulationAffectationHTS", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
@@ -231,7 +231,7 @@ export class SimulationAffectationHTS implements UseCase<SimulationAffectationHT
 
         const fileBuffer = await this.simulationAffectationHTSService.generateRapportExcel(rapportData, "HTS");
 
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const fileName = `simulation-affectation-hts/affectation_simulation_hts_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTS.ts
@@ -19,6 +19,7 @@ import { CentreGateway } from "../centre/Centre.gateway";
 import { FileGateway } from "@shared/core/File.gateway";
 import { SimulationAffectationHTSTaskParameters } from "./SimulationAffectationHTSTask.model";
 import { AffectationService } from "./Affectation.service";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 // TODO: déplacer dans un paramétrage dynamique
 const NB_MAX_ITERATION = 300;
@@ -46,6 +47,7 @@ export class SimulationAffectationHTS implements UseCase<SimulationAffectationHT
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
         @Inject(JeuneGateway) private readonly jeuneGateway: JeuneGateway,
         @Inject(CentreGateway) private readonly centresGateway: CentreGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly logger: Logger,
     ) {}
     async execute({
@@ -229,7 +231,7 @@ export class SimulationAffectationHTS implements UseCase<SimulationAffectationHT
 
         const fileBuffer = await this.simulationAffectationHTSService.generateRapportExcel(rapportData, "HTS");
 
-        const timestamp = `${new Date().toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const fileName = `simulation-affectation-hts/affectation_simulation_hts_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.spec.ts
@@ -111,7 +111,7 @@ describe("SimulationAffectationHTSDromCom", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.spec.ts
@@ -25,6 +25,7 @@ import { SimulationAffectationHTSService } from "./SimulationAffectationHTS.serv
 import * as mockJeunes from "./__tests__/youngs.json";
 import * as mockSejours from "./__tests__/sejours.json";
 import * as mockCentres from "./__tests__/centres.json";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const sessionNom = "2025 HTS 02 - Mai La Réunion";
 
@@ -105,6 +106,13 @@ describe("SimulationAffectationHTSDromCom", () => {
                 {
                     provide: PlanDeTransportGateway,
                     useValue: {},
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                    },
                 },
             ],
         }).compile();

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.ts
@@ -156,7 +156,7 @@ export class SimulationAffectationHTSDromCom implements UseCase<SimulationAffect
 
         const fileBuffer = await this.simulationAffectationHTSService.generateRapportExcel(rapportData, "HTS_DROMCOM");
 
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const fileName = `simulation-affectation-hts-dromcom/affectation_simulation_hts-dromcom_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/simulation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/SimulationAffectationHTSDromCom.ts
@@ -18,6 +18,7 @@ import { AffectationService } from "./Affectation.service";
 import { JeuneGateway } from "../../jeune/Jeune.gateway";
 import { CentreGateway } from "../centre/Centre.gateway";
 import { SejourModel } from "../sejour/Sejour.model";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export type SimulationAffectationHTSDromComResult = {
     rapportData: RapportData;
@@ -48,6 +49,7 @@ export class SimulationAffectationHTSDromCom implements UseCase<SimulationAffect
         @Inject(CentreGateway) private readonly centresGateway: CentreGateway,
         @Inject(JeuneGateway) private readonly jeuneGateway: JeuneGateway,
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly logger: Logger,
     ) {}
     async execute({
@@ -154,7 +156,7 @@ export class SimulationAffectationHTSDromCom implements UseCase<SimulationAffect
 
         const fileBuffer = await this.simulationAffectationHTSService.generateRapportExcel(rapportData, "HTS_DROMCOM");
 
-        const timestamp = `${new Date().toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const fileName = `simulation-affectation-hts-dromcom/affectation_simulation_hts-dromcom_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/simulation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLE.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLE.spec.ts
@@ -24,6 +24,7 @@ import { AffectationService } from "./Affectation.service";
 import { PlanDeTransportGateway } from "../PlanDeTransport/PlanDeTransport.gateway";
 import { YOUNG_STATUS } from "snu-lib";
 import { ValiderAffectationCLEService } from "./ValiderAffectationCLE.service";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const sessionNom = "2025 CLE 03 Fevrier";
 
@@ -148,6 +149,13 @@ describe("ValiderAffectationCLE", () => {
                                 mockLignesBus.map((ligne) => ({ id: ligne.id, capaciteJeunes: ligne.capaciteJeunes })),
                             ),
                         bulkUpdate: jest.fn().mockResolvedValue(1),
+                    },
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLE.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLE.spec.ts
@@ -155,7 +155,7 @@ describe("ValiderAffectationCLE", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLE.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLE.ts
@@ -215,7 +215,7 @@ export class ValiderAffectationCLE implements UseCase<ValiderAffectationCLEResul
         const fileBuffer = await this.fileGateway.generateExcel({ Affectations: rapportData });
 
         // upload du rapport du s3
-        const timestamp = this.clockGateway.formatSafeIsoDate(dateAffectation);
+        const timestamp = this.clockGateway.formatSafeDateTime(dateAffectation);
         const fileName = `affectation-cle/affectation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.spec.ts
@@ -144,7 +144,7 @@ describe("ValiderAffectationCLEDromcom", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.spec.ts
@@ -25,6 +25,7 @@ import { PlanDeTransportGateway } from "../PlanDeTransport/PlanDeTransport.gatew
 import { YOUNG_STATUS } from "snu-lib";
 import { ValiderAffectationCLEDromCom } from "./ValiderAffectationCLEDromCom";
 import { ValiderAffectationCLEService } from "./ValiderAffectationCLE.service";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const sessionNom = "2025 CLE 03 Fevrier";
 
@@ -137,6 +138,13 @@ describe("ValiderAffectationCLEDromcom", () => {
                         findById: jest.fn().mockResolvedValue({ id: "pdt1" }),
                         findByIds: jest.fn().mockResolvedValue(mockLignesBus.map((ligne) => ({ id: ligne.id }))),
                         bulkUpdate: jest.fn().mockResolvedValue(1),
+                    },
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.ts
@@ -177,7 +177,7 @@ export class ValiderAffectationCLEDromCom implements UseCase<ValiderAffectationC
         const fileBuffer = await this.fileGateway.generateExcel({ Affectations: rapportData });
 
         // upload du rapport du s3
-        const timestamp = this.clockGateway.formatSafeIsoDate(dateAffectation);
+        const timestamp = this.clockGateway.formatSafeDateTime(dateAffectation);
         const fileName = `affectation-cle-dromcom/affectation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/simulation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationCLEDromCom.ts
@@ -11,14 +11,13 @@ import { TaskGateway } from "@task/core/Task.gateway";
 
 import { JeuneGateway } from "../../jeune/Jeune.gateway";
 
-import { SejourGateway } from "../sejour/Sejour.gateway";
-
 import { RAPPORT_SHEETS, RapportData } from "./SimulationAffectationCLE.service";
 import { JeuneModel } from "../../jeune/Jeune.model";
 import { AffectationService } from "./Affectation.service";
 import { ValiderAffectationCLEDromComTaskParameters } from "./ValiderAffectationCLEDromComTask.model";
 import { ValiderAffectationCLEService } from "./ValiderAffectationCLE.service";
 import { SimulationAffectationCLEDromComTaskModel } from "./SimulationAffectationCLEDromComTask.model";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export type ValiderAffectationRapportData = Array<
     Pick<
@@ -79,6 +78,7 @@ export class ValiderAffectationCLEDromCom implements UseCase<ValiderAffectationC
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
         @Inject(JeuneGateway) private readonly jeuneGateway: JeuneGateway,
         @Inject(TaskGateway) private readonly taskGateway: TaskGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly cls: ClsService,
         private readonly logger: Logger,
     ) {}
@@ -177,7 +177,7 @@ export class ValiderAffectationCLEDromCom implements UseCase<ValiderAffectationC
         const fileBuffer = await this.fileGateway.generateExcel({ Affectations: rapportData });
 
         // upload du rapport du s3
-        const timestamp = `${dateAffectation.toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(dateAffectation);
         const fileName = `affectation-cle-dromcom/affectation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/simulation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.spec.ts
@@ -24,6 +24,7 @@ import { AffectationService } from "./Affectation.service";
 import { PlanDeTransportGateway } from "../PlanDeTransport/PlanDeTransport.gateway";
 import { ValiderAffectationHTSService } from "./ValiderAffectationHTS.service";
 import { YOUNG_STATUS } from "snu-lib";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const sessionNom = "Avril 2024 - C";
 
@@ -144,6 +145,13 @@ describe("ValiderAffectationHTS", () => {
                             .fn()
                             .mockResolvedValue(mockLignesBus.map((ligne) => ({ id: ligne.id, capaciteJeunes: 100 }))),
                         bulkUpdate: jest.fn().mockResolvedValue(1),
+                    },
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.spec.ts
@@ -151,7 +151,7 @@ describe("ValiderAffectationHTS", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.ts
@@ -10,12 +10,11 @@ import { FileGateway } from "@shared/core/File.gateway";
 
 import { JeuneGateway } from "../../jeune/Jeune.gateway";
 
-import { SejourGateway } from "../sejour/Sejour.gateway";
-
 import { JeuneModel } from "../../jeune/Jeune.model";
 import { AffectationService } from "./Affectation.service";
 import { ValiderAffectationHTSTaskParameters } from "./ValiderAffectationHTSTask.model";
 import { ValiderAffectationHTSService } from "./ValiderAffectationHTS.service";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export type ValiderAffectationRapportData = Array<
     Pick<
@@ -77,7 +76,7 @@ export class ValiderAffectationHTS implements UseCase<ValiderAffectationHTSResul
         private readonly validerAffectationHTSService: ValiderAffectationHTSService,
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
         @Inject(JeuneGateway) private readonly jeuneGateway: JeuneGateway,
-        @Inject(SejourGateway) private readonly sejoursGateway: SejourGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly cls: ClsService,
         private readonly logger: Logger,
     ) {}
@@ -204,7 +203,7 @@ export class ValiderAffectationHTS implements UseCase<ValiderAffectationHTSResul
         const fileBuffer = await this.fileGateway.generateExcel({ Affectations: rapportData });
 
         // upload du rapport du s3
-        const timestamp = `${dateAffectation.toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(dateAffectation);
         const fileName = `affectation-hts/affectation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTS.ts
@@ -203,7 +203,7 @@ export class ValiderAffectationHTS implements UseCase<ValiderAffectationHTSResul
         const fileBuffer = await this.fileGateway.generateExcel({ Affectations: rapportData });
 
         // upload du rapport du s3
-        const timestamp = this.clockGateway.formatSafeIsoDate(dateAffectation);
+        const timestamp = this.clockGateway.formatSafeDateTime(dateAffectation);
         const fileName = `affectation-hts/affectation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.spec.ts
@@ -23,6 +23,7 @@ import { YOUNG_STATUS } from "snu-lib";
 import { PointDeRassemblementGateway } from "../pointDeRassemblement/PointDeRassemblement.gateway";
 import { PlanDeTransportGateway } from "../PlanDeTransport/PlanDeTransport.gateway";
 import { LigneDeBusGateway } from "../ligneDeBus/LigneDeBus.gateway";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 const sessionNom = "2025 HTS 02 - Mai La Réunion";
 
@@ -124,6 +125,13 @@ describe("ValiderAffectationHTSDromCom", () => {
                 {
                     provide: LigneDeBusGateway,
                     useValue: {},
+                },
+                {
+                    provide: ClockGateway,
+                    useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                    },
                 },
             ],
         }).compile();

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.spec.ts
@@ -130,7 +130,7 @@ describe("ValiderAffectationHTSDromCom", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                     },
                 },
             ],

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.ts
@@ -160,7 +160,7 @@ export class ValiderAffectationHTSDromCom implements UseCase<ValiderAffectationH
         const fileBuffer = await this.fileGateway.generateExcel({ Affectations: rapportData });
 
         // upload du rapport du s3
-        const timestamp = this.clockGateway.formatSafeIsoDate(dateAffectation);
+        const timestamp = this.clockGateway.formatSafeDateTime(dateAffectation);
         const fileName = `affectation-hts-dromcom/affectation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.ts
+++ b/apiv2/src/admin/core/sejours/phase1/affectation/ValiderAffectationHTSDromCom.ts
@@ -17,6 +17,7 @@ import { AffectationService } from "./Affectation.service";
 
 import { ValiderAffectationHTSDromComTaskParameters } from "./ValiderAffectationHTSDromComTask.model";
 import { ValiderAffectationHTSService } from "./ValiderAffectationHTS.service";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export type ValiderAffectationRapportData = Array<
     Pick<
@@ -76,6 +77,7 @@ export class ValiderAffectationHTSDromCom implements UseCase<ValiderAffectationH
         private readonly validerAffectationHTSService: ValiderAffectationHTSService,
         @Inject(JeuneGateway) private readonly jeuneGateway: JeuneGateway,
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly cls: ClsService,
         private readonly logger: Logger,
     ) {}
@@ -158,7 +160,7 @@ export class ValiderAffectationHTSDromCom implements UseCase<ValiderAffectationH
         const fileBuffer = await this.fileGateway.generateExcel({ Affectations: rapportData });
 
         // upload du rapport du s3
-        const timestamp = `${dateAffectation.toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(dateAffectation);
         const fileName = `affectation-hts-dromcom/affectation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/affectation/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.spec.ts
@@ -63,6 +63,7 @@ describe("SimulationBasculeJeunes", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn().mockReturnValue(new Date()),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                         isAfter,
                         isWithinInterval,
                     },

--- a/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.spec.ts
@@ -63,7 +63,7 @@ describe("SimulationBasculeJeunes", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn().mockReturnValue(new Date()),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                         isAfter,
                         isWithinInterval,
                     },

--- a/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.ts
@@ -177,7 +177,7 @@ export class SimulationBasculeJeunes implements UseCase<SimulationBasculeJeunesR
             [RAPPORT_SHEETS.AVENIR]: rapportData.jeunesAvenir,
         });
 
-        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
+        const timestamp = this.clockGateway.formatSafeDateTime(this.clockGateway.now({ timeZone: "Europe/Paris" }));
         const fileName = `simulation-${type}/${type}_simulation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/inscription/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/SimulationBasculeJeunes.ts
@@ -177,7 +177,7 @@ export class SimulationBasculeJeunes implements UseCase<SimulationBasculeJeunesR
             [RAPPORT_SHEETS.AVENIR]: rapportData.jeunesAvenir,
         });
 
-        const timestamp = `${new Date().toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(this.clockGateway.now());
         const fileName = `simulation-${type}/${type}_simulation_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/inscription/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.spec.ts
@@ -91,6 +91,8 @@ describe("ValiderBasculeJeunesNonValides", () => {
                 {
                     provide: ClockGateway,
                     useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                         formatShort: jest.fn().mockReturnValue("DD/MM/YYYY"),
                     },
                 },

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.spec.ts
@@ -92,7 +92,7 @@ describe("ValiderBasculeJeunesNonValides", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                         formatShort: jest.fn().mockReturnValue("DD/MM/YYYY"),
                     },
                 },

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.ts
@@ -55,7 +55,7 @@ export class ValiderBasculeJeunesNonValides implements UseCase<ValiderBasculeJeu
         const fileBuffer = await this.fileGateway.generateExcel({ Volontaires: rapportData });
 
         // upload du rapport du s3
-        const timestamp = this.clockGateway.formatSafeIsoDate(dateValidation);
+        const timestamp = this.clockGateway.formatSafeDateTime(dateValidation);
         const fileName = `valider-bascule-jeunes-non-valides/bascule-jeunes-non-valides_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/inscription/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesNonValides.ts
@@ -9,12 +9,14 @@ import { ValiderBasculeJeunesNonValidesTaskParameters } from "./ValiderBasculeJe
 
 import { SessionGateway } from "../session/Session.gateway";
 import { ValiderBasculeJeunesResult, ValiderBasculeJeunesService } from "./ValiderBasculeJeunes.service";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export class ValiderBasculeJeunesNonValides implements UseCase<ValiderBasculeJeunesResult> {
     constructor(
         private readonly validerBasculeJeunesService: ValiderBasculeJeunesService,
         @Inject(SessionGateway) private readonly sessionGateway: SessionGateway,
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly logger: Logger,
     ) {}
 
@@ -53,7 +55,7 @@ export class ValiderBasculeJeunesNonValides implements UseCase<ValiderBasculeJeu
         const fileBuffer = await this.fileGateway.generateExcel({ Volontaires: rapportData });
 
         // upload du rapport du s3
-        const timestamp = `${dateValidation.toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(dateValidation);
         const fileName = `valider-bascule-jeunes-non-valides/bascule-jeunes-non-valides_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/inscription/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.spec.ts
@@ -91,6 +91,8 @@ describe("ValiderBasculeJeunesValides", () => {
                 {
                     provide: ClockGateway,
                     useValue: {
+                        now: jest.fn(),
+                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                         formatShort: jest.fn().mockReturnValue("DD/MM/YYYY"),
                     },
                 },

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.spec.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.spec.ts
@@ -92,7 +92,7 @@ describe("ValiderBasculeJeunesValides", () => {
                     provide: ClockGateway,
                     useValue: {
                         now: jest.fn(),
-                        formatSafeIsoDate: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
+                        formatSafeDateTime: jest.fn().mockReturnValue("2023-01-01T00:00:00.000Z"),
                         formatShort: jest.fn().mockReturnValue("DD/MM/YYYY"),
                     },
                 },

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.ts
@@ -59,7 +59,7 @@ export class ValiderBasculeJeunesValides implements UseCase<ValiderBasculeJeunes
         const fileBuffer = await this.fileGateway.generateExcel({ Volontaires: rapportData });
 
         // upload du rapport du s3
-        const timestamp = this.clockGateway.formatSafeIsoDate(dateValidation);
+        const timestamp = this.clockGateway.formatSafeDateTime(dateValidation);
         const fileName = `valider-bascule-jeunes-valides/bascule-jeunes-valides_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/inscription/${sessionId}/${fileName}`,

--- a/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.ts
+++ b/apiv2/src/admin/core/sejours/phase1/inscription/ValiderBasculeJeunesValides.ts
@@ -9,12 +9,14 @@ import { ValiderBasculeJeunesValidesTaskParameters } from "./ValiderBasculeJeune
 import { SessionGateway } from "../session/Session.gateway";
 
 import { ValiderBasculeJeunesResult, ValiderBasculeJeunesService } from "./ValiderBasculeJeunes.service";
+import { ClockGateway } from "@shared/core/Clock.gateway";
 
 export class ValiderBasculeJeunesValides implements UseCase<ValiderBasculeJeunesResult> {
     constructor(
         private readonly validerBasculeJeunesService: ValiderBasculeJeunesService,
         @Inject(SessionGateway) private readonly sessionGateway: SessionGateway,
         @Inject(FileGateway) private readonly fileGateway: FileGateway,
+        @Inject(ClockGateway) private readonly clockGateway: ClockGateway,
         private readonly logger: Logger,
     ) {}
 
@@ -57,7 +59,7 @@ export class ValiderBasculeJeunesValides implements UseCase<ValiderBasculeJeunes
         const fileBuffer = await this.fileGateway.generateExcel({ Volontaires: rapportData });
 
         // upload du rapport du s3
-        const timestamp = `${dateValidation.toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+        const timestamp = this.clockGateway.formatSafeIsoDate(dateValidation);
         const fileName = `valider-bascule-jeunes-valides/bascule-jeunes-valides_${sessionId}_${timestamp}.xlsx`;
         const rapportFile = await this.fileGateway.uploadFile(
             `file/admin/sejours/phase1/inscription/${sessionId}/${fileName}`,

--- a/apiv2/src/shared/core/Clock.gateway.ts
+++ b/apiv2/src/shared/core/Clock.gateway.ts
@@ -1,9 +1,11 @@
 export interface ClockGateway {
     addDaysToNow(days: number): Date;
     now(options?: { timeZone: string }): Date;
-    formatSafeIsoDate(date: Date): string;
+    getZonedDate(date: Date, timeZone?: string);
     isValidDate(date: Date): boolean;
     formatShort(date: Date): string;
+    formatDateTime(date: Date): string;
+    formatSafeDateTime(date: Date): string;
     isAfter(dateA: Date, dateB: Date);
     isBefore(dateA: Date, dateB: Date);
     isWithinInterval(date: Date, params: { start: Date; end: Date });

--- a/apiv2/src/shared/core/Clock.gateway.ts
+++ b/apiv2/src/shared/core/Clock.gateway.ts
@@ -1,7 +1,7 @@
 export interface ClockGateway {
     addDaysToNow(days: number): Date;
-    now(): Date;
-    getNowSafeIsoDate(): string;
+    now(options?: { timeZone: string }): Date;
+    formatSafeIsoDate(date: Date): string;
     isValidDate(date: Date): boolean;
     formatShort(date: Date): string;
     isAfter(dateA: Date, dateB: Date);

--- a/apiv2/src/shared/infra/Clock.provider.spec.ts
+++ b/apiv2/src/shared/infra/Clock.provider.spec.ts
@@ -1,0 +1,39 @@
+// Clock.provider.test.ts
+import { ClockProvider } from "./Clock.provider";
+import { add } from "date-fns";
+
+describe("ClockProvider", () => {
+    let clockProvider: ClockProvider;
+
+    beforeEach(() => {
+        clockProvider = new ClockProvider();
+    });
+
+    describe("formatSafeDateTime", () => {
+        it("should format the date correctly", () => {
+            const date = new Date("2024-10-01T12:34:56.789Z");
+            const formattedDate = clockProvider.formatSafeDateTime(date);
+            expect(formattedDate).toBe("2024-10-01T14-34-56");
+        });
+    });
+
+    describe("addDaysToNow", () => {
+        it("should add the specified number of days to the current date", () => {
+            const daysToAdd = 5;
+            const now = new Date();
+            const expectedDate = add(now, { days: daysToAdd });
+            const resultDate = clockProvider.addDaysToNow(daysToAdd);
+            expect(resultDate).toEqual(expectedDate);
+        });
+    });
+
+    describe("getZonedDate", () => {
+        it("should return zoned date", () => {
+            let date = clockProvider.getZonedDate(new Date("2024-06-03T00:00:00.000+00:00"));
+            expect(clockProvider.formatDateTime(date)).toBe("2024-06-03T02:00:00");
+
+            date = clockProvider.getZonedDate(new Date("2024-05-26T00:00:00.000Z"), "America/Martinique");
+            expect(clockProvider.formatDateTime(date)).toBe("2024-05-25T20:00:00");
+        });
+    });
+});

--- a/apiv2/src/shared/infra/Clock.provider.spec.ts
+++ b/apiv2/src/shared/infra/Clock.provider.spec.ts
@@ -11,7 +11,7 @@ describe("ClockProvider", () => {
 
     describe("formatSafeDateTime", () => {
         it("should format the date correctly", () => {
-            const date = new Date("2024-10-01T12:34:56.789Z");
+            const date = clockProvider.getZonedDate(new Date("2024-10-01T12:34:56.789Z"));
             const formattedDate = clockProvider.formatSafeDateTime(date);
             expect(formattedDate).toBe("2024-10-01T14-34-56");
         });

--- a/apiv2/src/shared/infra/Clock.provider.ts
+++ b/apiv2/src/shared/infra/Clock.provider.ts
@@ -21,8 +21,8 @@ export class ClockProvider implements ClockGateway {
     addDaysToNow(days: number): Date {
         return add(new Date(), { days });
     }
-    now({ timeZone }: { timeZone?: string } = { timeZone: "Europe/Paris" }) {
-        return getZonedDate(new Date(), timeZone);
+    now(options = { timeZone: "Europe/Paris" }) {
+        return getZonedDate(new Date(), options.timeZone);
     }
     isValidDate(date: Date): boolean {
         return !isNaN(new Date(date).getTime());

--- a/apiv2/src/shared/infra/Clock.provider.ts
+++ b/apiv2/src/shared/infra/Clock.provider.ts
@@ -19,7 +19,7 @@ export class ClockProvider implements ClockGateway {
         if (options?.timeZone) {
             return this.getZonedDate(new Date(), options.timeZone);
         } else {
-            return new Date(); // UTC
+            return this.getZonedDate(new Date(), "UTC");
         }
     }
     getZonedDate(date: Date, timeZone: string = "Europe/Paris") {

--- a/apiv2/src/shared/infra/Clock.provider.ts
+++ b/apiv2/src/shared/infra/Clock.provider.ts
@@ -1,5 +1,3 @@
-import { Injectable } from "@nestjs/common";
-import { ClockGateway } from "@shared/core/Clock.gateway";
 import {
     add,
     addHours,
@@ -10,16 +8,21 @@ import {
     isWithinInterval as isWithinIntervalFns,
 } from "date-fns";
 
+import { getZonedDate } from "snu-lib";
+
+import { Injectable } from "@nestjs/common";
+import { ClockGateway } from "@shared/core/Clock.gateway";
+
 @Injectable()
 export class ClockProvider implements ClockGateway {
-    getNowSafeIsoDate(): string {
-        return `${new Date().toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+    formatSafeIsoDate(date: Date): string {
+        return `${date.toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
     }
     addDaysToNow(days: number): Date {
         return add(new Date(), { days });
     }
-    now() {
-        return new Date();
+    now({ timeZone }: { timeZone?: string } = { timeZone: "Europe/Paris" }) {
+        return getZonedDate(new Date(), timeZone);
     }
     isValidDate(date: Date): boolean {
         return !isNaN(new Date(date).getTime());

--- a/apiv2/src/shared/infra/Clock.provider.ts
+++ b/apiv2/src/shared/infra/Clock.provider.ts
@@ -15,20 +15,27 @@ import { ClockGateway } from "@shared/core/Clock.gateway";
 
 @Injectable()
 export class ClockProvider implements ClockGateway {
-    formatSafeIsoDate(date: Date): string {
-        return `${date.toISOString()?.replaceAll(":", "-")?.replace(".", "-")}`;
+    now(options?: { timeZone: string }) {
+        if (options?.timeZone) {
+            return this.getZonedDate(new Date(), options.timeZone);
+        } else {
+            return new Date(); // UTC
+        }
     }
-    addDaysToNow(days: number): Date {
-        return add(new Date(), { days });
-    }
-    now(options = { timeZone: "Europe/Paris" }) {
-        return getZonedDate(new Date(), options.timeZone);
+    getZonedDate(date: Date, timeZone: string = "Europe/Paris") {
+        return getZonedDate(date, timeZone);
     }
     isValidDate(date: Date): boolean {
         return !isNaN(new Date(date).getTime());
     }
     formatShort(date: Date): string {
         return format(date, "dd/MM/yyyy");
+    }
+    formatDateTime(date: Date): string {
+        return format(date, "yyyy-MM-dd'T'HH:mm:ss");
+    }
+    formatSafeDateTime(date: Date): string {
+        return `${this.formatDateTime(date)?.replaceAll(":", "-")?.replace(".", "-")}`;
     }
     isAfter(dateA: Date, dateB: Date) {
         return isAfterFns(dateA, dateB);
@@ -44,5 +51,8 @@ export class ClockProvider implements ClockGateway {
     }
     addHours(date: Date, hours: number): Date {
         return addHours(date, hours);
+    }
+    addDaysToNow(days: number): Date {
+        return add(new Date(), { days });
     }
 }

--- a/apiv2/test/admin/referentiel/ImportReferentielController.spec.ts
+++ b/apiv2/test/admin/referentiel/ImportReferentielController.spec.ts
@@ -36,7 +36,8 @@ describe("ImportReferentielController", () => {
         });
 
         const mockClockGateway = {
-            getNowSafeIsoDate: jest.fn(),
+            now: jest.fn(),
+            formatSafeIsoDate: jest.fn(),
         };
         const mockNotificationGateway = {
             sendEmail: jest.fn(),

--- a/apiv2/test/admin/referentiel/ImportReferentielController.spec.ts
+++ b/apiv2/test/admin/referentiel/ImportReferentielController.spec.ts
@@ -37,7 +37,7 @@ describe("ImportReferentielController", () => {
 
         const mockClockGateway = {
             now: jest.fn(),
-            formatSafeIsoDate: jest.fn(),
+            formatSafeDateTime: jest.fn(),
         };
         const mockNotificationGateway = {
             sendEmail: jest.fn(),


### PR DESCRIPTION
**Description**

Dans les différents rapports de fichiers généré les dates sont en UTC au lieu de UTC+1, cette PR a pour objectif de rendre les date zonée en Europe/Paris dans l'apiv2.

cf `Clock.gateway.ts` et `Clock.provider.ts`

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Corriger-les-dates-dans-les-nom-fichier-des-silulation-1b272a322d5080fcbb64cecd9625951d?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
