### PR TITLE
feat(admin): 126 - Parametrage dynamique inscription manuel HTS

### DIFF
--- a/admin/src/components/Toggle.jsx
+++ b/admin/src/components/Toggle.jsx
@@ -1,25 +1,27 @@
 import React from "react";
 import { Switch } from "@headlessui/react";
-
-function classNames(...classes) {
-  return classes.filter(Boolean).join(" ");
-}
+import cx from "classnames";
 
 export default function Toggle({ onChange, value, disabled = false }) {
   return (
     <Switch
       checked={value}
       onChange={(e) => !disabled && onChange(e)}
-      className={` group relative inline-flex h-5 w-10 flex-shrink-0 cursor-wait items-center justify-center rounded-full `}>
+      className={cx(`group relative inline-flex h-5 w-10 flex-shrink-0 cursor-wait items-center justify-center rounded-full`)}>
       <span
         aria-hidden="true"
-        className={classNames(value ? "bg-blue-600" : "bg-gray-200", "pointer-events-none absolute mx-auto h-4 w-9 rounded-full transition-colors duration-200 ease-in-out")}
+        className={cx("pointer-events-none absolute mx-auto h-4 w-9 rounded-full transition-colors duration-200 ease-in-out", {
+          "bg-blue-600": value && !disabled,
+          "bg-blue-300": disabled,
+          "bg-gray-200": !value,
+        })}
       />
       <span
         aria-hidden="true"
-        className={classNames(
-          value ? "translate-x-5" : "translate-x-0",
+        className={cx(
           "pointer-events-none absolute left-0 inline-block h-5 w-5 transform rounded-full border border-gray-200 bg-white ring-0 transition-transform duration-200 ease-in-out",
+          { "translate-x-5": value },
+          { "translate-x-0": !value },
         )}
       />
     </Switch>

--- a/admin/src/scenes/phase0/components/ChangeCohortPen.tsx
+++ b/admin/src/scenes/phase0/components/ChangeCohortPen.tsx
@@ -27,14 +27,7 @@ export function ChangeCohortPen({ young, onChange }) {
     if (!young) return undefined;
 
     (async function getSessions() {
-      //When inscription is open for youngs, we don't want to display the cohort to come
-      // const isEligibleForCohortToCome = calculateAge(young.birthdateAt, new Date("2023-09-30")) < 18;
-      // const cohortToCome = { name: "à venir", isEligible: isEligibleForCohortToCome };
-      // if (user.role !== ROLES.ADMIN) {
-      //   setOptions(isEligibleForCohortToCome && young.cohort !== "à venir" ? [cohortToCome] : []);
-      //   return;
-      // }
-      const cohortsAvailable = await CohortService.getEligibilityForYoung({ id: young._id });
+      const cohortsAvailable = await CohortService.getEligibilityForYoung({ id: young._id, query: { type: "BASCULE" } });
       if (Array.isArray(cohortsAvailable)) {
         const cohorts: CohortAvailable[] = cohortsAvailable
           .filter((c) => c.name !== young.cohort)

--- a/admin/src/scenes/phase0/components/SchoolEditor.tsx
+++ b/admin/src/scenes/phase0/components/SchoolEditor.tsx
@@ -31,7 +31,6 @@ export default function SchoolEditor({ young, onChange, className, showBackgroun
 
   useEffect(() => {
     if (young) {
-      console.log("young.schoolCity: ", young.schoolCity);
       setSchoolInFrance(!!young.schoolCountry && young.schoolCountry.toUpperCase() === "FRANCE");
     } else {
       setSchoolInFrance(true);

--- a/admin/src/scenes/settings/general/GeneralTab.tsx
+++ b/admin/src/scenes/settings/general/GeneralTab.tsx
@@ -325,8 +325,7 @@ Cette fonctionnalité est à utiliser uniquement pour les séjours CLE spécifiq
                 <SimpleToggle
                   label="Dates spécifiques"
                   disabled={isLoading || readOnly}
-                  // @ts-ignore
-                  value={showSpecificDatesReInscription}
+                  value={!!showSpecificDatesReInscription}
                   onChange={(v) => {
                     if (v == false) onCohortChange({ ...cohort, reInscriptionEndDate: null, reInscriptionStartDate: null });
                     // @ts-ignore

--- a/admin/src/scenes/settings/general/phase0/ManualInscriptionSettings.tsx
+++ b/admin/src/scenes/settings/general/phase0/ManualInscriptionSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { MdInfoOutline } from "react-icons/md";
 
-import { CohortDto } from "snu-lib";
+import { COHORT_TYPE, CohortDto } from "snu-lib";
 import { Tooltip } from "@snu/ds/admin";
 
 import { getManualInscriptionTogglesByCohortType } from "./getManualInscriptionTogglesByCohortType";
@@ -43,7 +43,9 @@ export const ManualInscriptionSettings: React.FC<ManualInscriptionSettingsProps>
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
-        <p className="text-gray-900  text-xs font-medium">Inscriptions manuelles</p>
+        <p className="text-gray-900  text-xs font-medium">
+          {cohort.type === COHORT_TYPE.CLE ? "Inscriptions manuelles" : "Inscriptions manuelles après la fermeture des inscriptions des volontaires"}
+        </p>
         <Tooltip title="Ouverture et fermeture pour les utilisateurs de la possibilité d’inscrire manuellement des jeunes">
           <MdInfoOutline size={20} className="text-gray-400" />
         </Tooltip>

--- a/admin/src/scenes/settings/general/phase0/ManualInscriptionSettings.tsx
+++ b/admin/src/scenes/settings/general/phase0/ManualInscriptionSettings.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo } from "react";
-import { CohortDto } from "snu-lib";
-import { getManualInscriptionTogglesByCohortType } from "./getManualInscriptionTogglesByCohortType";
-import ReactTooltip from "react-tooltip";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { MdInfoOutline } from "react-icons/md";
+
+import { CohortDto } from "snu-lib";
+import { Tooltip } from "@snu/ds/admin";
+
+import { getManualInscriptionTogglesByCohortType } from "./getManualInscriptionTogglesByCohortType";
 
 interface ManualInscriptionSettingsProps {
   cohort: CohortDto;
@@ -43,12 +44,9 @@ export const ManualInscriptionSettings: React.FC<ManualInscriptionSettingsProps>
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
         <p className="text-gray-900  text-xs font-medium">Inscriptions manuelles</p>
-        <MdInfoOutline data-tip data-for="inscriptions" className="text-gray-400 h-5 w-5 cursor-pointer" />
-        <ReactTooltip id="inscriptions" type="light" place="top" effect="solid" className="custom-tooltip-radius !opacity-100 !shadow-md rounded-[6px]">
-          <p className=" text-left text-gray-600 text-xs w-[275px] !px-2 !py-1.5 list-outside">
-            Ouverture et fermeture pour les utilisateurs de la possibilité d’inscrire manuellement des jeunes.
-          </p>
-        </ReactTooltip>
+        <Tooltip title="Ouverture et fermeture pour les utilisateurs de la possibilité d’inscrire manuellement des jeunes">
+          <MdInfoOutline size={20} className="text-gray-400" />
+        </Tooltip>
       </div>
       {renderedManualInscriptionTogglesByCohortType}
     </div>

--- a/admin/src/scenes/settings/general/phase0/getManualInscriptionTogglesByCohortType.tsx
+++ b/admin/src/scenes/settings/general/phase0/getManualInscriptionTogglesByCohortType.tsx
@@ -6,6 +6,7 @@ type ToggleItem = {
   label: string;
   value: boolean;
   field: keyof CohortDto;
+  disabled?: boolean;
 };
 
 interface ManualInscriptionCLETogglesProps {
@@ -48,11 +49,44 @@ const renderManualInscriptionCLEToggles = ({ cohort, handleToggleChange, isLoadi
   );
 };
 
+const renderManualInscriptionHTSToggles = ({ cohort, handleToggleChange, isLoading, readOnly }: ManualInscriptionCLETogglesProps) => {
+  const toggles: ToggleItem[] = [
+    {
+      label: "Référents régionaux",
+      value: cohort.inscriptionOpenForReferentRegion ?? false,
+      field: "inscriptionOpenForReferentRegion" as keyof CohortDto,
+      disabled: cohort.isInscriptionOpen,
+    },
+    {
+      label: "Référents départementaux",
+      value: cohort.inscriptionOpenForReferentDepartment ?? false,
+      field: "inscriptionOpenForReferentDepartment" as keyof CohortDto,
+      disabled: cohort.isInscriptionOpen,
+    },
+  ];
+
+  return (
+    <>
+      {toggles.map((toggle) => (
+        <SimpleToggle
+          key={toggle.field}
+          label={toggle.label}
+          value={toggle.value}
+          disabled={isLoading || readOnly || toggle.disabled}
+          onChange={() => handleToggleChange(toggle.field)}
+        />
+      ))}
+    </>
+  );
+};
+
 export const getManualInscriptionTogglesByCohortType = ({ cohort, handleToggleChange, isLoading, readOnly }: ManualInscriptionCLETogglesProps) => {
   const cohortType = cohort.type as (typeof COHORT_TYPE)[keyof typeof COHORT_TYPE];
   switch (cohortType) {
     case COHORT_TYPE.CLE:
       return renderManualInscriptionCLEToggles({ cohort, handleToggleChange, isLoading, readOnly });
+    case COHORT_TYPE.VOLONTAIRE:
+      return renderManualInscriptionHTSToggles({ cohort, handleToggleChange, isLoading, readOnly });
     default:
       return null;
   }

--- a/admin/src/scenes/volontaires/create.tsx
+++ b/admin/src/scenes/volontaires/create.tsx
@@ -25,6 +25,7 @@ import {
   CohortType,
   EtablissementDto,
   ROLES,
+  CohortsRoutes,
 } from "snu-lib";
 import { youngSchooledSituationOptions, youngActiveSituationOptions, youngEmployedSituationOptions } from "../phase0/commons";
 import dayjs from "@/utils/dayjs.utils";
@@ -40,6 +41,7 @@ import FieldSituationsParticulieres from "../phase0/components/FieldSituationsPa
 import Check from "@/assets/icons/Check";
 import PhoneField from "../phase0/components/PhoneField";
 import ConfirmationModal from "@/components/ui/modals/ConfirmationModal";
+import { CohortService } from "@/services/cohortService";
 
 type FormErrors = {
   temporaryDate?: string;
@@ -152,16 +154,19 @@ type FormValues = {
   parent2ValidationDate?: string;
 };
 
+type CohortEligible = NonNullable<CohortsRoutes["PostEligibility"]["response"]["data"]>[0];
+
 export default function Create() {
   const history = useHistory();
   const location = useLocation();
+  const user = useSelector((state: AuthState) => state.Auth.user);
+
   const [selectedRepresentant, setSelectedRepresentant] = useState(1);
   const [loading, setLoading] = useState(false);
-  const [cohorts, setCohorts] = useState<CohortType[]>([]);
+  const [cohorts, setCohorts] = useState<CohortEligible[]>([]);
   const [egibilityError, setEgibilityError] = useState("");
   const [isComplememtaryListModalOpen, setComplememtaryListModalOpen] = useState(false);
   const classeId = new URLSearchParams(location.search).get("classeId");
-  const user = useSelector((state: AuthState) => state.Auth.user);
 
   const [errors, setErrors] = useState<FormErrors>({});
   const [values, setValues] = useState<FormValues>({
@@ -482,36 +487,26 @@ export default function Create() {
     if ((values.grade !== "" || values.schooled === "false") && (values.department !== "" || values.schoolDepartment !== "") && values.birthdateAt !== null) {
       (async () => {
         try {
-          let getAllSessions = "";
-          if (classeId && [ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role)) {
-            getAllSessions = "?getAllSessions=true";
-          }
-          let body = {};
+          const payload = {
+            grade: values.grade,
+            birthdateAt: values.birthdateAt!,
+            zip: values.zip,
+          } as NonNullable<CohortsRoutes["PostEligibility"]["payload"]>;
           if (values.schooled === "true") {
-            body = {
-              schoolDepartment: values.schoolDepartment,
-              department: values.department,
-              schoolRegion: values.schoolRegion,
-              birthdateAt: values.birthdateAt,
-              grade: values.grade,
-              zip: values.zip,
-            };
-          } else {
-            body = {
-              grade: values.grade,
-              birthdateAt: values.birthdateAt,
-              zip: values.zip,
-            };
+            payload.schoolDepartment = values.schoolDepartment;
+            payload.department = values.department;
+            payload.schoolRegion = values.schoolRegion;
           }
-          const res = await api.post(`/cohort-session/eligibility/2023${getAllSessions}`, body);
-          if (res.data.msg) return setEgibilityError(res.data.msg);
-          if (res.data.length === 0) {
+
+          const getAllSessions = !!classeId && [ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role);
+          const cohortsEligible = await CohortService.getEligibilityForYoung({ payload, query: { type: "INSCRIPTION_MANUELLE", getAllSessions } });
+          if (!cohortsEligible || cohortsEligible.length === 0) {
             setEgibilityError("Il n'y a malheureusement plus de séjour disponible.");
           } else {
             setEgibilityError("");
           }
 
-          setCohorts(res.data);
+          setCohorts(cohortsEligible!);
         } catch (e) {
           capture(e);
 
@@ -1231,7 +1226,7 @@ const PARENT_STATUS_NAME = {
 
 interface SectionConsentementsProps {
   young: FormValues;
-  cohort?: CohortType;
+  cohort?: CohortEligible;
   errors: FormErrors;
   setFieldValue: (field: string, value: string) => void;
 }

--- a/api/migrations/20250317085510-cohort-inscription-open-for-referent-dep-reg.js
+++ b/api/migrations/20250317085510-cohort-inscription-open-for-referent-dep-reg.js
@@ -1,0 +1,17 @@
+const { COHORT_TYPE } = require("snu-lib");
+const { CohortModel } = require("../src/models");
+
+module.exports = {
+  async up(db, client) {
+    await CohortModel.updateMany(
+      { name: new RegExp(`${new Date().getFullYear()}`), type: COHORT_TYPE.VOLONTAIRE },
+      { $set: { inscriptionOpenForReferentRegion: false, inscriptionOpenForReferentDepartment: false } },
+    );
+  },
+
+  async down(db, client) {
+    // TODO write the statements to rollback your migration (if possible)
+    // Example:
+    // await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+  },
+};

--- a/api/src/__tests__/young.test.ts
+++ b/api/src/__tests__/young.test.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 
 import request from "supertest";
 import jwt from "jsonwebtoken";
-import { ROLES, COHORTS, YOUNG_SOURCE, SENDINBLUE_TEMPLATES, ERRORS } from "snu-lib";
+import { ROLES, COHORTS, YOUNG_SOURCE, SENDINBLUE_TEMPLATES, ERRORS, COHORT_TYPE } from "snu-lib";
 import { sendTemplate } from "../brevo";
 import * as fileUtils from "../utils/file";
 import getAppHelper, { resetAppAuth } from "./helpers/app";
@@ -507,7 +507,7 @@ describe("Young", () => {
 
     it("should create a new young user and send an invitation email", async () => {
       const referent = await createReferentHelper(getNewReferentFixture({ role: ROLES.REFERENT_CLASSE }));
-      const cohort = await createCohortHelper(getNewCohortFixture({ inscriptionOpenForReferentClasse: true }));
+      const cohort = await createCohortHelper(getNewCohortFixture({ inscriptionOpenForReferentClasse: true, type: COHORT_TYPE.CLE }));
       const young = getNewYoungFixture({ cohortId: cohort._id.toString() });
 
       const passport = require("passport");

--- a/api/src/cohort/cohortValidator.ts
+++ b/api/src/cohort/cohortValidator.ts
@@ -104,6 +104,7 @@ const PostEligibilityRouteSchema = {
   }),
   query: Joi.object<CohortsRoutes["PostEligibility"]["query"]>({
     getAllSessions: Joi.boolean().default(false),
+    type: Joi.string().allow("INSCRIPTION_MANUELLE").allow("BASCULE").allow(null),
   }),
   body: Joi.object<CohortsRoutes["PostEligibility"]["payload"]>({
     schoolDepartment: Joi.string().allow("", null),

--- a/api/src/controllers/cohort-session.ts
+++ b/api/src/controllers/cohort-session.ts
@@ -29,6 +29,7 @@ router.post(
   async function (req: RouteRequest<CohortsRoutes["PostEligibility"]>, res: RouteResponse<CohortsRoutes["PostEligibility"]>) {
     try {
       let young: NonNullable<CohortsRoutes["PostEligibility"]["payload"]>;
+      let isManualInscription = false;
       const { id } = req.validatedParams;
       if (id) {
         const youngDocument = await YoungModel.findById(id).lean();
@@ -43,6 +44,7 @@ router.post(
           return res.status(400).send({ ok: false, code: ERRORS.INVALID_BODY });
         }
         young = body!;
+        isManualInscription = req.validatedQuery.type === "INSCRIPTION_MANUELLE";
       }
 
       let sessions: CohortsRoutes["PostEligibility"]["response"]["data"];
@@ -54,7 +56,7 @@ router.post(
       ) {
         sessions = await getAllSessions(young);
       } else {
-        sessions = await getFilteredSessions(young, Number(req.headers["x-user-timezone"]) || null);
+        sessions = await getFilteredSessions(young, Number(req.headers["x-user-timezone"]) || null, isManualInscription, req.user);
       }
 
       return res.json({ ok: true, data: sessions });

--- a/packages/ds/src/admin/ui/Tooltip.tsx
+++ b/packages/ds/src/admin/ui/Tooltip.tsx
@@ -31,7 +31,7 @@ export default function Tooltip({
   }, [forceRefresh, title]);
 
   return (
-    <div className={cx("flex items-center", className)}>
+    <div className={cx("inline-flex items-center", className)}>
       <button type="button" data-tip={title} data-for={tooltipId}>
         {children}
       </button>

--- a/packages/lib/src/dto/cohortDto.ts
+++ b/packages/lib/src/dto/cohortDto.ts
@@ -83,9 +83,13 @@ export type CohortDto = {
   inscriptionOpenForReferentDepartment?: boolean;
   inscriptionOpenForAdministrateurCle?: boolean;
   specificSnuIdCohort?: boolean;
+  //virtual
+  isInscriptionOpen?: boolean;
+  isInstructionOpen?: boolean;
+  isReInscriptionOpen?: boolean;
 };
 
-export type UpdateCohortDto = Omit<CohortDto, "name" | "type" | "snuId" | "eligibility">;
+export type UpdateCohortDto = Omit<CohortDto, "name" | "type" | "snuId" | "eligibility" | "isInscriptionOpen" | "isInstructionOpen" | "isReInscriptionOpen">;
 
 type ToFromDate = {
   from?: string | null;

--- a/packages/lib/src/mongoSchema/cohort.ts
+++ b/packages/lib/src/mongoSchema/cohort.ts
@@ -359,28 +359,28 @@ export const CohortSchema = {
 
   inscriptionOpenForReferentClasse: {
     type: Boolean,
-    default: true,
+    default: false,
     documentation: {
       description: "Ouverture ou fermeture de l'inscription manuelle pour les référents de classe",
     },
   },
   inscriptionOpenForReferentRegion: {
     type: Boolean,
-    default: true,
+    default: false,
     documentation: {
       description: "Ouverture ou fermeture de l'inscription manuelle pour les référents régionaux",
     },
   },
   inscriptionOpenForReferentDepartment: {
     type: Boolean,
-    default: true,
+    default: false,
     documentation: {
       description: "Ouverture ou fermeture de l'inscription manuelle pour les référents départementaux",
     },
   },
   inscriptionOpenForAdministrateurCle: {
     type: Boolean,
-    default: true,
+    default: false,
     documentation: {
       description: "Ouverture ou fermeture de l'inscription manuelle pour les administrateurs CLE",
     },

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -704,13 +704,13 @@ function canInviteYoung(actor: UserDto, cohort: CohortDto | null) {
     case ROLES.ADMIN:
       return true;
     case ROLES.REFERENT_DEPARTMENT:
-      return cohort.inscriptionOpenForReferentDepartment === true;
+      return cohort.isInscriptionOpen || cohort.inscriptionOpenForReferentDepartment === true;
     case ROLES.REFERENT_REGION:
-      return cohort.inscriptionOpenForReferentRegion === true;
+      return cohort.isInscriptionOpen || cohort.inscriptionOpenForReferentRegion === true;
     case ROLES.REFERENT_CLASSE:
-      return cohort.type === COHORT_TYPE.CLE && cohort.inscriptionOpenForReferentClasse === true;
+      return cohort.type === COHORT_TYPE.CLE && (cohort.isInscriptionOpen || cohort.inscriptionOpenForReferentClasse === true);
     case ROLES.ADMINISTRATEUR_CLE:
-      return cohort.type === COHORT_TYPE.CLE && cohort.inscriptionOpenForAdministrateurCle === true;
+      return cohort.type === COHORT_TYPE.CLE && (cohort.isInscriptionOpen || cohort.inscriptionOpenForAdministrateurCle === true);
     default:
       return false;
   }

--- a/packages/lib/src/roles.ts
+++ b/packages/lib/src/roles.ts
@@ -1,7 +1,7 @@
 import { CohortDto, ReferentDto, UserDto } from "./dto";
 import { region2department } from "./region-and-departments";
 import { isNowBetweenDates } from "./utils/date";
-import { LIMIT_DATE_ESTIMATED_SEATS, LIMIT_DATE_TOTAL_SEATS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, YOUNG_STATUS_PHASE3 } from "./constants/constants";
+import { COHORT_TYPE, LIMIT_DATE_ESTIMATED_SEATS, LIMIT_DATE_TOTAL_SEATS, YOUNG_STATUS_PHASE1, YOUNG_STATUS_PHASE2, YOUNG_STATUS_PHASE3 } from "./constants/constants";
 import { CohortType, PointDeRassemblementType, ReferentType, SessionPhase1Type, YoungType } from "./mongoSchema";
 import { isBefore } from "date-fns";
 
@@ -708,9 +708,9 @@ function canInviteYoung(actor: UserDto, cohort: CohortDto | null) {
     case ROLES.REFERENT_REGION:
       return cohort.inscriptionOpenForReferentRegion === true;
     case ROLES.REFERENT_CLASSE:
-      return cohort.inscriptionOpenForReferentClasse === true;
+      return cohort.type === COHORT_TYPE.CLE && cohort.inscriptionOpenForReferentClasse === true;
     case ROLES.ADMINISTRATEUR_CLE:
-      return cohort.inscriptionOpenForAdministrateurCle === true;
+      return cohort.type === COHORT_TYPE.CLE && cohort.inscriptionOpenForAdministrateurCle === true;
     default:
       return false;
   }

--- a/packages/lib/src/routes/cohort/postEligibility.ts
+++ b/packages/lib/src/routes/cohort/postEligibility.ts
@@ -16,11 +16,12 @@ export interface PostEligibilityRoute extends BasicRoute {
     zip?: string;
   };
   query?: {
+    type?: "INSCRIPTION_MANUELLE" | "BASCULE";
     getAllSessions?: boolean;
   };
   response: RouteResponseBody<
     Array<
-      Pick<CohortType, "_id" | "name" | "type" | "event" | "dateStart" | "dateEnd"> & {
+      CohortType & {
         numberOfCandidates?: number;
         numberOfValidated?: number;
         goal?: number;


### PR DESCRIPTION
**Description**

<img width="763" alt="image" src="https://github.com/user-attachments/assets/ad48a39b-d651-4b8a-a41d-6f6bb8e2155e" />

**Todo**

- [x] Ajout des toggles dans les paramétrages dynamique
- [x] Prendre en compte les paramètres dans le front pour les inscriptions
- [x] ajouter un contrôle côté backend

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Ouverture-des-inscriptions-manuelles-HTS-apr-s-la-fermeture-des-inscriptions-des-volontaires-17b72a322d5080d4a8e1d87394d3dc0e?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
