### PR TITLE
chore(misc): Add nginx client_body_temp_path directive

### DIFF
--- a/devops/build/all/nginx.conf
+++ b/devops/build/all/nginx.conf
@@ -12,6 +12,7 @@ http {
     default_type  application/octet-stream;
     sendfile on;
     access_log off;
+    client_body_temp_path $APP_HOME/nginx/client 1 2;
     proxy_temp_path $APP_HOME/nginx/proxy 1 2;
 
     server {

--- a/devops/build/build-all.sh
+++ b/devops/build/build-all.sh
@@ -50,7 +50,7 @@ mkdir -p $destination/apiv2/
 mv out/apiv2/{dist/*,node_modules} $destination/apiv2/
 
 envsubst '$APP_HOME $PORT' < devops/build/all/nginx.conf > $destination/nginx.conf
-mkdir -p $destination/nginx/proxy
+mkdir -p $destination/nginx/{proxy,client}
 cp devops/build/all/{package.json,ecosystem.config.js,start-nginx.sh} $destination
 
 rm -Rf out


### PR DESCRIPTION
Fix `/tmp/nginx/client/0000000022" failed (13: Permission denied)` in mono image