### PR TITLE
fix(api,apiv2): 426 - Reset des données d'affectation lors d'un desistement

### DIFF
--- a/api/src/controllers/young/index.ts
+++ b/api/src/controllers/young/index.ts
@@ -953,23 +953,39 @@ router.put("/withdraw", passport.authenticate("young", { session: false, failWit
 
     await handleNotifForYoungWithdrawn(young, cohort, withdrawnReason, req.user);
 
+    const { sessionPhase1Id, ligneId } = young;
+
     young.set({
       status: YOUNG_STATUS.WITHDRAWN,
       statusPhase1: young.statusPhase1 === YOUNG_STATUS_PHASE1.AFFECTED ? YOUNG_STATUS_PHASE1.WAITING_AFFECTATION : young.statusPhase1,
       lastStatusAt: Date.now(),
       withdrawnMessage,
       withdrawnReason,
+      // reset des informations d'affectation
+      cohesionCenterId: undefined,
+      sessionPhase1Id: undefined,
+      meetingPointId: undefined,
+      ligneId: undefined,
+      hasMeetingInformation: undefined,
+      transportInfoGivenByLocal: undefined,
+      deplacementPhase1Autonomous: undefined,
+      cohesionStayPresence: undefined,
+      presenceJDM: undefined,
+      departInform: undefined,
+      departSejourAt: undefined,
+      departSejourMotif: undefined,
+      departSejourMotifComment: undefined,
     });
 
     const updatedYoung = await young.save({ fromUser: req.user });
-    if (young.sessionPhase1Id) {
-      const sessionPhase1 = await SessionPhase1Model.findById(young.sessionPhase1Id);
+    if (sessionPhase1Id) {
+      const sessionPhase1 = await SessionPhase1Model.findById(sessionPhase1Id);
       if (sessionPhase1) await updatePlacesSessionPhase1(sessionPhase1, req.user);
     }
 
     // if they had a bus, we check if we need to update the places taken / left in the bus
-    if (young.ligneId) {
-      const bus = await LigneBusModel.findById(young.ligneId);
+    if (ligneId) {
+      const bus = await LigneBusModel.findById(ligneId);
       if (bus) await updateSeatsTakenInBusLine(bus);
     }
 

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -695,17 +695,19 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       newYoung.departSejourMotifComment = undefined;
     }
 
+    const { sessionPhase1Id, ligneId } = young;
+
     young.set(newYoung);
     await young.save({ fromUser: req.user });
 
     // if they had a cohesion center, we check if we need to update the places taken / left
-    if (young.sessionPhase1Id) {
-      const sessionPhase1 = await SessionPhase1Model.findById(young.sessionPhase1Id);
+    if (sessionPhase1Id) {
+      const sessionPhase1 = await SessionPhase1Model.findById(sessionPhase1Id);
       if (sessionPhase1) await updatePlacesSessionPhase1(sessionPhase1, req.user);
     }
 
-    if (young.ligneId) {
-      const bus = await LigneBusModel.findById(young.ligneId);
+    if (ligneId) {
+      const bus = await LigneBusModel.findById(ligneId);
       if (bus) await updateSeatsTakenInBusLine(bus);
     }
 

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -576,7 +576,7 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       }
     }
 
-    if (newYoung.status === "REINSCRIPTION") {
+    if (newYoung.status === YOUNG_STATUS.REINSCRIPTION) {
       newYoung.cohesionStayPresence = undefined;
       newYoung.presenceJDM = undefined;
       newYoung.departSejourAt = undefined;
@@ -679,6 +679,20 @@ router.put("/young/:id", passport.authenticate("referent", { session: false, fai
       const { withdrawnReason } = newYoung;
       await handleNotifForYoungWithdrawn(young, cohort, withdrawnReason, req.user);
       newYoung.statusPhase1 = young.statusPhase1 === YOUNG_STATUS_PHASE1.AFFECTED ? YOUNG_STATUS_PHASE1.WAITING_AFFECTATION : young.statusPhase1;
+      // reset des informations d'affectation
+      newYoung.cohesionCenterId = undefined;
+      newYoung.sessionPhase1Id = undefined;
+      newYoung.meetingPointId = undefined;
+      newYoung.ligneId = undefined;
+      newYoung.hasMeetingInformation = undefined;
+      newYoung.transportInfoGivenByLocal = undefined;
+      newYoung.deplacementPhase1Autonomous = undefined;
+      newYoung.cohesionStayPresence = undefined;
+      newYoung.presenceJDM = undefined;
+      newYoung.departInform = undefined;
+      newYoung.departSejourAt = undefined;
+      newYoung.departSejourMotif = undefined;
+      newYoung.departSejourMotifComment = undefined;
     }
 
     young.set(newYoung);

--- a/apiv2/src/admin/core/sejours/phase1/desistement/Desistement.service.ts
+++ b/apiv2/src/admin/core/sejours/phase1/desistement/Desistement.service.ts
@@ -67,6 +67,20 @@ export class DesistementService {
                 statut: YOUNG_STATUS.WITHDRAWN,
                 statutPhase1: YOUNG_STATUS_PHASE1.WAITING_AFFECTATION,
                 desistementMotif: "Non confirmation de la participation au séjour",
+                // reset des informations d'affectation
+                centreId: undefined,
+                sejourId: undefined,
+                pointDeRassemblementId: undefined,
+                ligneDeBusId: undefined,
+                hasPDR: undefined,
+                transportInfoGivenByLocal: undefined,
+                deplacementPhase1Autonomous: undefined,
+                presenceArrivee: undefined,
+                presenceJDM: undefined,
+                departInform: undefined,
+                departSejourAt: undefined,
+                departSejourMotif: undefined,
+                departSejourMotifComment: undefined,
             });
         }
         this.cls.set("user", { firstName: "Traitement - Désistement après affectation" });


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

- [x] Traitement de désistement automatique
- [x] Désistement manuel du jeune
- [x] Désistement manuel d'un référent

**Ticket / Issue**

https://www.notion.so/jeveuxaider/D-sist-mais-affect-et-notifi-quand-m-me-1b472a322d50806da625c69e477d4e34?pvs=23

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
