### PR TITLE
fix(api): 471 - rendre le contact convocation plus lisible sur la convocation

### DIFF
--- a/api/src/templates/convocation/cohesion.ts
+++ b/api/src/templates/convocation/cohesion.ts
@@ -35,7 +35,8 @@ function render(doc, { young, session, cohort, center, service, meetingPoint, li
 
   _y = doc.y;
   if (contacts.length && young.source !== "CLE") {
-    doc.font(FONT_BOLD).text("Affaire suivie par :", { underline: true, paragraphGap: 5 });
+    doc.moveDown(2.5);
+    doc.font(FONT_BOLD).text("Votre point de contact :", { underline: true, paragraphGap: 5 });
     doc
       .font(FONT)
       .fontSize(8)


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Rendre-le-contact-de-convocation-plus-lisible-sur-la-convocation-1ba72a322d5080cdbbd6f54fcf14453b?pvs=4

<img width="792" alt="Capture d’écran 2025-03-18 à 16 55 39" src="https://github.com/user-attachments/assets/730b91fb-6ab0-432a-bb6f-7f0840f8722c" />

