### PR TITLE
feat(admin): Améliorer la lisibilité de l'historique des missions

### DIFF
--- a/admin/src/components/views/Historic.jsx
+++ b/admin/src/components/views/Historic.jsx
@@ -2,102 +2,106 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { formatStringLongDate, translate, ROLES } from "../../utils";
 import Loader from "../../components/Loader";
-import { HiOutlineChevronUp, HiOutlineChevronDown, HiArrowRight } from "react-icons/hi";
+import { HiOutlineChevronDown, HiArrowRight } from "react-icons/hi";
 import { useToggle } from "@uidotdev/usehooks";
 import { filterResult, getFieldName, translator } from "./lib/patchesUtils";
 import { isIsoDate } from "snu-lib";
 import { usePatches } from "./lib/usePatches";
+import ReactTooltip from "react-tooltip";
 
 export default function Historic({ model, value }) {
   const { data: patches, isPending } = usePatches(model, value);
-  const [hideSync, setHideSync] = useToggle(true);
-  const [filter, setFilter] = useState("");
-  const filteredPatches = patches?.filter((hit) => filterResult(model, hit, filter, hideSync));
+  const [simpleMode, setSimpleMode] = useToggle(true);
+  const [search, setSearch] = useState("");
+  const filteredPatches = patches?.filter((hit) => filterResult(model, hit, search, simpleMode));
   const user = useSelector((state) => state.Auth.user);
 
   return isPending ? (
     <Loader />
   ) : (
-    <div className="flex w-full flex-col gap-3">
-      {filteredPatches.length === 0 ? <div className="p-1 italic">Aucune donnée</div> : null}
+    <>
       {user?.role === ROLES.ADMIN ? (
-        <div className="grid grid-cols-2 gap-4">
-          <input onChange={(e) => setFilter(e.target.value)} value={filter} className="rounded-lg bg-white p-2 shadow-sm" placeholder="Rechercher..." />
-          {model === "mission" && (
-            <div className="mt-2">
-              <input id="filter-modifs" type="checkbox" checked={hideSync} onChange={setHideSync} />
-              <label htmlFor="filter-modifs" className="ml-2 text-coolGray-500">
-                Masquer les synchronisations sans modification et les données source.
-              </label>
+        <>
+          <input onChange={(e) => setSearch(e.target.value)} value={search} className="w-full rounded-lg bg-white p-3 shadow-md" placeholder="Rechercher..." />
+          {model === "mission" ? (
+            <div className="w-fit">
+              <ReactTooltip id="filter-modifs" className="bg-white shadow-xl" arrowColor="white">
+                <p className="text-gray-800">Masquer les synchronisations sans modification et les données source, traduire les noms des champs.</p>
+              </ReactTooltip>
+              <div data-tip data-for="filter-modifs" className="p-3">
+                <input id="filter-modifs" type="checkbox" checked={simpleMode} onChange={setSimpleMode} />
+                <label htmlFor="filter-modifs" className="m-0 ml-2 text-coolGray-500">
+                  Mode simplifié
+                </label>
+              </div>
             </div>
+          ) : (
+            <div className="p-3"></div>
           )}
-        </div>
+        </>
       ) : null}
-      {filteredPatches.map((hit) => (
-        <Hit model={model} key={hit._id} hit={hit} hideSync={hideSync} />
-      ))}
-    </div>
+      <div className="grid gap-3">
+        {filteredPatches.length === 0 ? <p>Aucune donnée.</p> : filteredPatches.map((hit) => <Hit model={model} key={hit._id} hit={hit} simpleMode={simpleMode} />)}
+      </div>
+    </>
   );
 }
 
-const Hit = ({ hit, model, hideSync }) => {
-  const [viewDetails, setViewDetails] = useState(true);
+const Hit = ({ hit, model, simpleMode }) => {
+  const [viewModifs, setViewModifs] = useToggle(true);
   const user = useSelector((state) => state.Auth.user);
-  const filteredOps = hideSync ? hit.ops.filter((op) => !op.path.includes("/jvaRawData") && !op.path.includes("/lastSyncAt")) : hit.ops;
+  const modifications = simpleMode ? hit.ops.filter((op) => !op.path.includes("/jvaRawData") && !op.path.includes("/lastSyncAt")) : hit.ops;
 
   return (
     <div className="rounded-lg bg-white shadow-md">
-      <button className="w-full flex items-center justify-between border-b p-3" onClick={() => setViewDetails((e) => !e)}>
-        <div>
-          <span className="font-bold">
+      <div className="border-b p-3 flex justify-between">
+        <p>
+          <strong>
             {hit.user && hit.user.email ? (
               hit.user.role ? (
                 // * Referent
-                <a href={`/user/${hit.user._id}`} target="_blank" rel="noreferrer" className="text-snu-purple-300 hover:text-snu-purple-300 hover:underline">
+                <a href={`/user/${hit.user._id}`} target="_blank" rel="noreferrer" className="text-blue-600 underline-offset-2 hover:text-blue-600 hover:underline">
                   {`${hit.user.firstName} ${hit.user.lastName} (${translate(hit.user.role)})`}
                 </a>
               ) : (
                 // * Young
-                <a href={`/volontaire/${hit.user._id}`} target="_blank" rel="noreferrer" className="text-snu-purple-300 hover:text-snu-purple-300 hover:underline">
+                <a href={`/volontaire/${hit.user._id}`} target="_blank" rel="noreferrer" className="text-blue-600 underline-offset-2 hover:text-blue-600 hover:underline">
                   {`${hit.user.firstName} ${hit.user.lastName} (Volontaire)`}
                 </a>
               )
             ) : hit.user && hit.user.firstName ? (
               // * Scripts / Cron
               user?.role === ROLES.ADMIN ? (
-                [hit.user.firstName, hit.user.lastName].join(" ")
+                hit.user.firstName
               ) : (
                 "Modification automatique"
               )
             ) : (
               "Acteur non renseigné"
             )}
-          </span>
+          </strong>
           ,&nbsp;{formatStringLongDate(hit.date)}
-        </div>
+        </p>
+        <button className="text-gray-500" onClick={setViewModifs}>
+          {modifications.length} modification{hit.ops.length > 1 ? "s" : ""}
+          <HiOutlineChevronDown className={`inline-block ml-2 transition-all duration-300 ease-in-out ${viewModifs && "rotate-180"}`} />
+        </button>
+      </div>
 
-        <div className="flex items-center gap-2 text-coolGray-500">
-          <span className="italic">
-            {hit.ops.length} action{hit.ops.length > 1 ? "s" : ""}
-          </span>
-          {viewDetails ? <HiOutlineChevronUp /> : <HiOutlineChevronDown />}
-        </div>
-      </button>
-
-      {viewDetails
-        ? filteredOps?.map((e, i) => {
+      {viewModifs
+        ? modifications.map((e, i) => {
             const originalValue = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.originalValue)?.replace(/"/g, ""));
             const value = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.value)?.replace(/"/g, ""));
             return (
-              <div className="flex justify-between border-b border-[#f3f3f3] p-3" key={`${hit.date}-${i}`}>
-                <div className="flex-1 ">{getFieldName(model, e.path)}&nbsp;:</div>
-                <div className="flex-1 text-center">
+              <div className="grid grid-cols-12 border-b border-gray-100 p-3" key={`${hit.date}-${i}`}>
+                <div className="col-span-3">{simpleMode ? getFieldName(model, e.path) : e.path}&nbsp;:</div>
+                <div className="col-span-4">
                   {(isIsoDate(originalValue) ? formatStringLongDate(originalValue) : originalValue) || <span className="italic text-coolGray-400">Vide</span>}
                 </div>
-                <div className="text-center">
-                  <HiArrowRight />
+                <div>
+                  <HiArrowRight className="mx-3 my-1" />
                 </div>
-                <div className="flex-1 text-center">{(isIsoDate(value) ? formatStringLongDate(value) : value) || <span className="italic text-coolGray-400">Vide</span>}</div>
+                <div className="col-span-4">{(isIsoDate(value) ? formatStringLongDate(value) : value) || <span className="italic text-coolGray-400">Vide</span>}</div>
               </div>
             );
           })

--- a/admin/src/components/views/Historic.jsx
+++ b/admin/src/components/views/Historic.jsx
@@ -1,111 +1,64 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
-
-import { formatStringLongDate, translateModelFields, translate, translatePhase1, translatePhase2, translateApplication, translateEngagement, ROLES } from "../../utils";
+import { formatStringLongDate, translate, ROLES } from "../../utils";
 import Loader from "../../components/Loader";
-import api from "../../services/api";
 import { HiOutlineChevronUp, HiOutlineChevronDown, HiArrowRight } from "react-icons/hi";
-import { useHistory } from "react-router-dom";
+import { useToggle } from "@uidotdev/usehooks";
+import { filterResult, getFieldName, translator } from "./lib/patchesUtils";
+import { isIsoDate } from "snu-lib";
+import { usePatches } from "./lib/usePatches";
 
 export default function Historic({ model, value }) {
-  const [data, setData] = useState();
+  const { data: patches, isPending } = usePatches(model, value);
+  const [hideSync, setHideSync] = useToggle(true);
   const [filter, setFilter] = useState("");
+  const filteredPatches = patches?.filter((hit) => filterResult(model, hit, filter, hideSync));
   const user = useSelector((state) => state.Auth.user);
 
-  const getPatches = async () => {
-    try {
-      const { ok, data } = await api.get(`/${model}/${value._id}/patches`);
-      if (!ok) return;
-      setData(data);
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
-  useEffect(() => {
-    getPatches();
-  }, []);
-
-  return !data ? (
+  return isPending ? (
     <Loader />
   ) : (
     <div className="flex w-full flex-col gap-3">
-      {data.length === 0 ? <div className="p-1 italic">Aucune données</div> : null}
+      {filteredPatches.length === 0 ? <div className="p-1 italic">Aucune donnée</div> : null}
       {user?.role === ROLES.ADMIN ? (
-        <input onChange={(e) => setFilter(e.target.value)} value={filter} className="w-[350px] rounded-lg bg-white p-2" placeholder="Rechercher..." />
+        <div className="grid grid-cols-2 gap-4">
+          <input onChange={(e) => setFilter(e.target.value)} value={filter} className="rounded-lg bg-white p-2 shadow-sm" placeholder="Rechercher..." />
+          {model === "mission" && (
+            <div className="mt-2">
+              <input id="filter-modifs" type="checkbox" checked={hideSync} onChange={setHideSync} />
+              <label htmlFor="filter-modifs" className="ml-2 text-coolGray-500">
+                Masquer les synchronisations sans modification et les données source.
+              </label>
+            </div>
+          )}
+        </div>
       ) : null}
-      {data.map((hit) => (
-        <Hit model={model} key={hit._id} hit={hit} filter={filter} />
+      {filteredPatches.map((hit) => (
+        <Hit model={model} key={hit._id} hit={hit} hideSync={hideSync} />
       ))}
     </div>
   );
 }
 
-const Hit = ({ hit, model, filter }) => {
+const Hit = ({ hit, model, hideSync }) => {
   const [viewDetails, setViewDetails] = useState(true);
   const user = useSelector((state) => state.Auth.user);
-  const history = useHistory();
-  function isIsoDate(str) {
-    if (!Date.parse(str)) return false;
-    var d = new Date(str);
-    return d.toISOString() === str;
-  }
-
-  const splitElementArray = (v) => {
-    // si on modifie la valeur d'un element d'un champs array
-    // on doit le parser car il est affiché sous la forme : field/index
-    const elementOfArry = v.match(/(\w*)\/(\d)/);
-    if (elementOfArry?.length) {
-      //console.log("✍️ ~ elementOfArry", elementOfArry);
-      return `${translateModelFields(model, elementOfArry[1])} (nº${Number(elementOfArry[2]) + 1})`;
-    }
-    return v;
-  };
-
-  const translator = (path, value) => {
-    if (path === "/statusPhase1") {
-      return translatePhase1(value);
-    } else if (path === "/statusPhase2") {
-      return translatePhase2(value);
-    } else if (path === "/phase2ApplicationStatus") {
-      return translateApplication(value);
-    } else if (path === "/statusPhase2Contract") {
-      return translateEngagement(value);
-    } else {
-      return translate(value);
-    }
-  };
-
-  if (
-    !hit ||
-    (filter &&
-      !hit.ops?.some((e) => {
-        const originalValue = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.originalValue)?.replace(/"/g, ""));
-        const value = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.value)?.replace(/"/g, ""));
-
-        const matchFieldName = translateModelFields(model, e.path.substring(1)).toLowerCase().includes(filter.toLowerCase().trim());
-        const matchOriginalValue = (isIsoDate(originalValue) ? formatStringLongDate(originalValue) : originalValue)?.toLowerCase().includes(filter.toLowerCase().trim());
-        const matchFromValue = (isIsoDate(value) ? formatStringLongDate(value) : value)?.toLowerCase().includes(filter.toLowerCase().trim());
-
-        return matchFieldName || matchOriginalValue || matchFromValue;
-      }))
-  )
-    return null;
+  const filteredOps = hideSync ? hit.ops.filter((op) => !op.path.includes("/jvaRawData") && !op.path.includes("/lastSyncAt")) : hit.ops;
 
   return (
     <div className="rounded-lg bg-white shadow-md">
-      <div className="flex cursor-pointer items-center justify-between border-b p-3" onClick={() => setViewDetails((e) => !e)}>
+      <button className="w-full flex items-center justify-between border-b p-3" onClick={() => setViewDetails((e) => !e)}>
         <div>
           <span className="font-bold">
             {hit.user && hit.user.email ? (
               hit.user.role ? (
                 // * Referent
-                <a onClick={() => history.push(`/user/${hit.user._id}`)} className="cursor-pointer text-snu-purple-300 hover:text-snu-purple-300 hover:underline">
+                <a href={`/user/${hit.user._id}`} target="_blank" rel="noreferrer" className="text-snu-purple-300 hover:text-snu-purple-300 hover:underline">
                   {`${hit.user.firstName} ${hit.user.lastName} (${translate(hit.user.role)})`}
                 </a>
               ) : (
                 // * Young
-                <a onClick={() => history.push(`/volontaire/${hit.user._id}`)} className="cursor-pointer text-snu-purple-300 hover:text-snu-purple-300 hover:underline">
+                <a href={`/volontaire/${hit.user._id}`} target="_blank" rel="noreferrer" className="text-snu-purple-300 hover:text-snu-purple-300 hover:underline">
                   {`${hit.user.firstName} ${hit.user.lastName} (Volontaire)`}
                 </a>
               )
@@ -129,38 +82,25 @@ const Hit = ({ hit, model, filter }) => {
           </span>
           {viewDetails ? <HiOutlineChevronUp /> : <HiOutlineChevronDown />}
         </div>
-      </div>
+      </button>
+
       {viewDetails
-        ? hit.ops
-            ?.filter((e) => {
-              if (filter) {
-                const originalValue = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.originalValue)?.replace(/"/g, ""));
-                const value = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.value)?.replace(/"/g, ""));
-
-                const matchFieldName = translateModelFields(model, e.path.substring(1)).toLowerCase().includes(filter.toLowerCase().trim());
-                const matchOriginalValue = (isIsoDate(originalValue) ? formatStringLongDate(originalValue) : originalValue)?.toLowerCase().includes(filter.toLowerCase().trim());
-                const matchFromValue = (isIsoDate(value) ? formatStringLongDate(value) : value)?.toLowerCase().includes(filter.toLowerCase().trim());
-
-                return matchFieldName || matchOriginalValue || matchFromValue;
-              } else return true;
-            })
-            ?.map((e, i) => {
-              const originalValue = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.originalValue)?.replace(/"/g, ""));
-              const value = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.value)?.replace(/"/g, ""));
-              if (["/jvaRawData"].some((blackfield) => e.path.includes(blackfield))) return null;
-              return (
-                <div className="flex justify-between border-b border-[#f3f3f3] p-3" key={`${hit.date}-${i}`}>
-                  <div className="flex-1 ">{`${splitElementArray(translateModelFields(model, e.path.substring(1)))}`}&nbsp;:</div>
-                  <div className="flex-1 text-center">
-                    {(isIsoDate(originalValue) ? formatStringLongDate(originalValue) : originalValue) || <span className="italic text-coolGray-400">Vide</span>}
-                  </div>
-                  <div className="text-center">
-                    <HiArrowRight />
-                  </div>
-                  <div className="flex-1 text-center">{(isIsoDate(value) ? formatStringLongDate(value) : value) || <span className="italic text-coolGray-400">Vide</span>}</div>
+        ? filteredOps?.map((e, i) => {
+            const originalValue = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.originalValue)?.replace(/"/g, ""));
+            const value = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.value)?.replace(/"/g, ""));
+            return (
+              <div className="flex justify-between border-b border-[#f3f3f3] p-3" key={`${hit.date}-${i}`}>
+                <div className="flex-1 ">{getFieldName(model, e.path)}&nbsp;:</div>
+                <div className="flex-1 text-center">
+                  {(isIsoDate(originalValue) ? formatStringLongDate(originalValue) : originalValue) || <span className="italic text-coolGray-400">Vide</span>}
                 </div>
-              );
-            })
+                <div className="text-center">
+                  <HiArrowRight />
+                </div>
+                <div className="flex-1 text-center">{(isIsoDate(value) ? formatStringLongDate(value) : value) || <span className="italic text-coolGray-400">Vide</span>}</div>
+              </div>
+            );
+          })
         : null}
     </div>
   );

--- a/admin/src/components/views/Historic.jsx
+++ b/admin/src/components/views/Historic.jsx
@@ -26,7 +26,11 @@ export default function Historic({ model, value }) {
           {model === "mission" ? (
             <div className="w-fit">
               <ReactTooltip id="filter-modifs" className="bg-white shadow-xl" arrowColor="white">
-                <p className="text-gray-800">Masquer les synchronisations sans modification et les données source, traduire les noms des champs.</p>
+                <ul className="text-gray-800">
+                  <li>Masquer les synchronisations n'ayant pas entraîné de modification</li>
+                  <li>Masquer les données source</li>
+                  <li>Traduire les noms des champs</li>
+                </ul>
               </ReactTooltip>
               <div data-tip data-for="filter-modifs" className="p-3">
                 <input id="filter-modifs" type="checkbox" checked={simpleMode} onChange={setSimpleMode} />
@@ -99,7 +103,7 @@ const Hit = ({ hit, model, simpleMode }) => {
                   {(isIsoDate(originalValue) ? formatStringLongDate(originalValue) : originalValue) || <span className="italic text-coolGray-400">Vide</span>}
                 </div>
                 <div>
-                  <HiArrowRight className="mx-3 my-1" />
+                  <HiArrowRight className="mx-auto my-1" />
                 </div>
                 <div className="col-span-4">{(isIsoDate(value) ? formatStringLongDate(value) : value) || <span className="italic text-coolGray-400">Vide</span>}</div>
               </div>

--- a/admin/src/components/views/lib/patchesRepository.ts
+++ b/admin/src/components/views/lib/patchesRepository.ts
@@ -1,0 +1,7 @@
+import API from "@/services/api";
+
+export async function getPatches(model, value) {
+  const { ok, data, code } = await API.get(`/${model}/${value._id}/patches`);
+  if (!ok) throw new Error(code);
+  return data;
+}

--- a/admin/src/components/views/lib/patchesUtils.ts
+++ b/admin/src/components/views/lib/patchesUtils.ts
@@ -1,0 +1,53 @@
+import { formatStringLongDate, translate, translateApplication, translateEngagement, translateModelFields, translatePhase1, translatePhase2 } from "@/utils";
+import { isIsoDate } from "snu-lib";
+
+const splitElementArray = (model, value) => {
+  // si on modifie la valeur d'un element d'un champs array
+  // on doit le parser car il est affiché sous la forme : field/index
+  const elementOfArray = value.match(/(\w*)\/(\d)/);
+  if (elementOfArray?.length) {
+    //console.log("✍️ ~ elementOfArry", elementOfArry);
+    return `${translateModelFields(model, elementOfArray[1])} (nº${Number(elementOfArray[2]) + 1})`;
+  }
+  return value;
+};
+
+export const translator = (path, value) => {
+  if (path === "/statusPhase1") {
+    return translatePhase1(value);
+  } else if (path === "/statusPhase2") {
+    return translatePhase2(value);
+  } else if (path === "/phase2ApplicationStatus") {
+    return translateApplication(value);
+  } else if (path === "/statusPhase2Contract") {
+    return translateEngagement(value);
+  } else {
+    return translate(value);
+  }
+};
+
+export function patchHasMeaningfulChanges(patch) {
+  const opsWithMeaningfulChanges = patch.ops.filter((op) => {
+    return !op.path.includes("/jvaRawData") && !op.path.includes("/lastSyncAt");
+  });
+  return opsWithMeaningfulChanges.length > 0;
+}
+
+export function filterResult(model, hit, filter, showOnlyMeaningful) {
+  if (showOnlyMeaningful && !patchHasMeaningfulChanges(hit)) return false;
+  return hit.ops?.some((e) => {
+    const originalValue = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.originalValue)?.replace(/"/g, ""));
+    const value = translator(JSON.stringify(e.path)?.replace(/"/g, ""), JSON.stringify(e.value)?.replace(/"/g, ""));
+
+    const matchFieldName = translateModelFields(model, e.path.substring(1)).toLowerCase().includes(filter.toLowerCase().trim());
+    const matchOriginalValue = (isIsoDate(originalValue) ? formatStringLongDate(originalValue) : originalValue)?.toLowerCase().includes(filter.toLowerCase().trim());
+    const matchFromValue = (isIsoDate(value) ? formatStringLongDate(value) : value)?.toLowerCase().includes(filter.toLowerCase().trim());
+
+    return matchFieldName || matchOriginalValue || matchFromValue;
+  });
+}
+
+export function getFieldName(model, path) {
+  if (path.includes("jvaRawData")) return path;
+  return `${splitElementArray(model, translateModelFields(model, path.substring(1)))}`;
+}

--- a/admin/src/components/views/lib/usePatches.ts
+++ b/admin/src/components/views/lib/usePatches.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPatches } from "./patchesRepository";
+
+export function usePatches(model, value) {
+  return useQuery({
+    queryKey: [model, value],
+    queryFn: () => getPatches(model, value),
+  });
+}

--- a/admin/src/utils/translateFieldsModel.ts
+++ b/admin/src/utils/translateFieldsModel.ts
@@ -518,9 +518,9 @@ const translateFieldMission = (f) => {
     case "domains":
       return "Domaines";
     case "startAt":
-      return "Date début";
+      return "Date de début";
     case "endAt":
-      return "Date fin";
+      return "Date de fin";
     case "frequence":
       return "Fréquence";
     case "format":
@@ -560,7 +560,7 @@ const translateFieldMission = (f) => {
     case "isMilitaryPreparation":
       return "Préparation militaire";
     case "createdAt":
-      return "créé(e) le";
+      return "Créée le";
     case "updatedAt":
       return "mis(e) à jour le";
     case "jvaMissionId":
@@ -579,6 +579,22 @@ const translateFieldMission = (f) => {
       return "Autre";
     case "status":
       return "Statut";
+    case "pendingApplications":
+      return "Nombre de candidatures en attente";
+    case "applicationStatus":
+      return "Statut de la candidature";
+    case "description":
+      return "Description";
+    case "actions":
+      return "Actions";
+    case "duration":
+      return "Durée";
+    case "mainDomain":
+      return "Domaine principal";
+    case "visibility":
+      return "Visibilité";
+    case "apiEngagementId":
+      return "Id de la mission API Engagement";
     default:
       return f;
   }

--- a/admin/src/utils/translateFieldsModel.ts
+++ b/admin/src/utils/translateFieldsModel.ts
@@ -577,6 +577,8 @@ const translateFieldMission = (f) => {
       return "Retour d’expérience (rapport de MIG)";
     case "othersFiles":
       return "Autre";
+    case "status":
+      return "Statut";
     default:
       return f;
   }


### PR DESCRIPTION
Contexte : investigation sur les problèmes de synchronisation avec JVA.

Evolutions : 
- Par défaut, les patches qui ne contiennent qu'un changement de la date de synchronisation JVA  et des modifications dans les raw data sont masqués.
- Ajout d'une checkbox pour les admin pour afficher ces données (= possibilité retour à l'ancien affichage).
- Amélioration et simplification du code de la page.

<img width="1464" alt="Screenshot 2025-03-26 at 10 11 43" src="https://github.com/user-attachments/assets/6718673d-7c0b-4ee4-901d-abbbf87d765c" />
