### PR TITLE
fix(admin): Phase 2/Contrat : ne pas tenter d'afficher l'historique si non autorisé

### DIFF
--- a/admin/src/components/Contract.jsx
+++ b/admin/src/components/Contract.jsx
@@ -211,6 +211,8 @@ export default function Contract({ young }) {
     ((isYoungAdult && contract.youngContractStatus === "VALIDATED") ||
       (!isYoungAdult && contract.parent1Status === "VALIDATED" && (!young.parent2Email || contract.parent2Status === "VALIDATED")));
 
+  const canReadContractHistory = [ROLES.ADMIN, ROLES.REFERENT_DEPARTMENT, ROLES.REFERENT_REGION].includes(user.role);
+
   return (
     <>
       <BackLink
@@ -812,7 +814,7 @@ export default function Contract({ young }) {
           }}
         </Formik>
       )}
-      {contract ? (
+      {contract && canReadContractHistory ? (
         <div className="mt-4">
           <h3 className="my-2 mx-4 text-sm uppercase italic text-snu-purple-600">Historique des modifications du contrat d&apos;engagement</h3>
           <HistoricComponent model="contract" value={contract} />


### PR DESCRIPTION
Lors d'une réécriture du fetch des données de l'historique sur cette page, on est passé de `if (!ok) return` à `if (!ok) throw new Error(code)`.
Solution : conserver le throw en cas d'erreur (qui déclenche un toaster en front) mais ne pas tenter d'afficher l'historique si utilisateur non autorisé.

Erreur Sentry : https://sentry.selego.co/organizations/sentry/issues/15479/?alert_rule_id=104&alert_type=issue&environment=production&notification_uuid=1cbb82b1-94f2-4381-8b33-8ecbf0c7554e&project=140