### PR TITLE
feat(admin): 528 - Aligner l'export par département ou région sur celui des inscriptions

### DIFF
--- a/admin/src/scenes/inscription/index.jsx
+++ b/admin/src/scenes/inscription/index.jsx
@@ -18,7 +18,7 @@ import { appURL } from "../../config";
 import plausibleEvent from "../../services/plausible";
 import { ROLES, YOUNG_STATUS, formatStringLongDate, translate, translateInscriptionStatus } from "../../utils";
 import { Title } from "../pointDeRassemblement/components/common";
-import { transformInscription, transformVolontairesSchool } from "../volontaires/utils";
+import { transformInscription } from "../volontaires/utils";
 import DeletedInscriptionPanel from "./deletedPanel";
 import Panel from "./panel";
 import { toastr } from "react-redux-toastr";
@@ -279,7 +279,7 @@ export default function Inscription() {
                   button: `group flex items-center gap-3 rounded-lg border-[1px] text-white border-blue-600 bg-blue-600 px-3 py-2 text-sm hover:bg-white hover:!text-blue-600 transition ease-in-out`,
                   loadingButton: `group ml-auto flex items-center gap-3 rounded-lg border-[1px] text-white border-blue-600 bg-blue-600 px-3 py-2 text-sm hover:bg-white hover:!text-blue-600 transition ease-in-out`,
                 }}
-                transform={async (data) => transformVolontairesSchool(data)}
+                transform={async (data) => transformInscription(data)}
               />
             )}
           </div>

--- a/admin/src/scenes/volontaires/list.jsx
+++ b/admin/src/scenes/volontaires/list.jsx
@@ -19,7 +19,7 @@ import { ROLES, YOUNG_STATUS, YOUNG_STATUS_COLORS, getAge, translate, translateP
 import { Title } from "../pointDeRassemblement/components/common";
 import DeletedVolontairePanel from "./deletedPanel";
 import Panel from "./panel";
-import { getFilterArray, transformVolontaires, transformVolontairesSchool } from "./utils";
+import { getFilterArray, transformInscription, transformVolontaires } from "./utils";
 import { signinAs } from "@/utils/signinAs";
 import { getCohortGroups } from "@/services/cohort.service";
 import { Button } from "@snu/ds/admin";
@@ -47,7 +47,6 @@ export default function VolontaireList() {
   });
 
   const { exportToCsv, isProcessing: isLoadingExportRecipients } = useBrevoExport("volontaire");
-
 
   if (user?.role === ROLES.ADMINISTRATEUR_CLE) return history.push("/mes-eleves");
 
@@ -102,7 +101,7 @@ export default function VolontaireList() {
                   button: `group ml-auto flex items-center gap-3 rounded-lg border-[1px] text-white border-blue-600 bg-blue-600 px-3 py-2 text-sm hover:bg-white hover:!text-blue-600 transition ease-in-out`,
                   loadingButton: `group ml-auto flex items-center gap-3 rounded-lg border-[1px] text-white border-blue-600 bg-blue-600 px-3 py-2 text-sm hover:bg-white hover:!text-blue-600 transition ease-in-out`,
                 }}
-                transform={async (data) => transformVolontairesSchool(data)}
+                transform={async (data) => transformInscription(data)}
               />
             )}
           </div>

--- a/admin/src/scenes/volontaires/utils/index.js
+++ b/admin/src/scenes/volontaires/utils/index.js
@@ -655,6 +655,8 @@ export async function transformInscription(data) {
       "Mis à jour le": formatLongDateFR(data.updatedAt),
       "Dernière connexion le": formatLongDateFR(data.lastLoginAt),
       "Statut général": translate(data.status),
+      "Statut Phase 1": translatePhase1(data.statusPhase1),
+      "Statut Phase 2": translatePhase2(data.statusPhase2),
       "Dernier statut le": formatLongDateFR(data.lastStatusAt),
     };
   });

--- a/admin/src/scenes/volontaires/utils/index.js
+++ b/admin/src/scenes/volontaires/utils/index.js
@@ -564,29 +564,6 @@ export async function transformVolontaires(data, values) {
   });
 }
 
-export async function transformVolontairesSchool(data) {
-  let all = data;
-  return all.map((data) => {
-    return {
-      _id: data._id,
-      Cohorte: data.cohort,
-      Prénom: data.firstName,
-      Nom: data.lastName,
-      Département: data.department,
-      Situation: translate(data.situation),
-      Niveau: translate(data.grade),
-      "Type d'établissement": translate(data.school?.type || data.schoolType),
-      "Nom de l'établissement": data.school?.fullName || data.schoolName,
-      "Code postal de l'établissement": data.school?.postcode || data.schoolZip,
-      "Ville de l'établissement": data.school?.city || data.schoolCity,
-      "Département de l'établissement": departmentLookUp[data.school?.department] || data.schoolDepartment,
-      "UAI de l'établissement": data.school?.uai,
-      "Statut général": translate(data.status),
-      "Statut Phase 1": translate(data.statusPhase1),
-    };
-  });
-}
-
 export async function transformInscription(data) {
   let all = data;
   return all.map((data) => {


### PR DESCRIPTION
**Description**

Les exports de volontaires destinés aux référents départementaux et régionaux manquent d'informations. Alignement sur l'export des inscriptions, plus exhaustif.

**Todo**

- [x] Mettre à jour l'export de la page Inscriptions
- [x] Mettre à jour l'export de la page Volontaires

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

[Notion ticket #528](https://www.notion.so/jeveuxaider/Mettre-jour-l-export-des-volontaires-scolaris-s-dans-le-d-partement-r-gion-1c272a322d5080ab896cfc7eeeeb8e5f?pvs=4)

**Testing instructions**

Faire des exports en tant que ref dep ou ref reg depuis les pages concernées.
