### PR TITLE
feat(apiv2): 625 - ajouter cron apiv2

### DIFF
--- a/apiv2/src/MainJob.module.ts
+++ b/apiv2/src/MainJob.module.ts
@@ -6,6 +6,7 @@ import { QueueModule } from "@infra/Queue.module";
 import { ConfigModule } from "@nestjs/config";
 import { SentryModule } from "@sentry/nestjs/setup";
 import configuration from "./config/configuration";
+import { CronModule } from "./cron/cron.module";
 
 @Module({
     imports: [
@@ -15,7 +16,8 @@ import configuration from "./config/configuration";
         SentryModule.forRoot(),
         QueueModule,
         NotificationJobModule,
-        AdminJobModule
+        AdminJobModule,
+        CronModule,
     ],
     controllers: [HealthCheckController],
 })

--- a/apiv2/src/admin/infra/sejours/cle/etablissement/provider/EtablissementMongo.provider.ts
+++ b/apiv2/src/admin/infra/sejours/cle/etablissement/provider/EtablissementMongo.provider.ts
@@ -9,8 +9,14 @@ export const ETABLISSEMENT_MONGOOSE_ENTITY = "ETABLISSEMENT_MONGOOSE_ENTITY";
 export const etablissementMongoProviders = [
     {
         provide: ETABLISSEMENT_MONGOOSE_ENTITY,
-        useFactory: (connection: Connection) =>
-            connection.model(EtablissementName, new mongoose.Schema(EtablissementSchema)),
+        useFactory: (connection: Connection) => {
+            const modelExists = connection.modelNames().includes(EtablissementName);
+            if (modelExists) {
+                return connection.model(EtablissementName);
+            } else {
+                return connection.model(EtablissementName, new mongoose.Schema(EtablissementSchema));
+            }
+        },
         inject: [DATABASE_CONNECTION],
     },
 ];

--- a/apiv2/src/cron/cron.module.ts
+++ b/apiv2/src/cron/cron.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { BullModule } from "@nestjs/bullmq";
+import { QueueName } from "@shared/infra/Queue";
+import { CronJobSchedulerService } from "./infra/CronJobScheduler.service";
+import { CronJobConsumer } from "./infra/CronJob.consumer";
+import { CronJobSelectorService } from "./infra/CronJobSelector.service";
+import { PlanMarketingModule } from "@plan-marketing/plan-marketing.module";
+
+@Module({
+    imports: [
+        PlanMarketingModule,
+        BullModule.registerQueue({
+            name: QueueName.CRON,
+        }),
+    ],
+    providers: [CronJobSchedulerService, CronJobConsumer, CronJobSelectorService],
+})
+export class CronModule {}

--- a/apiv2/src/cron/infra/CronJob.consumer.ts
+++ b/apiv2/src/cron/infra/CronJob.consumer.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Job } from "bullmq";
+import { CronJob, CronJobName } from "../jobs.config";
+import { CronJobSelectorService } from "./CronJobSelector.service";
+import { ConsumerResponse } from "@shared/infra/ConsumerResponse";
+import { QueueName } from "@shared/infra/Queue";
+import { Processor, WorkerHost } from "@nestjs/bullmq";
+
+@Processor(QueueName.CRON)
+export class CronJobConsumer extends WorkerHost {
+    private readonly logger: Logger = new Logger(CronJobConsumer.name);
+    constructor(private readonly cronJobSelector: CronJobSelectorService) {
+        super();
+    }
+
+    async process(job: Job<CronJob, any, CronJobName>): Promise<ConsumerResponse> {
+        this.logger.log(`Processing cron job ${job.name}`);
+        try {
+            await this.cronJobSelector.handleCronJob(job);
+            this.logger.log(`Cron job ${job.name} processed successfully`);
+            return ConsumerResponse.SUCCESS;
+        } catch (error) {
+            this.logger.error(`Error processing cron job ${job.name}: ${error}`);
+            return ConsumerResponse.FAILURE;
+        }
+    }
+}

--- a/apiv2/src/cron/infra/CronJobScheduler.service.ts
+++ b/apiv2/src/cron/infra/CronJobScheduler.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { Queue } from "bullmq";
+import { QueueName } from "@shared/infra/Queue";
+import { cronJobs } from "../jobs.config";
+import { InjectQueue } from "@nestjs/bullmq";
+
+@Injectable()
+export class CronJobSchedulerService implements OnModuleInit {
+    private readonly logger: Logger = new Logger(CronJobSchedulerService.name);
+    constructor(@InjectQueue(QueueName.CRON) private jobQueue: Queue) {}
+
+    async onModuleInit() {
+        await this.scheduleJobs();
+    }
+
+    private async scheduleJobs() {
+        const repeatableJobs = await this.jobQueue.getJobSchedulers();
+        for (const job of repeatableJobs) {
+            await this.jobQueue.removeJobScheduler(job.name);
+        }
+
+        for (const job of cronJobs) {
+            this.logger.log(`Adding job ${job.name} with pattern ${job.pattern}`);
+            await this.jobQueue.upsertJobScheduler(
+                job.name,
+                { pattern: job.pattern },
+                {
+                    name: job.name,
+                    data: job.data,
+                    opts: {
+                        ...job.opts,
+                    },
+                },
+            );
+        }
+    }
+}

--- a/apiv2/src/cron/infra/CronJobSelector.service.ts
+++ b/apiv2/src/cron/infra/CronJobSelector.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import { EnvoyerCampagneProgrammee } from "@plan-marketing/core/useCase/cron/EnvoyerCampagneProgrammee";
+import { TechnicalException, TechnicalExceptionType } from "@shared/infra/TechnicalException";
+import { Job } from "bullmq";
+import { CronJob, CronJobName } from "../jobs.config";
+
+@Injectable()
+export class CronJobSelectorService {
+    constructor(private readonly envoyerCampagneProgrammee: EnvoyerCampagneProgrammee) {}
+
+    async handleCronJob(job: Job<CronJob, any, CronJobName>): Promise<void> {
+        switch (job.name) {
+            case CronJobName.ENVOYER_CAMPAGNES_PROGRAMMEES:
+                await this.envoyerCampagneProgrammee.execute();
+                break;
+
+            default:
+                throw new TechnicalException(
+                    TechnicalExceptionType.CRON_JOB_NOT_HANDLED,
+                    `Cron job of type ${job.name} not handled yet`,
+                );
+        }
+    }
+}

--- a/apiv2/src/cron/jobs.config.ts
+++ b/apiv2/src/cron/jobs.config.ts
@@ -1,0 +1,19 @@
+import { JobsOptions } from "bullmq";
+
+export interface CronJob {
+    name: CronJobName;
+    pattern: string;
+    data?: Record<string, unknown>;
+    opts?: JobsOptions;
+}
+
+export enum CronJobName {
+    ENVOYER_CAMPAGNES_PROGRAMMEES = "envoyer-campagnes-programmees",
+}
+
+export const cronJobs: CronJob[] = [
+    // {
+    //     name: CronJobName.ENVOYER_CAMPAGNES_PROGRAMMEES,
+    //     pattern: "0 8 * * *",
+    // },
+];

--- a/apiv2/src/infra/Queue.module.ts
+++ b/apiv2/src/infra/Queue.module.ts
@@ -31,6 +31,9 @@ import * as basicAuth from "express-basic-auth";
         BullModule.registerQueue({
             name: QueueName.ADMIN_TASK,
         }),
+        BullModule.registerQueue({
+            name: QueueName.CRON,
+        }),
         BullBoardModule.forRootAsync({
             imports: [ConfigModule],
             inject: [ConfigService],
@@ -55,6 +58,10 @@ import * as basicAuth from "express-basic-auth";
         }),
         BullBoardModule.forFeature({
             name: QueueName.ADMIN_TASK,
+            adapter: BullMQAdapter,
+        }),
+        BullBoardModule.forFeature({
+            name: QueueName.CRON,
             adapter: BullMQAdapter,
         }),
     ],

--- a/apiv2/src/plan-marketing/core/useCase/cron/EnvoyerCampagneProgrammee.ts
+++ b/apiv2/src/plan-marketing/core/useCase/cron/EnvoyerCampagneProgrammee.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+import { UseCase } from "@shared/core/UseCase";
+import { PreparerEnvoiCampagne } from "../PreparerEnvoiCampagne";
+@Injectable()
+export class EnvoyerCampagneProgrammee implements UseCase<void> {
+    constructor(private readonly preparerEnvoiCampagne: PreparerEnvoiCampagne) {}
+    async execute(): Promise<void> {
+        // Lister toutes les programmations de campagnes
+        // Pour chaque campagne programmée, vérifier si la date d'envoi est passée
+        // TODO: Récupérer les campagnes programmées
+        const campagnesProgrammeesIds: string[] = [];
+        for (const campagneProgrammeeId of campagnesProgrammeesIds) {
+            await this.preparerEnvoiCampagne.execute(campagneProgrammeeId);
+        }
+    }
+}

--- a/apiv2/src/plan-marketing/plan-marketing.module.ts
+++ b/apiv2/src/plan-marketing/plan-marketing.module.ts
@@ -34,6 +34,7 @@ import { EnvoyerCampagne } from "./core/useCase/EnvoyerCampagne";
 import { CampagneContactBuilderService } from "./core/service/CampagneContactBuilder.service";
 import { CampagneProcessorService } from "./core/service/CampagneProcessor.service";
 import { CampagneDataFetcherService } from "./core/service/CampagneDataFetcher.service";
+import { EnvoyerCampagneProgrammee } from "./core/useCase/cron/EnvoyerCampagneProgrammee";
 
 @Module({
     imports: [ConfigModule, TaskModule, DatabaseModule, AnalyticsModule, AdminModule],
@@ -77,6 +78,22 @@ import { CampagneDataFetcherService } from "./core/service/CampagneDataFetcher.s
         CampagneContactBuilderService,
         CampagneProcessorService,
         CampagneDataFetcherService,
+        EnvoyerCampagneProgrammee,
+    ],
+    exports: [
+        EnvoyerCampagneProgrammee,
+        PreparerEnvoiCampagne,
+        CreerListeDiffusion,
+        ImporterContacts,
+        {
+            provide: CampagneGateway,
+            useClass: CampagneMongoRepository,
+        },
+        {
+            provide: ListeDiffusionGateway,
+            useClass: ListeDiffusionMongoRepository,
+        },
+        planMarketingFactory,
     ],
 })
 export class PlanMarketingModule {}

--- a/apiv2/src/shared/infra/Queue.ts
+++ b/apiv2/src/shared/infra/Queue.ts
@@ -4,6 +4,7 @@ export enum QueueName {
     EMAIL = "email",
     CONTACT = "contact",
     ADMIN_TASK = "admin-task",
+    CRON = "cron-v2",
 }
 
 export type TaskQueue = Pick<TaskModel, "id" | "name">;

--- a/apiv2/src/shared/infra/TechnicalException.ts
+++ b/apiv2/src/shared/infra/TechnicalException.ts
@@ -6,6 +6,7 @@ export enum TechnicalExceptionType {
     NOT_IMPLEMENTED_YET = "NOT_IMPLEMENTED_YET",
     BREVO = "BREVO",
     DATABASE_ERROR = "DATABASE_ERROR",
+    CRON_JOB_NOT_HANDLED = "CRON_JOB_NOT_HANDLED",
 }
 
 export class TechnicalException extends HttpException {

--- a/apiv2/test/admin/sejour/phase1/desistement/Desistement.controller.spec.ts
+++ b/apiv2/test/admin/sejour/phase1/desistement/Desistement.controller.spec.ts
@@ -86,8 +86,6 @@ describe("DesistementController", () => {
                 affectationTaskId: affectationTask.id,
             });
 
-            console.log(response.body);
-
             expect(response.status).toBe(201);
             expect(response.body.name).toBe(TaskName.DESISTEMENT_POST_AFFECTATION_SIMULATION);
             expect(response.body.status).toBe(TaskStatus.PENDING);

--- a/apiv2/test/architecture/Architecture.spec.ts
+++ b/apiv2/test/architecture/Architecture.spec.ts
@@ -127,13 +127,15 @@ describe("Architecture test", () => {
     });
 
     describe("BullMQ", () => {
-        it("Consumer should be in jobModule", () => {
+        it("Consumer should be in jobModule or in CronModule", () => {
             classes()
                 .that()
                 .haveSimpleNameEndingWith(MatchingPattern.CONSUMER_SUFFIX)
                 .should()
                 .onlyHaveDependentClassesThat()
                 .haveSimpleNameEndingWith(MatchingPattern.JOB_MODULE_SUFFIX)
+                .orShould()
+                .haveSimpleNameEndingWith(MatchingPattern.CRON_CONSUMER_SUFFIX)
                 .andShould()
                 .dependOnClassesThat()
                 .resideInAPackage(MatchingPattern.NESTJS_BULLMQ)

--- a/apiv2/test/architecture/MatchingPattern.ts
+++ b/apiv2/test/architecture/MatchingPattern.ts
@@ -9,6 +9,7 @@ export enum MatchingPattern {
     FACTORY_SUFFIX = ".factory.ts",
     PRODUCER_SUFFIX = ".producer.ts",
     JOB_MODULE_SUFFIX = "Job.module.ts",
+    CRON_CONSUMER_SUFFIX = "CronJob.consumer.ts",
 
     ADMIN_CORE = "src.admin.core..",
     ADMIN_USECASE = "src.admin..core..useCase..",


### PR DESCRIPTION
- même principe que sur l'apiv1 : via des Job Scheduler de BullMQ
- le mapping NOM_JOB/USE_CASE est fait dans : [CronJobSelector.service.ts](https://github.com/betagouv/service-national-universel/pull/4912/files#diff-e3daabda32efc2e5bfb5d3dcda51b15c55fa4af312770496d41018fd355c2188)
- Suppression des job cron dans : [CronJobScheduler.service.ts](https://github.com/betagouv/service-national-universel/pull/4912/files#diff-a267f546d9b09dd8a83cb0b1fa5c7161afda2c1fcdba039170c68776dbe9283b)

https://www.notion.so/jeveuxaider/Cron-sur-APIV2-pour-PMR-lot-3-1d072a322d50800c9f12d54a1cfe265f?pvs=4