### PR TITLE
refactor(api): Simplifier davantage le cron de validation phase 1

### DIFF
--- a/api/src/crons/autoValidatePhase1/index.ts
+++ b/api/src/crons/autoValidatePhase1/index.ts
@@ -8,12 +8,6 @@ const title = "Autovalidation de la phase 1";
 export const handler = async (date = new Date()): Promise<void> => {
   try {
     const cohortesEnCours = await getSejoursEnCoursDeRealisation(date);
-    if (!cohortesEnCours.length) {
-      slack.info({ title, text: "Aucune cohorte en cours" });
-      return;
-    }
-    slack.info({ title, text: `Cohortes en cours : ${cohortesEnCours.map((cohort) => cohort.name)}` });
-
     const cohortesAValider = cohortesEnCours.filter((c) => isCohortValidationDateToday(c, date));
     if (!cohortesAValider.length) {
       slack.info({ title, text: "Aucune cohorte à valider aujourd'hui" });

--- a/api/src/crons/autoValidatePhase1/repository.ts
+++ b/api/src/crons/autoValidatePhase1/repository.ts
@@ -12,11 +12,11 @@ export async function getSejoursEnCoursDeRealisation(date: Date): Promise<Cohort
   });
 }
 
-export function getYoungCursorByCohortId(cohortId: string) {
+export function getCursorPourJeunesAValiderByCohortId(cohortId: string) {
   return YoungModel.find({
     cohortId,
     status: YOUNG_STATUS.VALIDATED,
     statusPhase1: YOUNG_STATUS_PHASE1.AFFECTED,
-    cohesionStayPresence: { $in: ["true", "false"] },
+    cohesionStayPresence: { $in: ["true", "false"] }, // On ne prend pas les volontaires qui n'ont pas encore été pointés, ils seront validés manuellement par le chef de centre.
   }).cursor();
 }

--- a/api/src/crons/autoValidatePhase1/repository.ts
+++ b/api/src/crons/autoValidatePhase1/repository.ts
@@ -13,5 +13,10 @@ export async function getSejoursEnCoursDeRealisation(date: Date): Promise<Cohort
 }
 
 export function getYoungCursorByCohortId(cohortId: string) {
-  return YoungModel.find({ cohortId, status: YOUNG_STATUS.VALIDATED, statusPhase1: YOUNG_STATUS_PHASE1.AFFECTED }).cursor();
+  return YoungModel.find({
+    cohortId,
+    status: YOUNG_STATUS.VALIDATED,
+    statusPhase1: YOUNG_STATUS_PHASE1.AFFECTED,
+    cohesionStayPresence: { $in: ["true", "false"] },
+  }).cursor();
 }

--- a/api/src/crons/autoValidatePhase1/service.ts
+++ b/api/src/crons/autoValidatePhase1/service.ts
@@ -1,46 +1,32 @@
 import { logger } from "../../logger";
-import { CohortDocument, SessionPhase1Model, YoungDocument } from "../../models";
+import { CohortDocument, YoungDocument } from "../../models";
 import { addDays, isSameDay } from "date-fns";
 import { getYoungCursorByCohortId } from "./repository";
-import { getDepartureDate } from "snu-lib";
 import { updateStatusPhase1 } from "../../sessionPhase1/validation/sessionPhase1ValidationService";
 
 const user = { firstName: "[CRON] Autovalidation de la phase 1" };
 
-export async function processCohort(cohort: CohortDocument, date: Date): Promise<number> {
+export function isCohortValidationDateToday(cohort: CohortDocument, date: Date): boolean {
+  const dateDebut = cohort.dateStart;
+  const daysToValidate = cohort.daysToValidate || 8;
+  const dateValidation = addDays(dateDebut, daysToValidate);
+  return isSameDay(date, dateValidation);
+}
+
+export async function processCohort(cohort: CohortDocument, dateValidation: Date): Promise<number> {
   logger.info(`Autovalidation de la phase 1 pour la cohorte ${cohort.name} au ${cohort.daysToValidate}e jour après l'arrivée`);
   const cursor = getYoungCursorByCohortId(cohort._id);
   let updateCount = 0;
   await cursor.eachAsync(async (young) => {
-    const wasUpdated = await processYoung(young, cohort, date);
-    if (wasUpdated) updateCount++;
+    await processYoung(young, dateValidation);
+    updateCount++;
   });
   await cursor.close();
   return updateCount;
 }
 
-export async function processYoung(young: YoungDocument, cohort: CohortDocument, date: Date): Promise<boolean> {
-  const sessionPhase1 = await SessionPhase1Model.findById(young.sessionPhase1Id);
-  const dateDebut = getDepartureDate(young, sessionPhase1, cohort);
-  logger.debug(`Jeune ${young._id} - date de début de séjour : ${dateDebut}`);
-
-  const daysToValidate = cohort.daysToValidate || 8;
-  const dateValidation = addDays(dateDebut, daysToValidate);
-  logger.debug(`Jeune ${young._id} - date de validation : ${dateValidation}`);
-
-  logger.debug(`Jeune ${young._id} - date actuelle : ${date}`);
-  if (!isSameDay(date, dateValidation)) {
-    logger.debug(`Jeune ${young._id} - date de validation non atteinte, aucune modification`);
-    return false;
-  }
-
-  if (!young.cohesionStayPresence) {
-    logger.debug(`Jeune ${young._id} - présence au séjour non renseignée, aucune modification`);
-    return false;
-  }
-
-  logger.debug(`Jeune ${young._id} - date de validation atteinte, mise à jour du statut`);
+export async function processYoung(young: YoungDocument, dateValidation: Date): Promise<YoungDocument> {
   const updatedYoung = await updateStatusPhase1(young, dateValidation, user);
   logger.debug(`Jeune ${young._id} - statut de la phase 1 mis à jour : ${updatedYoung.statusPhase1}`);
-  return true;
+  return updatedYoung;
 }

--- a/api/src/crons/autoValidatePhase1/service.ts
+++ b/api/src/crons/autoValidatePhase1/service.ts
@@ -1,32 +1,21 @@
 import { logger } from "../../logger";
-import { CohortDocument, YoungDocument } from "../../models";
-import { addDays, isSameDay } from "date-fns";
-import { getYoungCursorByCohortId } from "./repository";
+import { CohortDocument } from "../../models";
+import { getCursorPourJeunesAValiderByCohortId } from "./repository";
 import { updateStatusPhase1 } from "../../sessionPhase1/validation/sessionPhase1ValidationService";
+import { UserDto } from "snu-lib";
 
-const user = { firstName: "[CRON] Autovalidation de la phase 1" };
-
-export function isCohortValidationDateToday(cohort: CohortDocument, date: Date): boolean {
-  const dateDebut = cohort.dateStart;
-  const daysToValidate = cohort.daysToValidate || 8;
-  const dateValidation = addDays(dateDebut, daysToValidate);
-  return isSameDay(date, dateValidation);
-}
-
-export async function processCohort(cohort: CohortDocument, dateValidation: Date): Promise<number> {
+export async function processCohort(cohort: CohortDocument, dateValidation: Date, user: Partial<UserDto>): Promise<number> {
   logger.info(`Autovalidation de la phase 1 pour la cohorte ${cohort.name} au ${cohort.daysToValidate}e jour après l'arrivée`);
-  const cursor = getYoungCursorByCohortId(cohort._id);
-  let updateCount = 0;
+  const cursor = getCursorPourJeunesAValiderByCohortId(cohort._id);
+  let count = 0;
   await cursor.eachAsync(async (young) => {
-    await processYoung(young, dateValidation);
-    updateCount++;
+    try {
+      await updateStatusPhase1(young, dateValidation, user);
+      count++;
+    } catch (error) {
+      logger.error(`Erreur lors de la validation automatique de la phase 1 pour le volontaire ${young._id} : ${error.message}`);
+    }
   });
   await cursor.close();
-  return updateCount;
-}
-
-export async function processYoung(young: YoungDocument, dateValidation: Date): Promise<YoungDocument> {
-  const updatedYoung = await updateStatusPhase1(young, dateValidation, user);
-  logger.debug(`Jeune ${young._id} - statut de la phase 1 mis à jour : ${updatedYoung.statusPhase1}`);
-  return updatedYoung;
+  return count;
 }

--- a/api/src/crons/autoValidatePhase1/utils.ts
+++ b/api/src/crons/autoValidatePhase1/utils.ts
@@ -1,0 +1,9 @@
+import { addDays, isSameDay } from "date-fns";
+import { CohortDocument } from "../../models";
+
+export function isCohortValidationDateToday(cohort: CohortDocument, date: Date): boolean {
+  const dateDebut = cohort.dateStart;
+  const daysToValidate = cohort.daysToValidate || 8;
+  const dateValidation = addDays(dateDebut, daysToValidate);
+  return isSameDay(date, dateValidation);
+}

--- a/api/src/sessionPhase1/validation/sessionPhase1ValidationService.ts
+++ b/api/src/sessionPhase1/validation/sessionPhase1ValidationService.ts
@@ -38,7 +38,8 @@ export async function updateStatusPhase1(young: YoungDocument, validationDate: s
   const { shouldValidate, message } = shouldValidatePhase1(young, validationDate);
 
   if (shouldValidate) {
-    young.set({ statusPhase1: YOUNG_STATUS_PHASE1.DONE, statusPhase2OpenedAt: new Date() });
+    young.set({ statusPhase1: YOUNG_STATUS_PHASE1.DONE });
+    if (!young.statusPhase2OpenedAt) young.set({ statusPhase2OpenedAt: new Date() });
   } else {
     const note = {
       note: `Phase 1 non validée pour la raison suivante : ${message}.`,
@@ -56,6 +57,9 @@ export async function updateStatusPhase1(young: YoungDocument, validationDate: s
 }
 
 export function shouldValidatePhase1(young: YoungDocument, validationDate: Date | string): { shouldValidate: boolean; message?: string } {
+  if (!young.cohesionStayPresence) {
+    throw new Error(`La présence au séjour n'est pas définie pour le jeune ${young._id}`);
+  }
   if (young.cohesionStayPresence === "false") {
     return { shouldValidate: false, message: "Le volontaire a été pointé absent au séjour" };
   }


### PR DESCRIPTION
**Description**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? screenshot? -->

**Todo**

- [x] Passer à une logique globale (par séjour) de dates d'arrivée et de validation au lieu de vérifier par volontaire.
- [x] N'itérer que sur les volontaires ayant été pointés (que ce soit présent ou absent).
- [x] Bugfixes

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Bug-Script-autovalidation-phase-1-n-est-pas-pass-1cf72a322d5080dda3b7c464298f45f8?pvs=4

**Testing instructions**
