### PR TITLE
fix(admin): 280 - Corriger le comportement du formulaire d'édition de classe

### DIFF
--- a/admin/src/scenes/classe/view/Details.tsx
+++ b/admin/src/scenes/classe/view/Details.tsx
@@ -135,7 +135,7 @@ export default function Details(props) {
       }
       setClasse(data);
       handleModiferReferent({ nom: classe.referents[0].lastName, prenom: classe.referents[0].firstName, email: classe.referents[0].email });
-      handleCancel();
+      closeForm();
       toastr.success("Succès", "La classe a bien été modifié");
     } catch (e) {
       capture(e);
@@ -145,12 +145,17 @@ export default function Details(props) {
     }
   };
 
-  const handleCancel = () => {
+  const closeForm = () => {
     setEdit(false);
     setEditRef(false);
     setEditStay(false);
     setIsLoading(false);
     setErrors({});
+  };
+
+  const reset = () => {
+    setClasse(props.classe);
+    closeForm();
   };
 
   if (!classe) return <Loader />;
@@ -167,7 +172,7 @@ export default function Details(props) {
         rights={rights}
         cohorts={cohorts}
         user={user}
-        onCancel={handleCancel}
+        onCancel={reset}
         onCheckInfo={checkInfo}
         isLoading={isLoading}
         setIsLoading={setIsLoading}
@@ -186,7 +191,7 @@ export default function Details(props) {
           errors={errors}
           user={user}
           infoBus={infoBus}
-          onCancel={handleCancel}
+          onCancel={reset}
           isLoading={isLoading}
           onSendInfo={sendInfo}
         />


### PR DESCRIPTION
**Description**

Cliquer sur “Annuler” ne remet pas les informations de départ dans le formulaire.

**Todo**

- [x] Ajouter la fonction de reset des informations en utilisant le prop du parent.
- [x] Distinguer les logiques fermer le formulaire/reset le formulaire (pour ne pas pas reset en cas de validation des changements).

**Checklist**

- [x] **⚠️ My code can have side-effects on other part of the code-base**
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Bug-affichage-redirection-apr-s-action-de-modification-classe-19d72a322d50808c8a7fd536f1d883fe?pvs=4

**Testing instructions**

Modifier la classe 668ea36dc269e600463e8297
