### PR TITLE
fix(admin): 624 - afficher l'heure du traitement dans la modale de selection des désistements de masse

### DIFF
--- a/admin/src/scenes/settings/operations/actions/Desistement/SimulationDesistementModal.tsx
+++ b/admin/src/scenes/settings/operations/actions/Desistement/SimulationDesistementModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { HiOutlineLightningBolt } from "react-icons/hi";
-import { CohortDto, formatDateFR, TaskName, translateSimulationName } from "snu-lib";
+import { CohortDto, TaskName, translateSimulationName, formatLongDateFR, getZonedDate } from "snu-lib";
 import { Button, Modal, Select } from "@snu/ds/admin";
 import useTraitements from "../../hooks/useTraitements";
 import dayjs from "dayjs";
@@ -13,7 +13,7 @@ export default function SimulationDesistementModal({ session, onClose }: { sessi
 
   const options = traitements?.map((t) => ({
     value: t.id,
-    label: `${translateSimulationName(t.name)} - ${formatDateFR(dayjs(t.createdAt))}`,
+    label: `${translateSimulationName(t.name)} - ${formatLongDateFR(getZonedDate(t.createdAt))}`,
   }));
   const sortedTraitements = traitements?.sort((a, b) => dayjs(b.createdAt).diff(dayjs(a.createdAt)));
   const selectedTraitement = selectedOption ? sortedTraitements?.find((t) => t.id === selectedOption) : sortedTraitements?.[0];


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Afficher-l-heure-de-traitement-dans-la-modale-de-s-lection-des-d-sistements-en-masse-1cf72a322d508061bf2cee5284dd9252?pvs=4