### PR TITLE
fix(api): 694 - dans la génération des convocs et certificate, on prend UTC+00 comme base

### DIFF
--- a/api/src/utils/cohort.ts
+++ b/api/src/utils/cohort.ts
@@ -186,13 +186,11 @@ export function getDepartureDateSession(session, young, cohort) {
 export function getReturnDateSession(session, young, cohort) {
   if (session?.dateEnd) {
     const sessionDateEnd = new Date(session.dateEnd);
-    sessionDateEnd.setHours(sessionDateEnd.getHours() + 12);
     return sessionDateEnd;
   }
   if (young?.cohort === "Juillet 2023" && [...regionsListDROMS, "Polynésie française"].includes(young.region)) {
     return new Date(2023, 6, 16);
   }
   const cohortDateEnd = new Date(cohort?.dateEnd);
-  cohortDateEnd.setHours(cohortDateEnd.getHours() + 12);
-  return new Date(cohortDateEnd);
+  return cohortDateEnd;
 }

--- a/api/src/young/youngCertificateService.ts
+++ b/api/src/young/youngCertificateService.ts
@@ -27,8 +27,6 @@ export const fetchDataForYoungCertificate = async (young: YoungDto) => {
 
   const cohort = await CohortModel.findOne({ name: young.cohort });
   if (!cohort) throw new Error(`cohort ${young.cohort} not found for young ${young._id}`);
-  cohort.dateStart.setMinutes(cohort.dateStart.getMinutes() - cohort.dateStart.getTimezoneOffset());
-  cohort.dateEnd.setMinutes(cohort.dateEnd.getMinutes() - cohort.dateEnd.getTimezoneOffset());
 
   let service = null;
   if (young.source !== "CLE") {

--- a/packages/lib/src/transport-info.ts
+++ b/packages/lib/src/transport-info.ts
@@ -109,9 +109,9 @@ function getReturnHour(meetingPoint: any = null) {
  */
 const transportDatesToString = (departureDate, returnDate) => {
   if (departureDate.getMonth() === returnDate.getMonth()) {
-    return `du ${departureDate.getDate()} au ${returnDate.getDate()} ${departureDate.toLocaleString("fr", { month: "long", year: "numeric" })}`;
+    return `du ${departureDate.getUTCDate()} au ${returnDate.getUTCDate()} ${departureDate.toLocaleString("fr", { month: "long", year: "numeric" })}`;
   }
-  return `du ${departureDate.getDate()} ${departureDate.toLocaleString("fr", { month: "long" })} au ${returnDate.getDate()} ${returnDate.toLocaleString("fr", {
+  return `du ${departureDate.getUTCDate()} ${departureDate.toLocaleString("fr", { month: "long" })} au ${returnDate.getUTCDate()} ${returnDate.toLocaleString("fr", {
     month: "long",
     year: "numeric",
   })}`;


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/HTS-CLE-Mauvaise-date-de-retour-sur-les-convocations-les-attestations-de-phase-1-des-jeunes-J--1df72a322d5080ffa377e0460f664440?pvs=4

La generation des convocs et certificat prenaieent en compte le décalage horaires pour ecrire les date de début et de fin de séjour. 
La RUN a passé toutes les dates de fin de cohortes a 21h00 UTC au lieu de minuit, ce qui a provoqué des erreurs dans les génerations des convocs. 

Solution -> On n'a pas besoin de prendre en compte le décalage horaire pour ces document, étant donné que seul le jour est utilisé. Un séjour se termine le 2 mai, qu'on soit en france ou a la Reunion
