### PR TITLE
fix(admin): 797 - petit fix pour bien reset les infos de la cohort avant d'en changer dans les params dynamiques

### DIFF
--- a/admin/src/components/ui/forms/dateForm/DatePickerInput.tsx
+++ b/admin/src/components/ui/forms/dateForm/DatePickerInput.tsx
@@ -26,9 +26,10 @@ export default function DatePickerWrapper({ label, value, onChange, disabled = f
 
   useEffect(() => {
     handleChange(value);
-  }, [time]);
+  }, [time, value]);
 
   const handleChange = (date) => {
+    console.log("DatePickerWrapper handleChange called with:", date);
     if (!date) return undefined;
     if (!isTime || mode !== "single") return onChange(date);
 

--- a/admin/src/components/ui/forms/dateForm/DatePickerInput.tsx
+++ b/admin/src/components/ui/forms/dateForm/DatePickerInput.tsx
@@ -26,10 +26,9 @@ export default function DatePickerWrapper({ label, value, onChange, disabled = f
 
   useEffect(() => {
     handleChange(value);
-  }, [time, value]);
+  }, [time]);
 
   const handleChange = (date) => {
-    console.log("DatePickerWrapper handleChange called with:", date);
     if (!date) return undefined;
     if (!isTime || mode !== "single") return onChange(date);
 

--- a/admin/src/scenes/settings/eligibility/EligibilityTab.tsx
+++ b/admin/src/scenes/settings/eligibility/EligibilityTab.tsx
@@ -6,7 +6,6 @@ import ButtonPrimary from "@/components/ui/buttons/ButtonPrimary";
 import { BiLoaderAlt } from "react-icons/bi";
 import { toastr } from "react-redux-toastr";
 import { capture } from "@/sentry";
-import api from "@/services/api";
 import { IoWarningOutline } from "react-icons/io5";
 import ReactTooltip from "react-tooltip";
 import { useUpdateEligibilityMutation } from "@/scenes/settings/general/hooks/useCohortUpdate";

--- a/admin/src/scenes/settings/general/components/InfosAffectation.tsx
+++ b/admin/src/scenes/settings/general/components/InfosAffectation.tsx
@@ -3,6 +3,7 @@ import { MdInfoOutline } from "react-icons/md";
 import ReactTooltip from "react-tooltip";
 import { Controller, useForm } from "react-hook-form";
 import { HiOutlineExclamation } from "react-icons/hi";
+import cx from "classnames";
 
 import { COHORT_TYPE, CohortDto } from "snu-lib";
 import NumberInput from "@/components/ui/forms/NumberInput";
@@ -93,7 +94,7 @@ export default function InfosAffectations({ cohort, readOnly }: AffectationsProp
   };
 
   return (
-    <Container className={`${isDirty && "outline outline-2 outline-blue-600"}`}>
+    <Container className={cx({ "outline outline-2 outline-blue-600": isDirty })}>
       <div className="flex w-full flex-col gap-8">
         <p className="text-lg font-medium leading-5 text-gray-900">Affectation et pointage (phase 1)</p>
         <div className="flex">

--- a/admin/src/scenes/settings/general/components/general/InfosGenerales.tsx
+++ b/admin/src/scenes/settings/general/components/general/InfosGenerales.tsx
@@ -3,6 +3,7 @@ import { MdInfoOutline } from "react-icons/md";
 import { HiOutlineExclamation } from "react-icons/hi";
 import ReactTooltip from "react-tooltip";
 import { Controller, useForm } from "react-hook-form";
+import cx from "classnames";
 
 import { COHORT_TYPE, COHORT_STATUS, CohortDto } from "snu-lib";
 import InputText from "@/components/ui/forms/InputText";
@@ -64,7 +65,7 @@ export default function InfosGenerales({ cohort, readOnly }: InfosGeneralesProps
   ];
 
   return (
-    <Container className={`${isDirty && "outline outline-2 outline-blue-600"}`}>
+    <Container className={cx({ "outline outline-2 outline-blue-600": isDirty })}>
       <div className="flex w-full flex-col gap-8">
         <p className="text-lg font-medium leading-5 text-gray-900">Informations générales</p>
         <div className="flex">

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -3,6 +3,7 @@ import { MdInfoOutline } from "react-icons/md";
 import ReactTooltip from "react-tooltip";
 import { Controller, useForm } from "react-hook-form";
 import { HiOutlineExclamation } from "react-icons/hi";
+import cx from "classnames";
 
 import { COHORT_TYPE, CohortDto, INSCRIPTION_GOAL_LEVELS } from "snu-lib";
 import { Button, Container } from "@snu/ds/admin";
@@ -76,7 +77,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
   };
 
   return (
-    <Container className={`${isDirty && "outline outline-2 outline-blue-600"}`}>
+    <Container className={cx({ "outline outline-2 outline-blue-600": isDirty })}>
       <div className="flex flex-col w-full gap-8">
         <p className="text-gray-900 leading-5 text-lg font-medium">Inscriptions (phase 0)</p>
         <div className="flex">

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -43,7 +43,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
     reset,
   } = useForm<InscriptionsFormData>({
     defaultValues: {
-      inscriptionStartDate: cohort.inscriptionStartDate,
+      inscriptionStartDate: cohort.inscriptionStartDate ? dayjs(cohort.inscriptionStartDate).local().toDate() : undefined,
       inscriptionEndDate: cohort.inscriptionEndDate,
       reInscriptionStartDate: cohort.reInscriptionStartDate,
       reInscriptionEndDate: cohort.reInscriptionEndDate,
@@ -118,9 +118,9 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                     label="Ouverture"
                     placeholder="Date et heure"
                     // @ts-ignore
-                    value={field.value ? dayjs(field.value).local().toDate() : null}
+                    value={field.value ? dayjs(field.value).toDate() : null}
                     error={errors.inscriptionStartDate?.message}
-                    onChange={(value) => field.onChange(value)}
+                    onChange={(value) => field.onChange(value ? dayjs(value).format() : undefined)}
                     readOnly={readOnly}
                     disabled={isSubmitting}
                   />

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { MdInfoOutline } from "react-icons/md";
 import ReactTooltip from "react-tooltip";
 import { Controller, useForm } from "react-hook-form";
@@ -63,27 +63,6 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
   const [showSpecificDatesReInscription, setShowSpecificDatesReInscription] = useState(!!(cohort.reInscriptionStartDate || cohort.reInscriptionEndDate));
   const updateCohorteInscriptionsMutation = useUpdateCohortInscriptions();
 
-  useEffect(() => {
-    console.log("Normalized default values:", normalizedDefaultValues);
-    if (isDirty) {
-      console.log("Form is dirty. Dirty fields:", dirtyFields);
-      console.log("Original values:", {
-        inscriptionStartDate: cohort.inscriptionStartDate,
-        inscriptionEndDate: cohort.inscriptionEndDate,
-        inscriptionModificationEndDate: cohort.inscriptionModificationEndDate,
-        instructionEndDate: cohort.instructionEndDate,
-      });
-      console.log("Current form values:", {
-        inscriptionStartDate: control._formValues.inscriptionStartDate,
-        inscriptionEndDate: control._formValues.inscriptionEndDate,
-        inscriptionModificationEndDate: control._formValues.inscriptionModificationEndDate,
-        instructionEndDate: control._formValues.instructionEndDate,
-      });
-    } else {
-      console.log("Form is NOT dirty - solution appears to be working!");
-    }
-  }, [isDirty, dirtyFields, cohort, control._formValues]);
-
   function normalizeDate(dateValue) {
     if (!dateValue) return undefined;
     return new Date(dateValue);
@@ -133,10 +112,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                     // @ts-ignore
                     value={field.value}
                     error={errors.inscriptionStartDate?.message}
-                    onChange={(value) => {
-                      console.log("Date changed:", value);
-                      field.onChange(value);
-                    }}
+                    onChange={(value) => field.onChange(value)}
                     readOnly={readOnly}
                     disabled={isSubmitting}
                   />
@@ -153,7 +129,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                     label="Fermeture"
                     placeholder="Date et heure"
                     // @ts-ignore
-                    value={field.value ? dayjs(field.value).local().toDate() : null}
+                    value={field.value}
                     onChange={(value) => field.onChange(value)}
                     readOnly={readOnly}
                     disabled={isSubmitting}
@@ -172,7 +148,6 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                 disabled={isSubmitting || readOnly}
                 value={!!showSpecificDatesReInscription}
                 onChange={(v) => {
-                  console.log("Toggle changed to:", v, "Previous state:", showSpecificDatesReInscription);
                   if (v == false) {
                     setValue("reInscriptionStartDate", null, { shouldDirty: true });
                     setValue("reInscriptionEndDate", null, { shouldDirty: true });
@@ -193,7 +168,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                         label="Ouverture"
                         placeholder="Date et heure"
                         // @ts-ignore
-                        value={field.value ? dayjs(field.value).local().toDate() : null}
+                        value={field.value}
                         error={errors.reInscriptionStartDate?.message}
                         onChange={(value) => field.onChange(value)}
                         readOnly={readOnly}
@@ -211,7 +186,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                         label="Fermeture"
                         placeholder="Date et heure"
                         // @ts-ignore
-                        value={field.value ? dayjs(field.value).local().toDate() : null}
+                        value={field.value}
                         error={errors.reInscriptionEndDate?.message}
                         onChange={(value) => field.onChange(value)}
                         readOnly={readOnly}
@@ -254,7 +229,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                       label="Fermeture"
                       placeholder="Date"
                       // @ts-ignore
-                      value={field.value ? dayjs(field.value).local().toDate() : null}
+                      value={field.value}
                       onChange={(value) => field.onChange(value)}
                       readOnly={readOnly}
                       disabled={isSubmitting}
@@ -287,7 +262,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                       label="Fermeture"
                       placeholder="Date"
                       // @ts-ignore
-                      value={field.value ? dayjs(field.value).local().toDate() : null}
+                      value={field.value}
                       onChange={(value) => field.onChange(value)}
                       readOnly={readOnly}
                       disabled={isSubmitting}

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -43,7 +43,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
     reset,
   } = useForm<InscriptionsFormData>({
     defaultValues: {
-      inscriptionStartDate: cohort.inscriptionStartDate ? dayjs(cohort.inscriptionStartDate).local().toDate() : undefined,
+      inscriptionStartDate: cohort.inscriptionStartDate,
       inscriptionEndDate: cohort.inscriptionEndDate,
       reInscriptionStartDate: cohort.reInscriptionStartDate,
       reInscriptionEndDate: cohort.reInscriptionEndDate,
@@ -118,9 +118,9 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                     label="Ouverture"
                     placeholder="Date et heure"
                     // @ts-ignore
-                    value={field.value ? dayjs(field.value).toDate() : null}
+                    value={field.value}
                     error={errors.inscriptionStartDate?.message}
-                    onChange={(value) => field.onChange(value ? dayjs(value).format() : undefined)}
+                    onChange={(value) => field.onChange(value)}
                     readOnly={readOnly}
                     disabled={isSubmitting}
                   />

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -120,7 +120,10 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                     // @ts-ignore
                     value={field.value}
                     error={errors.inscriptionStartDate?.message}
-                    onChange={(value) => field.onChange(value)}
+                    onChange={(value) => {
+                      console.log("Date changed:", value);
+                      field.onChange(value);
+                    }}
                     readOnly={readOnly}
                     disabled={isSubmitting}
                   />

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -66,12 +66,16 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
     if (isDirty) {
       console.log("Form is dirty. Dirty fields:", dirtyFields);
       console.log("Original values:", {
-        reInscriptionStartDate: cohort.reInscriptionStartDate,
-        reInscriptionEndDate: cohort.reInscriptionEndDate,
+        inscriptionStartDate: cohort.inscriptionStartDate,
+        inscriptionEndDate: cohort.inscriptionEndDate,
+        inscriptionModificationEndDate: cohort.inscriptionModificationEndDate,
+        instructionEndDate: cohort.instructionEndDate,
       });
       console.log("Current form values:", {
-        reInscriptionStartDate: control._formValues.reInscriptionStartDate,
-        reInscriptionEndDate: control._formValues.reInscriptionEndDate,
+        inscriptionStartDate: control._formValues.inscriptionStartDate,
+        inscriptionEndDate: control._formValues.inscriptionEndDate,
+        inscriptionModificationEndDate: control._formValues.inscriptionModificationEndDate,
+        instructionEndDate: control._formValues.instructionEndDate,
       });
     }
   }, [isDirty, dirtyFields, cohort, control._formValues]);

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { MdInfoOutline } from "react-icons/md";
 import ReactTooltip from "react-tooltip";
 import { Controller, useForm } from "react-hook-form";
@@ -61,6 +61,20 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
   const isNotSaved = isDirty && !isSubmitting;
   const [showSpecificDatesReInscription, setShowSpecificDatesReInscription] = useState(!!(cohort.reInscriptionStartDate || cohort.reInscriptionEndDate));
   const updateCohorteInscriptionsMutation = useUpdateCohortInscriptions();
+
+  useEffect(() => {
+    if (isDirty) {
+      console.log("Form is dirty. Dirty fields:", dirtyFields);
+      console.log("Original values:", {
+        reInscriptionStartDate: cohort.reInscriptionStartDate,
+        reInscriptionEndDate: cohort.reInscriptionEndDate,
+      });
+      console.log("Current form values:", {
+        reInscriptionStartDate: control._formValues.reInscriptionStartDate,
+        reInscriptionEndDate: control._formValues.reInscriptionEndDate,
+      });
+    }
+  }, [isDirty, dirtyFields, cohort, control._formValues]);
 
   const handleOnCancel = () => {
     reset();
@@ -142,6 +156,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
                 disabled={isSubmitting || readOnly}
                 value={!!showSpecificDatesReInscription}
                 onChange={(v) => {
+                  console.log("Toggle changed to:", v, "Previous state:", showSpecificDatesReInscription);
                   if (v == false) {
                     setValue("reInscriptionStartDate", null, { shouldDirty: true });
                     setValue("reInscriptionEndDate", null, { shouldDirty: true });

--- a/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
+++ b/admin/src/scenes/settings/general/components/phase0/InfosInscriptions.tsx
@@ -35,6 +35,20 @@ interface InscriptionsProps {
 }
 
 export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProps) {
+  const normalizedDefaultValues = {
+    inscriptionStartDate: normalizeDate(cohort.inscriptionStartDate),
+    inscriptionEndDate: normalizeDate(cohort.inscriptionEndDate),
+    reInscriptionStartDate: normalizeDate(cohort.reInscriptionStartDate),
+    reInscriptionEndDate: normalizeDate(cohort.reInscriptionEndDate),
+    inscriptionModificationEndDate: normalizeDate(cohort.inscriptionModificationEndDate),
+    instructionEndDate: normalizeDate(cohort.instructionEndDate),
+    youngHTSBasculeLPDisabled: cohort.youngHTSBasculeLPDisabled,
+    objectifLevel: cohort.objectifLevel,
+    inscriptionOpenForReferentRegion: cohort.inscriptionOpenForReferentRegion,
+    inscriptionOpenForReferentDepartment: cohort.inscriptionOpenForReferentDepartment,
+    inscriptionOpenForReferentClasse: cohort.inscriptionOpenForReferentClasse,
+    inscriptionOpenForAdministrateurCle: cohort.inscriptionOpenForAdministrateurCle,
+  };
   const {
     control,
     setValue,
@@ -42,20 +56,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
     formState: { errors, isDirty, isSubmitting, dirtyFields },
     reset,
   } = useForm<InscriptionsFormData>({
-    defaultValues: {
-      inscriptionStartDate: cohort.inscriptionStartDate,
-      inscriptionEndDate: cohort.inscriptionEndDate,
-      reInscriptionStartDate: cohort.reInscriptionStartDate,
-      reInscriptionEndDate: cohort.reInscriptionEndDate,
-      inscriptionModificationEndDate: cohort.inscriptionModificationEndDate,
-      instructionEndDate: cohort.instructionEndDate,
-      youngHTSBasculeLPDisabled: cohort.youngHTSBasculeLPDisabled,
-      objectifLevel: cohort.objectifLevel,
-      inscriptionOpenForReferentRegion: cohort.inscriptionOpenForReferentRegion,
-      inscriptionOpenForReferentDepartment: cohort.inscriptionOpenForReferentDepartment,
-      inscriptionOpenForReferentClasse: cohort.inscriptionOpenForReferentClasse,
-      inscriptionOpenForAdministrateurCle: cohort.inscriptionOpenForAdministrateurCle,
-    },
+    defaultValues: normalizedDefaultValues,
     mode: "onChange",
   });
   const isNotSaved = isDirty && !isSubmitting;
@@ -63,6 +64,7 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
   const updateCohorteInscriptionsMutation = useUpdateCohortInscriptions();
 
   useEffect(() => {
+    console.log("Normalized default values:", normalizedDefaultValues);
     if (isDirty) {
       console.log("Form is dirty. Dirty fields:", dirtyFields);
       console.log("Original values:", {
@@ -77,8 +79,15 @@ export default function InfosInscriptions({ cohort, readOnly }: InscriptionsProp
         inscriptionModificationEndDate: control._formValues.inscriptionModificationEndDate,
         instructionEndDate: control._formValues.instructionEndDate,
       });
+    } else {
+      console.log("Form is NOT dirty - solution appears to be working!");
     }
   }, [isDirty, dirtyFields, cohort, control._formValues]);
+
+  function normalizeDate(dateValue) {
+    if (!dateValue) return undefined;
+    return new Date(dateValue);
+  }
 
   const handleOnCancel = () => {
     reset();

--- a/admin/src/scenes/settings/general/components/phase1/InfosPreparation.tsx
+++ b/admin/src/scenes/settings/general/components/phase1/InfosPreparation.tsx
@@ -3,6 +3,7 @@ import { MdInfoOutline } from "react-icons/md";
 import ReactTooltip from "react-tooltip";
 import { Controller, useForm } from "react-hook-form";
 import { HiOutlineExclamation } from "react-icons/hi";
+import cx from "classnames";
 
 import { COHORT_TYPE, CohortDto } from "snu-lib";
 import { Button, Container } from "@snu/ds/admin";
@@ -88,7 +89,7 @@ export default function InfosPreparation({ cohort, readOnly }: PreparationProps)
     reset(data);
   };
   return (
-    <Container className={`${isDirty && "outline outline-2 outline-blue-600"}`}>
+    <Container className={cx({ "outline outline-2 outline-blue-600": isDirty })}>
       <div className="flex w-full flex-col gap-8">
         <p className="text-lg font-medium leading-5 text-gray-900">Préparation des affectations et des transports (phase 1)</p>
         <div className="flex">


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Bug-Param-tres-dynamiques-sauvegarde-bloc-par-bloc-test-en-live-1fa72a322d5080b98b07ee1cd17723ba?pvs=4

2 issue : le second bloc était toujours "dirty" car on modifiait le format des date dans les input apres les avoir initialisé.
parfois en switchant de cohort dans le selecteur, certaines infos ne s'updatait pas, on avait un mélange des infos de la cohorte sélectionnée et de l'ancienne cohort