### PR TITLE
fix(api): migration pour fusionner les lignes de bus ARA 2025 HTS 03 Juin

### DIFF
--- a/api/migrations/20250522161849-lignesbus-fusion-ara.js
+++ b/api/migrations/20250522161849-lignesbus-fusion-ara.js
@@ -1,0 +1,26 @@
+const { LigneBusModel } = require("../src/models");
+
+const cohortName = "2025 HTS 03 - Juin";
+const fromUser = { firstName: `Correction de lignes fusionnées ARA cohort ${cohortName}` };
+
+module.exports = {
+  async up() {
+    const ligneARA638695 = await LigneBusModel.findOne({ busId: "ARA638695", cohort: cohortName });
+    ligneARA638695.set({ mergedBusIds: ["ARA638695", "ARA638426"] });
+    await ligneARA638695.save({ fromUser });
+
+    const ligneARA638426 = await LigneBusModel.findOne({ busId: "ARA638426", cohort: cohortName });
+    ligneARA638426.set({ mergedBusIds: ["ARA638426", "ARA638695"] });
+    await ligneARA638426.save({ fromUser });
+  },
+
+  async down() {
+    const ligneARA638695 = await LigneBusModel.findOne({ busId: "ARA638695", cohort: cohortName });
+    ligneARA638695.set({ mergedBusIds: [] });
+    await ligneARA638695.save({ fromUser });
+
+    const ligneARA638426 = await LigneBusModel.findOne({ busId: "ARA638426", cohort: cohortName });
+    ligneARA638426.set({ mergedBusIds: [] });
+    await ligneARA638426.save({ fromUser });
+  },
+};


### PR DESCRIPTION
**Description**

Script de migration pour fusionner les lignes "ARA638695" et "ARA638426", session "2025 HTS 03 Juin".

**Todo**

- [x] Faire le script de migration pour les lignes concernées

**Checklist**

- [ ] **⚠️ My code can have side-effects on other part of the code-base**
- [ ] I have added the Plausible tags/events
- [x] I have performed a self-review of my code (and removed console.log)

**Ticket / Issue**

Fixes [Notion ticket #795](https://www.notion.so/jeveuxaider/Fusionner-2-lignes-ARA-1f972a322d5080018091f1346a2808a2?pvs=4)
