### PR TITLE
fix(api): 815 - Ajout des PDR manquants sur les PDT

### DIFF
--- a/api/migrations/20250526153020-815-ajout-pdr-pdt.js
+++ b/api/migrations/20250526153020-815-ajout-pdr-pdt.js
@@ -1,0 +1,50 @@
+const { LigneBusModel, LigneToPointModel, PlanTransportModel, PointDeRassemblementModel } = require("../src/models");
+
+const nouveauPDRid = "63caa1bcf3d20208cd5b5d03";
+const ligneIds = ["67ed4e7b322e805767af0b84", "67ed4e7c322e805767af0bbc", "67ed4e7c322e805767af0bcf"];
+module.exports = {
+  async up(db, client) {
+    const nouveauPDR = await PointDeRassemblementModel.findById(nouveauPDRid);
+    if (!nouveauPDR) {
+      throw new Error(`PDR ${nouveauPDRid} non trouvé`);
+    }
+    for (const ligneId of ligneIds) {
+      const ligne = await LigneBusModel.findById(ligneId);
+      if (!ligne) {
+        throw new Error(`Ligne ${ligneId} non trouvée`);
+      }
+      const ligneToPoint = await LigneToPointModel.findOne({ lineId: ligneId }).lean();
+      if (!ligneToPoint) {
+        throw new Error(`LigneToPoint non trouvée pour la ligne ${ligneId}`);
+      }
+
+      const planTransport = await PlanTransportModel.findById(ligne);
+      const pdrToAdd = {
+        ...nouveauPDR,
+        meetingPointId: nouveauPDRid,
+        transportType: "bus",
+        busArrivalHour: ligneToPoint.busArrivalHour,
+        departureHour: ligneToPoint.departureHour,
+        meetingHour: ligneToPoint.meetingHour,
+        returnHour: ligneToPoint.returnHour,
+      };
+      planTransport.set({ pointDeRassemblements: [...planTransport.pointDeRassemblements, pdrToAdd] });
+      await planTransport.save({ fromUser: { firstName: "815-ajout-pdr-pdt" } });
+    }
+  },
+
+  async down(db, client) {
+    for (const ligneId of ligneIds) {
+      const ligne = await LigneBusModel.findById(ligneId);
+      if (!ligne) {
+        throw new Error(`Ligne ${ligneId} non trouvée`);
+      }
+      const planTransport = await PlanTransportModel.findById(ligne);
+      if (!planTransport) {
+        throw new Error(`PlanTransport non trouvé pour la ligne ${ligneId}`);
+      }
+      planTransport.set({ pointDeRassemblements: planTransport.pointDeRassemblements.filter((pdr) => pdr.meetingPointId !== nouveauPDRid) });
+      await planTransport.save({ fromUser: { firstName: "815-ajout-pdr-pdt" } });
+    }
+  },
+};


### PR DESCRIPTION
**Description**

Impossible de modifier les PDR de la ligne de bus si il n'est pas aussi présent dans le model du PDT.

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

https://www.notion.so/jeveuxaider/Rajout-PDR-2-1fc72a322d5080e3a2b7d46b1554c906

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
