### PR TITLE
fix(api,admin): 827 - bouton renouvellement invitation expirée

### DIFF
--- a/admin/src/scenes/utilisateur/edit/details.jsx
+++ b/admin/src/scenes/utilisateur/edit/details.jsx
@@ -21,8 +21,10 @@ import {
   regionList,
   ROLES,
   translate,
+  isSuperAdmin,
   VISITOR_SUBROLES,
-} from "@/utils";
+} from "snu-lib";
+
 import dayjs from "@/utils/dayjs.utils";
 import UserHeader from "../composants/UserHeader";
 import { Session, CohortSelect, AddButton, SubRoleAndRegionOrDep } from "../composants";
@@ -35,6 +37,7 @@ import ViewStructureLink from "../../../components/buttons/ViewStructureLink";
 import { isPossiblePhoneNumber } from "libphonenumber-js";
 import { Container, Button, Badge, Label, InputText } from "@snu/ds/admin";
 import { isResponsableDeCentre } from "@/utils";
+import RenewInvitation from "./partials/RenewInvitation";
 
 export default function Details({ user, setUser, currentUser }) {
   const [structures, setStructures] = useState([]);
@@ -577,6 +580,7 @@ export default function Details({ user, setUser, currentUser }) {
 
         {canDeleteReferent({ actor: currentUser, originalTarget: user, structure }) && (
           <div className="flex items-center justify-center">
+            {isSuperAdmin(currentUser) && <RenewInvitation userId={user._id} />}
             <BorderButton mode="red" className="mt-3" onClick={onClickDelete}>
               Supprimer le compte
             </BorderButton>

--- a/admin/src/scenes/utilisateur/edit/partials/RenewInvitation.tsx
+++ b/admin/src/scenes/utilisateur/edit/partials/RenewInvitation.tsx
@@ -1,0 +1,26 @@
+import api from "@/services/api";
+import { Button } from "@snu/ds/admin";
+import { useMutation } from "@tanstack/react-query";
+import React from "react";
+import { toastr } from "react-redux-toastr";
+import { formatLongDateFR, translate } from "snu-lib";
+
+export default function RenewInvitation({ userId }: { userId: string }) {
+  const { mutate } = useMutation({
+    mutationFn: async () => {
+      const { ok, code, data } = await api.post(`/referent/${userId}/renew-invitation`);
+      if (!ok) {
+        throw new Error(code);
+      }
+      return data;
+    },
+    onSuccess: (response) => {
+      toastr.success("Date d'expiration d'invitation renouvelée avec succès", formatLongDateFR(response?.invitationExpires));
+    },
+    onError: (error) => {
+      toastr.error("Une erreur est survenue lors du renouvellement de l'invitation", translate(error.message));
+    },
+  });
+
+  return <Button title="Renouveler invitation" type="cancel" className="mt-3 mr-3" onClick={() => mutate()} />;
+}

--- a/api/src/referent/referentController.ts
+++ b/api/src/referent/referentController.ts
@@ -127,6 +127,7 @@ import { authMiddleware } from "../middlewares/authMiddleware";
 import { CohortDocumentWithPlaces } from "../utils/cohort";
 import { handleNotifForYoungWithdrawn } from "../young/youngService";
 import { getAcl } from "../services/iam/Permission.service";
+import { addMonths } from "date-fns";
 
 const router = express.Router();
 const ReferentAuth = new AuthObject(ReferentModel);
@@ -1923,4 +1924,31 @@ router.post("/exist", passport.authenticate(["referent"], { session: false, fail
   }
 });
 
+router.post(
+  "/:id/renew-invitation",
+  authMiddleware(["referent"]),
+  accessControlMiddleware([ROLES.ADMIN]),
+  requestValidatorMiddleware({
+    params: Joi.object({ id: idSchema().required() }),
+  }),
+  async (req: RouteRequest<any>, res: RouteResponse<any>) => {
+    try {
+      const referent = await ReferentModel.findById(req.validatedParams.id);
+      if (!referent) return res.status(404).json({ ok: false, code: ERRORS.NOT_FOUND });
+
+      if (!referent.invitationExpires || !referent.invitationToken) {
+        return res.status(400).json({ ok: false, code: ERRORS.INVALID_PARAMS });
+      }
+
+      const invitationExpires = addMonths(new Date(), 1);
+      referent.set({ invitationExpires });
+      await referent.save({ fromUser: req.user });
+
+      return res.status(200).json({ ok: true, data: { invitationExpires } });
+    } catch (error) {
+      capture(error);
+      res.status(500).json({ ok: false, code: ERRORS.SERVER_ERROR });
+    }
+  },
+);
 export default router;


### PR DESCRIPTION
**Description**

Ajout d'un bouton pour les admin afin d'étendre la durée de validation d'une invitation.

**Todo**

<!--
- [ ] ${{ Todo item 1 }}
- [ ] ${{ Todo item 2 }}
-->

**Ticket / Issue**

https://www.notion.so/jeveuxaider/BUG-Admin-lien-d-invitation-expir-r-f-rent-de-classe-20072a322d50805d952efa5e047bfc76

**Testing instructions**

<!--
    Explain how another dev can test this PR. Create a workflow using checkboxes to explain how to run your code and the expected outputs:

    ${{ Test the following }}
    - [x] ${{ QA Scenario 1 }}
    - [x] ${{ QA Scenario 2 }}
    - [x] ${{ QA Scenario 3 }}
-->
