### PR TITLE
fix(admin): 842 - Ajout du params "cohort" dans l'URL du lien "Centre" de la Sidebar pour les Responsable de Centre

### DIFF
--- a/admin/src/components/drawer/SideBar.tsx
+++ b/admin/src/components/drawer/SideBar.tsx
@@ -188,16 +188,19 @@ const SideBar = ({ sessionsList }) => {
       setCurrentOpen={setDropDownOpen}
     />
   );
-  const CentresHeadCenter = () => (
-    <SimpleNavItem
-      sideBarOpen={open}
-      Icon={SejourIcon}
-      title="Centre"
-      link={`/centre/${sessionPhase1?.cohesionCenterId}`}
-      active={centerHeadCenterRegex.test(exactPath)}
-      setCurrentOpen={setDropDownOpen}
-    />
-  );
+  const CentresHeadCenter = () => {
+    const buildCentreLink = () => {
+      const baseUrl = `/centre/${sessionPhase1?.cohesionCenterId}`;
+      if (sessionPhase1?.cohort) {
+        return `${baseUrl}?cohorte=${encodeURIComponent(sessionPhase1.cohort)}`;
+      }
+      return baseUrl;
+    };
+
+    return (
+      <SimpleNavItem sideBarOpen={open} Icon={SejourIcon} title="Centre" link={buildCentreLink()} active={centerHeadCenterRegex.test(exactPath)} setCurrentOpen={setDropDownOpen} />
+    );
+  };
   const Institution = () => (
     <SimpleNavItem
       sideBarOpen={open}


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/BUG-Admin-chef-de-centre-n-a-pas-les-bonnes-dates-de-s-jours-20372a322d5080fea977c00928ac155f?source=copy_link

Sur leur page de Centre, les Responsable de centres voyaient toujours les infos de la meme sessions par défault, (celle en cours) et non celle qu'ils avaient sélectionné dans le menu déroulant. Il ne pouvait donc modifier que les infos de cette sessions et pas des autres. 
L'ajout du params cohorte dans l'URL permet d'etre sur qu'il voit la bonne session