### PR TITLE
fix(admin): 851 - On ne peut pas ajouter un CDC en tant que CDC adjoint

### DIFF
--- a/admin/src/scenes/centersV2/view/Team.tsx
+++ b/admin/src/scenes/centersV2/view/Team.tsx
@@ -170,6 +170,10 @@ export default function Team({ focusedSession: focusedSessionfromProps }) {
         });
         return {};
       }
+      if (referent.role !== teamate.role) {
+        toastr.error("Erreur", "Ce membre a déjà un rôle sur la plateforme. Un utilisateur ne peut pas avoir plusieurs rôles.");
+        return {};
+      }
 
       return setDirectionCenterMutation.mutate(referent._id);
     } catch (e) {


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/BUG-quand-on-assigne-un-CDC-au-poste-d-ajoint-ca-marche-20672a322d5080458ac6d95ec3260500?source=copy_link
