### PR TITLE
fix(apiv2): 272 - Ajout du fuseau horaire aux jobs cron

### DIFF
--- a/apiv2/src/cron/infra/CronJobScheduler.service.ts
+++ b/apiv2/src/cron/infra/CronJobScheduler.service.ts
@@ -28,9 +28,13 @@ export class CronJobSchedulerService implements OnModuleInit {
 
         for (const job of cronJobs) {
             this.logger.log(`Adding/updating job ${job.name} with pattern ${job.pattern}`);
+
             await this.jobQueue.upsertJobScheduler(
                 job.name,
-                { pattern: job.pattern },
+                {
+                    pattern: job.pattern,
+                    tz: job.tz,
+                },
                 {
                     name: job.name,
                     data: job.data,

--- a/apiv2/src/cron/jobs.config.ts
+++ b/apiv2/src/cron/jobs.config.ts
@@ -5,6 +5,7 @@ export interface CronJob {
     pattern: string;
     data?: Record<string, unknown>;
     opts?: JobsOptions;
+    tz?: string;
 }
 
 export enum CronJobName {
@@ -15,5 +16,6 @@ export const cronJobs: CronJob[] = [
     {
         name: CronJobName.ENVOYER_CAMPAGNES_PROGRAMMEES,
         pattern: "0 8-18 * * *",
+        tz: "Europe/Paris",
     },
 ];


### PR DESCRIPTION
Les cron ne portaient pas le fuseau horaire local.

<img width="526" alt="image" src="https://github.com/user-attachments/assets/7de15272-01f4-4766-a19d-6750bbf36b3f" />
