### PR TITLE
fix(api): 837 - les referent n'avaient plus accès a leur liste utilisateur

### DIFF
--- a/api/src/controllers/elasticsearch/referent.js
+++ b/api/src/controllers/elasticsearch/referent.js
@@ -55,7 +55,7 @@ async function buildReferentContext(user) {
           },
           {
             bool: {
-              must: [{ term: { "role.keyword": [ROLES.HEAD_CENTER, ROLES.HEAD_CENTER_ADJOINT, ROLES.REFERENT_SANITAIRE] } }, { terms: { "department.keyword": user.department } }],
+              must: [{ terms: { "role.keyword": [ROLES.HEAD_CENTER, ROLES.HEAD_CENTER_ADJOINT, ROLES.REFERENT_SANITAIRE] } }, { terms: { "department.keyword": user.department } }],
             },
           },
         ],


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/BUG-Admin-pas-d-acc-s-aux-utilisateur-depuis-son-compte-r-f-rent-20172a322d5080bba915ec62f1c23132?source=copy_link
