### PR TITLE
feat(api): 860 - Rattrapage de données pour les jeunes qui ont été désisté par le script automatique

### DIFF
--- a/api/migrations/20250617140442-rattrapage_jeune_desistement.js
+++ b/api/migrations/20250617140442-rattrapage_jeune_desistement.js
@@ -1,0 +1,18 @@
+const { YoungModel } = require("../src/models");
+const { logger } = require("../src/logger");
+module.exports = {
+  async up() {
+    const result = await YoungModel.updateMany(
+      {
+        withdrawnReason: "Non confirmation de la participation au séjour",
+        $or: [{ withdrawnMessage: { $exists: false } }, { withdrawnMessage: "" }],
+      },
+      {
+        $set: {
+          withdrawnMessage: "Script de désistement en masse pour non confirmation de la participation",
+        },
+      },
+    );
+    logger.info(`Mise à jour des jeunes désistés : ${result.modifiedCount} jeunes ont été mis à jour.`);
+  },
+};


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Faire-un-rattrapage-de-donn-es-pour-ajouter-la-raison-sur-les-jeunes-ayant-t-d-sist-s-en-masse-20972a322d508040bd1aebc9300814aa?source=copy_link
