### PR TITLE
Feat 901 fermeture centre

### DIFF
--- a/api/migrations/20250620141607-901-fermeture-centre.js
+++ b/api/migrations/20250620141607-901-fermeture-centre.js
@@ -1,0 +1,58 @@
+const { logger } = require("../src/logger");
+const { YOUNG_STATUS_PHASE1, YOUNG_STATUS } = require("snu-lib");
+const { YoungModel } = require("../src/models");
+
+module.exports = {
+  async up() {
+    const filter = {
+      cohesionCenterId: "659e70f6e3485608196927a6",
+      sessionPhase1Id: "67ed294d1e4b7c03031d8104",
+      status: YOUNG_STATUS.VALIDATED,
+      statusPhase1: { $in: [YOUNG_STATUS_PHASE1.AFFECTED] },
+    };
+
+    const youngs = await YoungModel.find(filter);
+    logger.info(`Migration 901-fermeture-centre: Found ${youngs.length} youngs to update`);
+
+    let updatedCount = 0;
+    for (const young of youngs) {
+      young.statusPhase1 = YOUNG_STATUS_PHASE1.DONE;
+      young.departSejourAt = new Date("2025-06-19");
+      young.departSejourMotif = "Cas de force majeure pour le volontaire";
+      young.departSejourMotifComment = "Ce commentaire attend Mathilde";
+
+      await young.save({ fromUser: { firstName: "901-fermeture-centre" } });
+      updatedCount++;
+      logger.info(`Updated young ${young._id} (${updatedCount}/${youngs.length})`);
+    }
+
+    logger.info(`Migration 901-fermeture-centre: ${updatedCount} youngs updated with new statusPhase1 (${YOUNG_STATUS_PHASE1.DONE}) and departure information`);
+  },
+
+  async down() {
+    const filter = {
+      cohesionCenterId: "659e70f6e3485608196927a6",
+      sessionPhase1Id: "67ed294d1e4b7c03031d8104",
+      status: YOUNG_STATUS.VALIDATED,
+      statusPhase1: { $in: [YOUNG_STATUS_PHASE1.DONE] },
+      departSejourMotif: "Cas de force majeure pour le volontaire",
+    };
+
+    const youngs = await YoungModel.find(filter);
+    logger.info(`Migration 901-fermeture-centre rollback: Found ${youngs.length} youngs to revert`);
+
+    let revertedCount = 0;
+    for (const young of youngs) {
+      young.statusPhase1 = YOUNG_STATUS_PHASE1.AFFECTED;
+      young.departSejourAt = undefined;
+      young.departSejourMotif = undefined;
+      young.departSejourMotifComment = undefined;
+
+      await young.save({ fromUser: { firstName: "901-fermeture-centre-rollback" } });
+      revertedCount++;
+      logger.info(`Reverted young ${young._id} (${revertedCount}/${youngs.length})`);
+    }
+
+    logger.info(`Migration 901-fermeture-centre rollback: ${revertedCount} youngs reverted to ${YOUNG_STATUS_PHASE1.AFFECTED} status and departure info removed`);
+  },
+};

--- a/api/migrations/20250620141607-901-fermeture-centre.js
+++ b/api/migrations/20250620141607-901-fermeture-centre.js
@@ -19,7 +19,8 @@ module.exports = {
       young.statusPhase1 = YOUNG_STATUS_PHASE1.DONE;
       young.departSejourAt = new Date("2025-06-19");
       young.departSejourMotif = "Cas de force majeure pour le volontaire";
-      young.departSejourMotifComment = "Ce commentaire attend Mathilde";
+      young.departSejourMotifComment = "décision administrative de fermeture du centre";
+      young.statusPhase2OpenedAt = new Date();
 
       await young.save({ fromUser: { firstName: "901-fermeture-centre" } });
       updatedCount++;

--- a/api/src/crons/autoValidatePhase1/service.ts
+++ b/api/src/crons/autoValidatePhase1/service.ts
@@ -2,7 +2,7 @@ import { logger } from "../../logger";
 import { CohortDocument } from "../../models";
 import { getCursorPourJeunesAValiderByCohortId } from "./repository";
 import { updateStatusPhase1 } from "../../sessionPhase1/validation/sessionPhase1ValidationService";
-import { UserDto } from "snu-lib";
+import { UserDto, YOUNG_STATUS_PHASE1 } from "snu-lib";
 
 export async function processCohort(cohort: CohortDocument, dateValidation: Date, user: Partial<UserDto>): Promise<number> {
   logger.info(`Autovalidation de la phase 1 pour la cohorte ${cohort.name} au ${cohort.daysToValidate}e jour après l'arrivée`);
@@ -10,6 +10,10 @@ export async function processCohort(cohort: CohortDocument, dateValidation: Date
   let count = 0;
   await cursor.eachAsync(async (young) => {
     try {
+      if (young.statusPhase1 === YOUNG_STATUS_PHASE1.DONE) {
+        logger.info(`processCohort - Le volontaire ${young._id} est déjà validé pour la phase 1, pas de modification`);
+        return;
+      }
       await updateStatusPhase1(young, dateValidation, user);
       count++;
     } catch (error) {


### PR DESCRIPTION
Modification du cron autoValidatePhase1 pour ignorer les jeunes dont young.statusPhase1 === YOUNG_STATUS_PHASE1.DONE

Script de migration, ~~données à Vérifier avec Mathilde~~ : 
- [x] departSejourAt
- [x] departSejourMotif
- [x] departSejourMotifComment


https://www.notion.so/jeveuxaider/Valider-phase-1-cas-de-force-majeure-21772a322d50801f9d33d3afb07a8015?source=copy_link

_Reprise de la PR #5079 pour appliquer le process production hotfix_