### PR TITLE
fix(lib): 918 - Corriger la gestion de onChange dans Combobox

### DIFF
--- a/packages/ds/src/common/inputs/Combobox.tsx
+++ b/packages/ds/src/common/inputs/Combobox.tsx
@@ -24,7 +24,15 @@ export default function Combobox({
   onChange,
 }: proptype) {
   return (
-    <HeadlessCombobox as="div" value={value} onChange={onChange}>
+    <HeadlessCombobox
+      as="div"
+      value={value}
+      onChange={(value) => {
+        if (value) {
+          onChange(value);
+        }
+      }}
+    >
       <HeadlessCombobox.Label className="block text-sm font-medium leading-6 text-gray-800">
         {label}
       </HeadlessCombobox.Label>


### PR DESCRIPTION
HeadlessCombobox trigger le onChange quand Input est vide
=> value est null
=> Erreur : Cannot read properties of null

https://www.notion.so/jeveuxaider/Sentry-TypeError-sur-le-composant-ComboBox-MonCompte-21d72a322d5080f4bad7d446739628b5?source=copy_link