### PR TITLE
fix(admin): 925 - Corriger filtre pour données nulles

### DIFF
--- a/admin/src/components/filters-system-v2/components/filters/FilterPopOver.tsx
+++ b/admin/src/components/filters-system-v2/components/filters/FilterPopOver.tsx
@@ -134,7 +134,7 @@ export const DropDown = ({ isShowing, filter, selectedFilters, setSelectedFilter
         ? data.filter((f) => (filter?.translate ? normalizeString(filter.translate(f.key)).includes(normalizedSearch) : normalizeString(f.key).includes(normalizedSearch)))
         : data;
     if (filter?.filter) {
-      newData = newData.filter(filter.filter);
+      newData = newData?.filter(filter.filter);
     }
     setOptionsVisible(newData);
   }, [search]);


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Sentry-TypeError-sur-le-composant-FilterPopOver-Admin-21e72a322d508019b710d7ff8aa54d39?source=copy_link