### PR TITLE
fix(api): 978 - Corriger la vérification de statut des missions JVA

### DIFF
--- a/api/src/crons/missionsJVA/JVAService.ts
+++ b/api/src/crons/missionsJVA/JVAService.ts
@@ -122,7 +122,7 @@ async function updateMission(mission: MissionDocument, updatedMission: Partial<M
     ...updatedMission,
     placesLeft,
   });
-  if ([MISSION_STATUS.CANCEL, MISSION_STATUS.ARCHIVED].includes(mission.status as any)) {
+  if (mission.status === MISSION_STATUS.CANCEL) {
     mission.set({ status: MISSION_STATUS.WAITING_VALIDATION });
   }
   await mission.save({ fromUser });


### PR DESCRIPTION
https://www.notion.so/jeveuxaider/Mettre-jour-le-script-de-synchronisation-JVA-pour-ne-pas-mettre-jour-le-statut-d-une-mission-JVA-23872a322d508040af57c86a343e481c?source=copy_link