### PR TITLE
feat(api): 1030 - Ajouter l'envoi de notifications pour les modficati…

### DIFF
--- a/api/src/application/application.service.test.ts
+++ b/api/src/application/application.service.test.ts
@@ -1,0 +1,307 @@
+import { sendNotificationsByStatus } from "./applicationService";
+import { MissionModel, ReferentModel } from "../models";
+import { sendTemplate } from "../brevo";
+import { getCcOfYoung } from "../utils";
+import { APPLICATION_STATUS, SENDINBLUE_TEMPLATES } from "snu-lib";
+import { config } from "../config";
+import { capture } from "../sentry";
+
+// Mock des dépendances
+jest.mock("../brevo", () => ({
+  sendTemplate: jest.fn(),
+}));
+
+jest.mock("../utils", () => ({
+  getCcOfYoung: jest.fn(),
+}));
+
+jest.mock("../sentry", () => ({
+  capture: jest.fn(),
+}));
+
+jest.mock("../models", () => ({
+  MissionModel: {
+    findById: jest.fn(),
+  },
+  ReferentModel: {
+    findById: jest.fn(),
+  },
+}));
+
+const mockSendTemplate = sendTemplate as jest.MockedFunction<typeof sendTemplate>;
+const mockGetCcOfYoung = getCcOfYoung as jest.MockedFunction<typeof getCcOfYoung>;
+const mockCapture = capture as jest.MockedFunction<typeof capture>;
+
+describe("sendApplicationStatusEmails", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockApplication = {
+    _id: "application123",
+    youngId: "young123",
+    missionId: "mission123",
+    youngFirstName: "John",
+    youngLastName: "Doe",
+    youngEmail: "john.doe@example.com",
+  };
+
+  const mockYoung = {
+    _id: "young123",
+    firstName: "John",
+    lastName: "Doe",
+    email: "john.doe@example.com",
+    parent1FirstName: "Jane",
+    parent1LastName: "Doe",
+    parent1Email: "jane.doe@example.com",
+    parent2FirstName: "Bob",
+    parent2LastName: "Doe",
+    parent2Email: "bob.doe@example.com",
+  };
+
+  const mockMission = {
+    _id: "mission123",
+    name: "Mission Test",
+    tutorId: "referent123",
+  };
+
+  const mockReferent = {
+    _id: "referent123",
+    firstName: "Referent",
+    lastName: "Test",
+    email: "referent@example.com",
+  };
+
+  it("should send emails for VALIDATED status", async () => {
+    // Arrange
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(mockReferent);
+    mockGetCcOfYoung.mockReturnValue([]);
+    mockSendTemplate.mockResolvedValue(undefined);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, APPLICATION_STATUS.VALIDATED);
+
+    // Assert
+    expect(MissionModel.findById).toHaveBeenCalledWith("mission123");
+    expect(ReferentModel.findById).toHaveBeenCalledWith("referent123");
+    expect(mockSendTemplate).toHaveBeenCalledTimes(2);
+
+    // Vérifier l'email au référent
+    expect(mockSendTemplate).toHaveBeenCalledWith(SENDINBLUE_TEMPLATES.referent.YOUNG_VALIDATED, {
+      emailTo: [{ name: "Referent Test", email: "referent@example.com" }],
+      params: {
+        youngFirstName: "John",
+        youngLastName: "Doe",
+        missionName: "Mission Test",
+        cta: `${config.ADMIN_URL}/volontaire/young123/phase2/application/application123/contrat`,
+      },
+      cc: [],
+    });
+    // Vérifier l'email au jeune
+    expect(mockSendTemplate).toHaveBeenCalledWith(SENDINBLUE_TEMPLATES.young.VALIDATE_APPLICATION, {
+      emailTo: [
+        { name: "John Doe", email: "john.doe@example.com" },
+        { name: "Jane Doe", email: "jane.doe@example.com" },
+        { name: "Bob Doe", email: "bob.doe@example.com" },
+      ],
+      params: {
+        youngFirstName: "John",
+        youngLastName: "Doe",
+        missionName: "Mission Test",
+        cta: `${config.APP_URL}/candidature?utm_campaign=transactionel+mig+candidature+approuvee&utm_source=notifauto&utm_medium=mail+151+faire`,
+      },
+      cc: [],
+    });
+  });
+
+  it("should send email for REFUSED status", async () => {
+    // Arrange
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(mockReferent);
+    mockGetCcOfYoung.mockReturnValue([]);
+    mockSendTemplate.mockResolvedValue(undefined);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, APPLICATION_STATUS.REFUSED);
+
+    // Assert
+    expect(mockSendTemplate).toHaveBeenCalledTimes(1);
+    expect(mockSendTemplate).toHaveBeenCalledWith(SENDINBLUE_TEMPLATES.young.REFUSE_APPLICATION, {
+      emailTo: [
+        { name: "John Doe", email: "john.doe@example.com" },
+        { name: "Jane Doe", email: "jane.doe@example.com" },
+        { name: "Bob Doe", email: "bob.doe@example.com" },
+      ],
+      params: {
+        youngFirstName: "John",
+        youngLastName: "Doe",
+        missionName: "Mission Test",
+        cta: `${config.APP_URL}/mission?utm_campaign=transactionnel+mig+candidature+nonretenue&utm_source=notifauto&utm_medium=mail+152+candidater`,
+      },
+      cc: [],
+    });
+  });
+
+  it("should send emails for CANCEL status", async () => {
+    // Arrange
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(mockReferent);
+    mockGetCcOfYoung.mockReturnValue([]);
+    mockSendTemplate.mockResolvedValue(undefined);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, APPLICATION_STATUS.CANCEL);
+
+    // Assert
+    expect(mockSendTemplate).toHaveBeenCalledTimes(2);
+
+    // Vérifier l'email au jeune
+    expect(mockSendTemplate).toHaveBeenCalledWith(SENDINBLUE_TEMPLATES.young.CANCEL_APPLICATION, {
+      emailTo: [
+        { name: "John Doe", email: "john.doe@example.com" },
+        { name: "Jane Doe", email: "jane.doe@example.com" },
+        { name: "Bob Doe", email: "bob.doe@example.com" },
+      ],
+      params: {
+        youngFirstName: "John",
+        youngLastName: "Doe",
+        missionName: "Mission Test",
+      },
+      cc: [],
+    });
+
+    // Vérifier l'email au référent
+    expect(mockSendTemplate).toHaveBeenCalledWith(SENDINBLUE_TEMPLATES.referent.CANCEL_APPLICATION, {
+      emailTo: [{ name: "Referent Test", email: "referent@example.com" }],
+      params: {
+        youngFirstName: "John",
+        youngLastName: "Doe",
+        missionName: "Mission Test",
+      },
+      cc: [],
+    });
+  });
+
+  it("should filter out recipients without email", async () => {
+    // Arrange
+    const youngWithoutParents = {
+      ...mockYoung,
+      parent1Email: undefined,
+      parent2Email: undefined,
+    };
+
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(mockReferent);
+    mockGetCcOfYoung.mockReturnValue([]);
+    mockSendTemplate.mockResolvedValue(undefined);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, youngWithoutParents as any, APPLICATION_STATUS.VALIDATED);
+
+    // Assert
+    expect(mockSendTemplate).toHaveBeenCalledWith(SENDINBLUE_TEMPLATES.young.VALIDATE_APPLICATION, {
+      emailTo: [{ name: "John Doe", email: "john.doe@example.com" }],
+      params: expect.any(Object),
+      cc: [],
+    });
+  });
+
+  it("should return early if mission is not found", async () => {
+    // Arrange
+    (MissionModel.findById as jest.Mock).mockResolvedValue(null);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, APPLICATION_STATUS.VALIDATED);
+
+    // Assert
+    expect(ReferentModel.findById).not.toHaveBeenCalled();
+    expect(mockSendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("should return early if referent is not found", async () => {
+    // Arrange
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(null);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, APPLICATION_STATUS.VALIDATED);
+
+    // Assert
+    expect(mockSendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("should handle unknown status gracefully", async () => {
+    // Arrange
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(mockReferent);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, "UNKNOWN_STATUS");
+
+    // Assert
+    expect(mockSendTemplate).not.toHaveBeenCalled();
+  });
+
+  it("should handle errors and capture them", async () => {
+    // Arrange
+    const error = new Error("Test error");
+    (MissionModel.findById as jest.Mock).mockRejectedValue(error);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, APPLICATION_STATUS.VALIDATED);
+
+    // Assert
+    expect(mockCapture).toHaveBeenCalledWith(error);
+  });
+
+  it("should not send email if no recipients", async () => {
+    // Arrange
+    const applicationWithoutEmail = {
+      ...mockApplication,
+      youngEmail: undefined,
+    };
+
+    const youngWithoutEmail = {
+      ...mockYoung,
+      parent1Email: undefined,
+      parent2Email: undefined,
+    };
+
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(mockReferent);
+
+    // Act
+    await sendNotificationsByStatus(applicationWithoutEmail as any, youngWithoutEmail as any, APPLICATION_STATUS.VALIDATED);
+
+    // Assert
+    // Seul l'email au référent devrait être envoyé
+    expect(mockSendTemplate).toHaveBeenCalledTimes(1);
+    expect(mockSendTemplate).toHaveBeenCalledWith(SENDINBLUE_TEMPLATES.referent.YOUNG_VALIDATED, expect.any(Object));
+  });
+
+  it("should use getCcOfYoung for young emails", async () => {
+    // Arrange
+    const mockCc = [{ name: "CC User", email: "cc@example.com" }];
+    (MissionModel.findById as jest.Mock).mockResolvedValue(mockMission);
+    (ReferentModel.findById as jest.Mock).mockResolvedValue(mockReferent);
+    mockGetCcOfYoung.mockReturnValue(mockCc);
+    mockSendTemplate.mockResolvedValue(undefined);
+
+    // Act
+    await sendNotificationsByStatus(mockApplication as any, mockYoung as any, APPLICATION_STATUS.VALIDATED);
+
+    // Assert
+    expect(mockGetCcOfYoung).toHaveBeenCalledWith({
+      template: SENDINBLUE_TEMPLATES.young.VALIDATE_APPLICATION,
+      young: mockYoung,
+    });
+
+    expect(mockSendTemplate).toHaveBeenCalledWith(
+      SENDINBLUE_TEMPLATES.young.VALIDATE_APPLICATION,
+      expect.objectContaining({
+        cc: mockCc,
+      }),
+    );
+  });
+});

--- a/api/src/application/applicationController.ts
+++ b/api/src/application/applicationController.ts
@@ -42,7 +42,7 @@ import {
   updateYoungApplicationFilesType,
 } from "../utils";
 import { scanFile } from "../utils/virusScanner";
-import { getAuthorizationToApply, updateMission } from "../application/applicationService";
+import { getAuthorizationToApply, updateMission, sendNotificationsByStatus } from "../application/applicationService";
 import { apiEngagement } from "../services/gouv.fr/api-engagement";
 import { getMimeFromBuffer, getMimeFromFile } from "../utils/file";
 import { requestValidatorMiddleware } from "../middlewares/requestValidatorMiddleware";
@@ -334,6 +334,10 @@ router.post(
         await updateYoungPhase2StatusAndHours(young, req.user);
         await updateYoungStatusPhase2Contract(young, req.user);
         await updateMission(application, req.user);
+
+        if (young) {
+          await sendNotificationsByStatus(application, young, valueKey.key);
+        }
       });
       res.status(200).send({ ok: true });
     } catch (error) {

--- a/api/src/brevo.ts
+++ b/api/src/brevo.ts
@@ -46,7 +46,7 @@ type Contact = {
   unlinkListIds?: number[];
 };
 
-type Email = {
+export type Email = {
   email: string;
   name?: string;
 };


### PR DESCRIPTION
## Implémentation de l'envoi automatique d'emails lors du changement de statut des candidatures

### Objectif
Cette PR implémente un système d'envoi automatique d'emails de notification lors des changements de statut des candidatures de mission, améliorant ainsi la communication avec les jeunes et leurs référents.

### Fonctionnalités ajoutées

#### 1. **Nouvelle fonction `sendNotificationsByStatus`**
- **Localisation** : `api/src/application/applicationService.ts`
- **Responsabilité** : Gère l'envoi d'emails selon le statut de la candidature
- **Statuts supportés** :
  - `VALIDATED` : Email au jeune + parents + référent
  - `REFUSED` : Email au jeune + parents uniquement  
  - `CANCEL` : Email au jeune + parents + référent

#### 2. **Architecture modulaire et maintenable**
- **Interfaces TypeScript** : `EmailTemplate`, `EmailParams` pour la sécurité des types
- **Fonctions utilitaires** :
  - `getEmailTemplatesForStatus()` : Détermine les templates selon le statut
  - `getEmailParamsForStatus()` : Génère les paramètres d'email avec CTA appropriés
  - `getYoungEmailRecipients()` : Construit la liste des destinataires (jeune + parents)
  - `getReferentEmailRecipients()` : Construit la liste des référents
  - `getReferentCtaForTemplate()` : Gère les CTA spécifiques aux référents

#### 3. **Intégration dans le contrôleur**
- **Localisation** : `api/src/application/applicationController.ts` (ligne 338-340)
- **Déclenchement** : Automatique lors du changement de statut via l'endpoint POST
- **Sécurité** : Vérification de l'existence du jeune avant envoi

#### 4. **Tests complets**
- **Fichier** : `api/src/application/application.service.test.ts` (307 lignes)
- **Couverture** : Tous les statuts, cas d'erreur, gestion des destinataires manquants
- **Mocks** : Brevo, modèles MongoDB, utilitaires

### Améliorations techniques

#### **Gestion des destinataires**
- Filtrage automatique des destinataires sans email
- Support des parents (parent1, parent2) avec validation des emails
- Utilisation de `getCcOfYoung()` pour les emails aux jeunes

#### **Gestion des erreurs**
- Try/catch avec capture Sentry
- Retour anticipé si mission ou référent introuvable
- Gestion gracieuse des statuts inconnus

#### **URLs et tracking**
- CTA personnalisées selon le statut
- Paramètres UTM pour le tracking marketing
- URLs différentes pour jeunes vs référents

### Qualité du code

#### **TypeScript**
- Types explicites et interfaces bien définies
- Export du type `Email` depuis `brevo.ts`
- Import des types depuis `snu-lib`

#### **Tests**
- 9 cas de test couvrant tous les scénarios
- Mocks appropriés pour toutes les dépendances
- Assertions détaillées sur les paramètres d'email

### Impact

#### **Utilisateur final**
- Notifications automatiques lors des changements de statut
- Meilleure communication avec les familles
- Réduction du travail manuel pour les référents

#### **Développement**
- Code modulaire et testable
- Séparation claire des responsabilités
- Facilité d'ajout de nouveaux statuts

### Checklist de validation
- [x] Tests unitaires complets
- [x] Gestion d'erreurs robuste
- [x] Types TypeScript appropriés
- [x] Intégration dans le flux existant
- [x] Documentation du code
- [x] Respect des conventions de nommage

Cette implémentation respecte les bonnes pratiques de développement et améliore significativement l'expérience utilisateur du système de candidatures.


https://www.notion.so/jeveuxaider/Bug-Mail-automatique-non-envoy-suite-une-action-en-masse-pour-modifier-une-candidature-26f72a322d5080359c28dca045abdfd8?source=copy_link