### PR TITLE
fix(api): 1034 - Ajouter l'URL de la base de connaissances

### DIFF
--- a/snupport-api/src/config.ts
+++ b/snupport-api/src/config.ts
@@ -74,6 +74,7 @@ export const config = {
   SNU_URL_ADMIN: _env(envStr, "SNU_URL_ADMIN", "http://localhost:8082"),
   SNUPPORT_URL_ADMIN: _env(envStr, "SNUPPORT_URL_ADMIN", "http://localhost:8092"),
   SNUPPORT_URL_KB: _env(envStr, "SNUPPORT_URL_KB", "http://localhost:8091"),
+  KNOWLEDGE_BASE_PUBLIC_URL: _env(envStr, "KNOWLEDGE_BASE_PUBLIC_URL", "http://localhost:8084"),
   CELLAR_ENDPOINT: _env(envStr, "CELLAR_ENDPOINT"),
   CELLAR_KEYID: _env(envStr, "CELLAR_KEYID"),
   CELLAR_KEYSECRET: _env(envStr, "CELLAR_KEYSECRET"),

--- a/snupport-api/src/index.ts
+++ b/snupport-api/src/index.ts
@@ -25,7 +25,9 @@ console.log("ENVIRONMENT:", config.ENVIRONMENT);
 app.use(logger("dev"));
 
 const origin = [config.SNU_URL_APP, config.SNU_URL_ADMIN, config.SNUPPORT_URL_KB, config.SNUPPORT_URL_ADMIN];
-console.log("origin", origin);
+if (config.ENVIRONMENT === "development") {
+  origin.push(config.KNOWLEDGE_BASE_PUBLIC_URL);
+}
 app.use(express.json({ limit: "10mb" }));
 app.use(
   cors({


### PR DESCRIPTION
Ajout de KNOWLEDGE_BASE_PUBLIC_URL dans les origines de snupport-api en mode dev.
Pour la prod, pas besoin car c'est un sous-domaine dont le domaine principal est déjà dans les origines du CORS.