### PR TITLE
fix(support): 1067 slow support when applying macros

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31445,6 +31445,7 @@
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "jest": "^29.7.0",
         "prettier": "^2.8.8",
         "tsx": "^4.7.1",
         "typescript": "^5.4.3",

--- a/snupport-api/jest.config.js
+++ b/snupport-api/jest.config.js
@@ -1,0 +1,10 @@
+const config = {
+  roots: ["src/"],
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["/node_modules/", "/__mocks__/", "/helpers/", "/fixtures/", "/scripts/"],
+  testMatch: ["**/?(*.)+(test).[jt]s?(x)"],
+  coveragePathIgnorePatterns: ["/node_modules/", "/__mocks__/", "/helpers/", "/fixtures/", "/scripts/"],
+};
+
+module.exports = config;
+

--- a/snupport-api/package.json
+++ b/snupport-api/package.json
@@ -9,6 +9,8 @@
     "start": "node ./src/index.js",
     "build": "tsc -b ./tsconfig.build.json",
     "check-types": "tsc -p tsconfig.check.json --emitDeclarationOnly",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "lint": "eslint src --ext .js,.jsx",
     "lint:fix": "eslint --ext .js --fix src",
     "clean": "rm -fr node_modules .turbo build .swc"
@@ -61,6 +63,7 @@
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "jest": "^29.7.0",
     "prettier": "^2.8.8",
     "tsx": "^4.7.1",
     "typescript": "^5.4.3",

--- a/snupport-api/src/__tests__/README.md
+++ b/snupport-api/src/__tests__/README.md
@@ -1,0 +1,29 @@
+# Tests SNUpport API
+
+## Installation
+
+Pour installer les dépendances de test :
+
+```bash
+npm install
+```
+
+## Exécution des tests
+
+Pour exécuter tous les tests :
+
+```bash
+npm test
+```
+
+Pour exécuter les tests en mode watch :
+
+```bash
+npm run test:watch
+```
+
+## Tests actuels
+
+### Message Model
+- Vérifie que le champ `ticketId` a bien un index pour optimiser les requêtes de recherche par ticket.
+

--- a/snupport-api/src/__tests__/message.test.js
+++ b/snupport-api/src/__tests__/message.test.js
@@ -1,0 +1,17 @@
+const MessageModel = require("../models/message");
+
+describe("Message Model", () => {
+  describe("Indexes", () => {
+    it("should have an index on ticketId", () => {
+      const indexes = MessageModel.schema.indexes();
+      const ticketIdIndex = indexes.find((index) => {
+        const fields = index[0];
+        return fields.ticketId !== undefined;
+      });
+      
+      expect(ticketIdIndex).toBeDefined();
+      expect(ticketIdIndex[0].ticketId).toBe(1);
+    });
+  });
+});
+

--- a/snupport-api/src/models/message.js
+++ b/snupport-api/src/models/message.js
@@ -3,7 +3,7 @@ const mongoose = require("mongoose");
 const MODELNAME = "message";
 
 const Schema = new mongoose.Schema({
-  ticketId: { type: String, required: true },
+  ticketId: { type: String, required: true, index: true },
 
   text: { type: String },
   slateContent: {},


### PR DESCRIPTION
L'interface de l'application support est lente lors de l'application d'une macro. 

Il semble qu'une opération fréquente est réalisé de count des documents ayant le même id de ticket. 

Le patch vise à mettre un index sur ticketId sur la collection Messages afin de passer d'un scan de collection (COLLSCAN), coûteux sur une collection de 300 000 messages, à un scan des index IDXSCAN (et non les documents complets).

Gain estimé : quelques micro-seconds à secondes lors de chaque application. 