### PR TITLE
fix(admin, apiv2): 1108 - whole structure collection is being pulled

### DIFF
--- a/apiv2/src/admin/Admin.module.ts
+++ b/apiv2/src/admin/Admin.module.ts
@@ -77,6 +77,7 @@ import { ClasseImportService } from "./core/sejours/cle/classe/importEnMasse/Cla
 import { InscrireEleveManuellement } from "./core/sejours/cle/classe/useCase/InscrireEleveManuellement";
 import { JeuneService } from "./core/sejours/jeune/Jeune.service";
 import { MissionController } from "./infra/engagement/mission/api/Mission.controller";
+import { StructureController } from "./infra/engagement/structure/api/Structure.controller";
 import { SharedModule } from "@shared/Shared.module";
 import { AllExceptionsFilter } from "@shared/infra/AllExceptions.filter";
 import { APP_FILTER, APP_GUARD } from "@nestjs/core";
@@ -84,6 +85,9 @@ import { InscriptionController } from "./infra/sejours/phase1/inscription/api/In
 import { JeuneController } from "./infra/sejours/phase1/api/Jeune.controller";
 import { ExporterJeuneService } from "./core/sejours/phase1/jeune/ExporterJeune.service";
 import { PermissionGuard } from "@auth/infra/guard/Permissions.guard";
+import { StructureGateway } from "./core/engagement/structure/Structure.gateway";
+import { StructureRepository } from "./infra/engagement/structure/repository/mongo/StructureMongo.repository";
+import { structureMongoProviders } from "./infra/engagement/structure/provider/StructureMongo.provider";
 
 @Module({
     imports: [
@@ -120,6 +124,7 @@ import { PermissionGuard } from "@auth/infra/guard/Permissions.guard";
         DesistementController,
         InscriptionController,
         MissionController,
+        StructureController,
         JeuneController,
     ],
     providers: [
@@ -150,6 +155,7 @@ import { PermissionGuard } from "@auth/infra/guard/Permissions.guard";
         ...guardProviders,
         ...taskMongoProviders,
         ...historyProvider,
+        ...structureMongoProviders,
         Logger,
         SigninReferent,
         { provide: FileGateway, useClass: FileProvider },
@@ -173,6 +179,7 @@ import { PermissionGuard } from "@auth/infra/guard/Permissions.guard";
             provide: APP_FILTER,
             useClass: AllExceptionsFilter,
         },
+        { provide: StructureGateway, useClass: StructureRepository },
     ],
     exports: [
         ClsModule,

--- a/apiv2/src/admin/core/engagement/structure/Structure.gateway.ts
+++ b/apiv2/src/admin/core/engagement/structure/Structure.gateway.ts
@@ -1,9 +1,10 @@
-import { StructureModel } from "./Structure.model";
+import { StructureModel, StructureProjection } from "./Structure.model";
 
 export interface StructureGateway {
     findById(id: string): Promise<StructureModel>;
     findByIds(ids: string[]): Promise<StructureModel[]>;
     findByIdOrNetworkId(id: string): Promise<StructureModel[]>;
+    findAll(projection?: StructureProjection[]): Promise<Partial<StructureModel>[]>;
 }
 
 export const StructureGateway = Symbol("StructureGateway");

--- a/apiv2/src/admin/core/engagement/structure/Structure.model.ts
+++ b/apiv2/src/admin/core/engagement/structure/Structure.model.ts
@@ -5,4 +5,17 @@ export type StructureModel = {
     types: string[];
     associationTypes: string[];
     isJvaStructure: boolean;
+    region?: string;
+    department?: string;
+    networkId?: string;
 };
+
+export type StructureProjection = keyof StructureModel;
+
+export const STRUCTURE_PROJECTION_KEYS: readonly StructureProjection[] = [
+    "id",
+    "name",
+    "region",
+    "department",
+    "networkId",
+] as const;

--- a/apiv2/src/admin/infra/engagement/structure/api/Structure.controller.ts
+++ b/apiv2/src/admin/infra/engagement/structure/api/Structure.controller.ts
@@ -1,0 +1,27 @@
+import { StructureModel, STRUCTURE_PROJECTION_KEYS } from "@admin/core/engagement/structure/Structure.model";
+import { StructureGateway } from "@admin/core/engagement/structure/Structure.gateway";
+import { Body, Controller, Get, Inject, Post, Query, UseGuards } from "@nestjs/common";
+import { UseAnyGuard } from "@admin/infra/iam/guard/Any.guard";
+import { AdminGuard } from "@admin/infra/iam/guard/Admin.guard";
+import { ReferentRegionalGuard } from "@admin/infra/iam/guard/ReferentRegional.guard";
+import { ReferentDepartementalGuard } from "@admin/infra/iam/guard/ReferentDepartemental.guard";
+import { ResponsableGuard } from "@admin/infra/iam/guard/Responsable.guard";
+import { SupervisorGuard } from "@admin/infra/iam/guard/Superviseur.guard";
+import { StructureProjectionPayloadDto } from "./Structure.validation";
+
+@Controller("structure")
+export class StructureController {
+    constructor(@Inject(StructureGateway) private readonly structureGateway: StructureGateway) {}
+
+    @Post("/")
+    @UseAnyGuard(AdminGuard, ReferentRegionalGuard, ReferentDepartementalGuard, ResponsableGuard, SupervisorGuard)
+    async findAll(@Body() body: StructureProjectionPayloadDto): Promise<Partial<StructureModel>[]> {
+        let projection: (keyof StructureModel)[] | undefined;
+
+        if (body.fields) {
+            projection = body.fields.filter((field) => STRUCTURE_PROJECTION_KEYS.includes(field));
+        }
+
+        return this.structureGateway.findAll(projection);
+    }
+}

--- a/apiv2/src/admin/infra/engagement/structure/api/Structure.validation.ts
+++ b/apiv2/src/admin/infra/engagement/structure/api/Structure.validation.ts
@@ -1,0 +1,9 @@
+import { StructureProjection, STRUCTURE_PROJECTION_KEYS } from "@admin/core/engagement/structure/Structure.model";
+import { IsArray, IsIn, IsString } from "class-validator";
+
+export class StructureProjectionPayloadDto {
+    @IsArray()
+    @IsString({ each: true })
+    @IsIn(STRUCTURE_PROJECTION_KEYS, { each: true })
+    fields: readonly StructureProjection[];
+}

--- a/apiv2/src/admin/infra/engagement/structure/repository/Structure.mapper.ts
+++ b/apiv2/src/admin/infra/engagement/structure/repository/Structure.mapper.ts
@@ -1,10 +1,24 @@
-import { StructureModel } from "@admin/core/engagement/structure/Structure.model";
+import { StructureModel, StructureProjection } from "@admin/core/engagement/structure/Structure.model";
 import { StructureDocument } from "../provider/StructureMongo.provider";
 import { StructureType } from "snu-lib";
 
 export class StructureMapper {
     static toModels(structureDocuments: StructureDocument[]): StructureModel[] {
         return structureDocuments.map((structureDocument) => this.toModel(structureDocument));
+    }
+
+    static toModelProjections(
+        structureDocuments: StructureDocument[],
+        projection: Record<string, 1>,
+    ): Partial<StructureModel>[] {
+        const models = structureDocuments.map((structureDocument) => this.toModel(structureDocument));
+        const projectedModels = models.map((model) => {
+            return Object.keys(projection).reduce((acc: Partial<StructureModel>, key) => {
+                acc[key] = model[key];
+                return acc;
+            }, {});
+        });
+        return projectedModels;
     }
 
     static toModel(structureDocument: StructureDocument): StructureModel {
@@ -15,6 +29,9 @@ export class StructureMapper {
             types: structureDocument.types,
             associationTypes: structureDocument.associationTypes,
             isJvaStructure: structureDocument.isJvaStructure === "true",
+            region: structureDocument.region,
+            department: structureDocument.department,
+            networkId: structureDocument.networkId,
         };
     }
 
@@ -26,6 +43,9 @@ export class StructureMapper {
             types: structureModel.types,
             associationTypes: structureModel.associationTypes,
             isJvaStructure: structureModel.isJvaStructure ? "true" : "false",
+            region: structureModel.region,
+            department: structureModel.department,
+            networkId: structureModel.networkId,
         };
     }
 }

--- a/apiv2/src/admin/infra/engagement/structure/repository/mongo/StructureMongo.repository.ts
+++ b/apiv2/src/admin/infra/engagement/structure/repository/mongo/StructureMongo.repository.ts
@@ -5,7 +5,7 @@ import { ClsService } from "nestjs-cls";
 import { STRUCTURE_MONGOOSE_ENTITY, StructureDocument } from "../../provider/StructureMongo.provider";
 import { StructureMapper } from "../Structure.mapper";
 
-import { StructureModel } from "@admin/core/engagement/structure/Structure.model";
+import { StructureModel, StructureProjection } from "@admin/core/engagement/structure/Structure.model";
 import { StructureGateway } from "@admin/core/engagement/structure/Structure.gateway";
 
 @Injectable()
@@ -28,5 +28,16 @@ export class StructureRepository implements StructureGateway {
     async findByIdOrNetworkId(id: string): Promise<StructureModel[]> {
         const structures = await this.structureMongooseEntity.find({ $or: [{ _id: id }, { networkId: id }] });
         return StructureMapper.toModels(structures);
+    }
+
+    async findAll(projection?: StructureProjection[]): Promise<Partial<StructureModel>[]> {
+        const projectionObj: Record<string, 1> = {};
+        if (projection && projection.length > 0) {
+            projection.forEach((key) => {
+                projectionObj[key] = 1;
+            });
+        }
+        const structures = await this.structureMongooseEntity.find({}, { ...projectionObj, _id: 1 });
+        return StructureMapper.toModelProjections(structures, { ...projectionObj, id: 1 });
     }
 }

--- a/packages/lib/src/routes/index.ts
+++ b/packages/lib/src/routes/index.ts
@@ -44,6 +44,7 @@ export type { FilterLabelRoutes } from "./filterLabel";
 export type { DepartmentServiceRoutes } from "./departmentService";
 export type { PlanMarketingRoutes } from "./planMarketing";
 export type { AnalyticsRoutes } from "./analytics";
+export type { StructureRoutes } from "./structure";
 
 export * from "./phase1";
 export * from "./phase2";

--- a/packages/lib/src/routes/structure/index.ts
+++ b/packages/lib/src/routes/structure/index.ts
@@ -1,0 +1,5 @@
+import { PostFindAll } from "./postFindAll";
+
+export type StructureRoutes = {
+  FindAll: PostFindAll;
+};

--- a/packages/lib/src/routes/structure/postFindAll.ts
+++ b/packages/lib/src/routes/structure/postFindAll.ts
@@ -1,0 +1,11 @@
+import { BasicRoute, RouteResponseBodyV2 } from "..";
+import { StructureType } from "../../mongoSchema/structure";
+
+export interface PostFindAll extends BasicRoute {
+  method: "POST";
+  path: "/structure";
+  payload: {
+    query: string;
+  };
+  response: RouteResponseBodyV2<Partial<StructureType & { id: string }>[]>;
+}


### PR DESCRIPTION
##  Optimisation de l'appel `/structure` 

###  Problème
Sur la page `/user`, l'appel à `/structure` retourne **toutes les structures** (4345 ko) alors que seuls 5 champs sont utilisés :
- `id`, `name` → affichage dans la liste
- `region`, `department`, `networkId` → permissions (`canDeleteReferent`)

### Solution
**Projection des données** : Seuls les champs nécessaires sont retournés.

**Changements :**
1. **Validation stricte** (`Structure.validation.ts`) : `@IsIn(STRUCTURE_PROJECTION_KEYS)`
2. **Champs autorisés** (`Structure.model.ts`) : Liste restreinte à 5 propriétés
3. **Projection MongoDB** (`StructureMongo.repository.ts`)

###  Impact
- Réduction du volume de données transférées
- Temps de réponse amélioré
- Validation stricte des champs demandés

---

https://www.notion.so/jeveuxaider/Onglet-Utilisateurs-endpoint-structure-plusieurs-Mo-29572a322d5080d2b81bde6da433be77?source=copy_link