### PR TITLE
fix(support): 1230 hash password reset tokens (HMAC)

### DIFF
--- a/snupport-api/src/__tests__/resetToken.test.js
+++ b/snupport-api/src/__tests__/resetToken.test.js
@@ -1,0 +1,17 @@
+const { hashResetToken } = require("../utils/resetToken");
+
+describe("reset token hashing", () => {
+  it("should return a 64-hex sha256 hmac", () => {
+    const token = "a".repeat(40);
+    const secret = "unit-test-secret";
+    const hash = hashResetToken({ token, secret });
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("should be deterministic for same inputs", () => {
+    const token = "deadbeef";
+    const secret = "unit-test-secret";
+    expect(hashResetToken({ token, secret })).toBe(hashResetToken({ token, secret }));
+  });
+});
+

--- a/snupport-api/src/config.ts
+++ b/snupport-api/src/config.ts
@@ -70,6 +70,11 @@ export const config = {
   PORT: _env(envInt, "PORT", 8090),
   MONGO_URL: _env(envStr, "MONGO_URL", "mongodb://localhost:27017/snu_dev?directConnection=true"),
   JWT_SECRET: _env(envStr, "JWT_SECRET", "my-secret"),
+  PASSWORD_RESET_TOKEN_SECRET: _env(
+    envStr,
+    "PASSWORD_RESET_TOKEN_SECRET",
+    environment === "development" || environment === "test" ? "dev-reset-token-secret" : undefined
+  ),
   SNU_URL_APP: _env(envStr, "SNU_URL_APP", "http://localhost:8081"),
   SNU_URL_ADMIN: _env(envStr, "SNU_URL_ADMIN", "http://localhost:8082"),
   SNUPPORT_URL_ADMIN: _env(envStr, "SNUPPORT_URL_ADMIN", "http://localhost:8092"),
@@ -95,3 +100,9 @@ export const config = {
   SENDINBLUEKEY: _env(envStr, "SENDINBLUEKEY"),
   SENTRY_DEBUG_MODE: _env(envBool, "SENTRY_DEBUG_MODE", false),
 };
+
+if (environment !== "development" && environment !== "test") {
+  if (!config.PASSWORD_RESET_TOKEN_SECRET) {
+    throw new Error("Missing required environment variable PASSWORD_RESET_TOKEN_SECRET");
+  }
+}

--- a/snupport-api/src/controllers/agent.js
+++ b/snupport-api/src/controllers/agent.js
@@ -13,6 +13,7 @@ const { SCHEMA_EMAIL, SCHEMA_ROLE } = require("../schemas");
 const { config } = require("../config");
 const AgentModel = require("../models/agent");
 const { validatePassword } = require("../utils");
+const { hashResetToken } = require("../utils/resetToken");
 const { cookieOptions, logoutCookieOptions } = require("../cookie-options");
 const { JWT_MAX_AGE, JWT_VERSION } = require("../jwt-options");
 
@@ -154,7 +155,8 @@ router.post(
     const agent = await AgentModel.findOne({ email });
     if (!agent) return res.status(404).send({ ok: false, code: ERRORS.USER_NOT_EXISTS });
     const token = crypto.randomBytes(SCHEMA_TOKEN_LENGTH).toString("hex");
-    agent.set({ forgotPasswordResetToken: token, forgotPasswordResetExpires: Date.now() + JWT_MAX_AGE });
+    const tokenHash = hashResetToken({ token, secret: config.PASSWORD_RESET_TOKEN_SECRET });
+    agent.set({ forgotPasswordResetToken: tokenHash, forgotPasswordResetExpires: Date.now() + JWT_MAX_AGE });
     await agent.save();
     const subject = "Réinitialiser votre mot de passe";
     const body = `Une demande de réinitialisation de mot de passe a été faite, si elle vient bien de vous vous pouvez <a href="${config.SNUPPORT_URL_ADMIN}/auth/reset?token=${token}" style="color: #584FEC">cliquer ici pour réinitialiser votre mot de passe</a>`;
@@ -174,7 +176,8 @@ router.post(
   ),
   async (req, res) => {
     const { token, password, passwordConfirm } = req.cleanBody;
-    const agent = await AgentModel.findOne({ forgotPasswordResetToken: token, forgotPasswordResetExpires: { $gt: Date.now() } });
+    const tokenHash = hashResetToken({ token, secret: config.PASSWORD_RESET_TOKEN_SECRET });
+    const agent = await AgentModel.findOne({ forgotPasswordResetToken: tokenHash, forgotPasswordResetExpires: { $gt: Date.now() } });
     if (!agent) return res.status(400).send({ ok: false, code: ERRORS.PASSWORD_TOKEN_EXPIRED_OR_INVALID });
     if (password !== passwordConfirm) return res.status(400).send({ ok: false, code: ERRORS.PASSWORD_NOT_VALIDATED });
     if (!validatePassword(password)) return res.status(400).send({ ok: false, code: ERRORS.PASSWORD_NOT_VALIDATED });

--- a/snupport-api/src/scripts/invalidatePasswordResetTokens.js
+++ b/snupport-api/src/scripts/invalidatePasswordResetTokens.js
@@ -1,0 +1,32 @@
+require("../mongo");
+
+const AgentModel = require("../models/agent");
+
+async function main() {
+  const result = await AgentModel.updateMany(
+    { forgotPasswordResetToken: { $ne: "" } },
+    { $set: { forgotPasswordResetToken: "", forgotPasswordResetExpires: null } }
+  );
+
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        matchedCount: result.matchedCount ?? result.n ?? null,
+        modifiedCount: result.modifiedCount ?? result.nModified ?? null,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    process.exit(1);
+  });
+

--- a/snupport-api/src/utils/resetToken.js
+++ b/snupport-api/src/utils/resetToken.js
@@ -1,0 +1,14 @@
+const crypto = require("crypto");
+
+function hashResetToken({ token, secret }) {
+  if (!secret) {
+    throw new Error("Missing secret for reset token hashing");
+  }
+  if (!token) {
+    throw new Error("Missing token to hash");
+  }
+  return crypto.createHmac("sha256", secret).update(token).digest("hex");
+}
+
+module.exports = { hashResetToken };
+


### PR DESCRIPTION
**Description**

Cette PR remplace le stockage en clair des tokens de reset mot de passe SNUpport par un stockage HMAC-SHA256, afin de réduire l’impact d’une fuite DB.

- Les endpoints restent identiques (`/agent/forgot_password`, `/agent/forgot_password_reset`).
- Le token **brut** est toujours envoyé par email.
- En base, on stocke uniquement `HMAC(token)` et on recherche via `HMAC(token)`.
- Ajout d’un secret requis: `PASSWORD_RESET_TOKEN_SECRET` (fail-fast hors `development/test`).
- Script fourni pour invalider les tokens existants (stratégie retenue).

**Todo**

- [x] Provisionner `PASSWORD_RESET_TOKEN_SECRET` sur les environnements
- [ ] Exécuter la migration d’invalidation des tokens existants au déploiement (si on confirme cette stratégie)

**Testing instructions**

- [x] Tests unitaires (scopés snupport-api):
  - `npx jest --config snupport-api/jest.config.js --rootDir snupport-api --runInBand`
- [x] Reset nominal:
  - `POST /agent/forgot_password` puis vérifier en DB que `forgotPasswordResetToken` ressemble à un hash (64 hex)
  - `POST /agent/forgot_password_reset` avec le token brut reçu → 200
- [x] Simulation fuite DB:
  - utiliser la valeur DB (hash) comme `token` → doit échouer (`PASSWORD_TOKEN_EXPIRED_OR_INVALID`)
- [x] Migration (invalidation):
  - exécuter `node snupport-api/src/scripts/invalidatePasswordResetTokens.js`
  - un ancien lien de reset ne doit plus fonctionner, un nouveau reset oui